### PR TITLE
fix: Redocly container not working

### DIFF
--- a/Dockerfile-redocly
+++ b/Dockerfile-redocly
@@ -1,15 +1,10 @@
-FROM node:24-alpine
+FROM redocly/redoc
 
-WORKDIR /usr/src/app
+# Copy the OpenAPI specification into nginx html directory
+COPY openapi.yaml /usr/share/nginx/html/openapi.yaml
 
-# Install Redocly CLI
-RUN npm install -g @redocly/cli@latest
+# Configure Redoc to serve our spec on port 8080
+ENV SPEC_URL=openapi.yaml
+ENV PORT=8080
 
-# Copy the OpenAPI specification
-COPY openapi.yaml /usr/src/app/openapi.yaml
-
-# Expose the port
 EXPOSE 8080
-
-# Start Redocly in preview mode
-CMD ["redocly", "preview-docs", "--port", "8080", "--host", "0.0.0.0", "openapi.yaml"]


### PR DESCRIPTION
- Changed base image to `redocly/redoc` for serving documentation.
- Set environment variables for OpenAPI specification URL and port.
- Removed unnecessary installation and command for Redocly CLI.
