### PR TITLE
fix: add missing installed_app to fix jwt refresh

### DIFF
--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
     "rest_framework_simplejwt",
+    "rest_framework_simplejwt.token_blacklist",
     "corsheaders",
     # Authentication
     "allauth",


### PR DESCRIPTION
This issue has apparently existed since 2013, when they made OutstandingToken abstract if 'blacklist' is not in installed apps

see: https://github.com/jazzband/djangorestframework-simplejwt/issues/364#issuecomment-1079998865
see: https://github.com/encode/django-rest-framework/issues/705