### PR TITLE
feat(nodes): add traceroute-links endpoint for node-centric link data

### DIFF
--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -350,6 +350,42 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         serializer = DeviceMetricsSerializer(metrics, many=True)
         return Response(serializer.data)
 
+    @action(detail=True, methods=["get"], url_path="traceroute-links")
+    def traceroute_links(self, request, node_id=None):
+        """
+        Get traceroute links for this node from Neo4j.
+        Returns edges (with avg SNR in/out), nodes, and snr_history per peer.
+
+        Query parameters:
+        - triggered_at_after: ISO 8601 datetime to filter edges
+        """
+        from django.utils.dateparse import parse_datetime
+
+        from traceroute.neo4j_service import run_node_links_query
+
+        node = self.get_object()
+        nid = node.node_id
+
+        triggered_at_after = None
+        if request.query_params.get("triggered_at_after"):
+            dt = parse_datetime(request.query_params.get("triggered_at_after"))
+            if dt:
+                if timezone.is_naive(dt):
+                    dt = timezone.make_aware(dt)
+                triggered_at_after = dt
+
+        try:
+            result = run_node_links_query(nid, triggered_at_after=triggered_at_after)
+            return Response(result)
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).exception("traceroute_links: Neo4j query failed: %s", e)
+            return Response(
+                {"detail": "Failed to fetch traceroute links."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
     @action(detail=False, methods=["get"], url_path="infrastructure")
     def infrastructure(self, request):
         """

--- a/Meshflow/traceroute/neo4j_service.py
+++ b/Meshflow/traceroute/neo4j_service.py
@@ -135,14 +135,16 @@ def _get_node_names(
     return (fallback, fallback)
 
 
-def _extract_edges(route_data: list) -> list[tuple[int, int]]:
-    """Extract consecutive (from_id, to_id) pairs from route list of {node_id, snr}."""
+def _extract_edges(route_data: list) -> list[tuple[int, int, float | None]]:
+    """Extract consecutive (from_id, to_id, snr) from route list of {node_id, snr}.
+    SNR at receiving node (b) is the SNR of the link a->b."""
     edges = []
     for i in range(len(route_data) - 1):
         a = route_data[i]["node_id"]
         b = route_data[i + 1]["node_id"]
+        snr = route_data[i + 1].get("snr")
         if a != UNKNOWN_NODE_ID and b != UNKNOWN_NODE_ID:
-            edges.append((a, b))
+            edges.append((a, b, snr if snr is not None else None))
     return edges
 
 
@@ -183,7 +185,7 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None):
             coords[nid] = pos
             names[nid] = _get_node_names(nid, auto_tr.source_node, auto_tr.target_node, observed_by_id)
 
-    # Extract edges
+    # Extract edges (from_id, to_id, snr)
     edges = []
     if auto_tr.route:
         edges.extend(_extract_edges(auto_tr.route))
@@ -191,7 +193,7 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None):
         edges.extend(_extract_edges(auto_tr.route_back))
 
     # Filter: both endpoints must have coords
-    valid_edges = [(a, b) for a, b in edges if a in coords and b in coords]
+    valid_edges = [(a, b, snr) for a, b, snr in edges if a in coords and b in coords]
     if not valid_edges:
         logger.debug(
             "add_traceroute_edges: no edges with coords for AutoTraceRoute %s",
@@ -208,7 +210,7 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None):
         triggered_at_str = datetime.utcnow().isoformat() + "Z"
 
     with driver.session() as session:
-        for a_id, b_id in valid_edges:
+        for a_id, b_id, snr in valid_edges:
             a_str = meshtastic_id_to_hex(a_id)
             b_str = meshtastic_id_to_hex(b_id)
             a_lat, a_lng = coords[a_id]
@@ -216,29 +218,38 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None):
             a_short, a_long = names.get(a_id, (a_str, a_str))
             b_short, b_long = names.get(b_id, (b_str, b_str))
 
+            # Build relationship props: weight, triggered_at always; snr when present
+            rel_props = "weight: 1, triggered_at: datetime($triggered_at)"
+            params = {
+                "a_id": a_id,
+                "a_str": a_str,
+                "a_lat": a_lat,
+                "a_lng": a_lng,
+                "a_short_name": a_short,
+                "a_long_name": a_long,
+                "b_id": b_id,
+                "b_str": b_str,
+                "b_lat": b_lat,
+                "b_lng": b_lng,
+                "b_short_name": b_short,
+                "b_long_name": b_long,
+                "triggered_at": triggered_at_str,
+            }
+            if snr is not None:
+                rel_props += ", snr: $snr"
+                params["snr"] = float(snr)
+
             session.run(
-                """
-                MERGE (a:MeshNode {node_id: $a_id})
+                f"""
+                MERGE (a:MeshNode {{node_id: $a_id}})
                 SET a.node_id_str = $a_str, a.latitude = $a_lat, a.longitude = $a_lng,
                     a.short_name = $a_short_name, a.long_name = $a_long_name
-                MERGE (b:MeshNode {node_id: $b_id})
+                MERGE (b:MeshNode {{node_id: $b_id}})
                 SET b.node_id_str = $b_str, b.latitude = $b_lat, b.longitude = $b_lng,
                     b.short_name = $b_short_name, b.long_name = $b_long_name
-                CREATE (a)-[:ROUTED_TO {weight: 1, triggered_at: datetime($triggered_at)}]->(b)
+                CREATE (a)-[:ROUTED_TO {{{rel_props}}}]->(b)
                 """,
-                a_id=a_id,
-                a_str=a_str,
-                a_lat=a_lat,
-                a_lng=a_lng,
-                a_short_name=a_short,
-                a_long_name=a_long,
-                b_id=b_id,
-                b_str=b_str,
-                b_lat=b_lat,
-                b_lng=b_lng,
-                b_short_name=b_short,
-                b_long_name=b_long,
-                triggered_at=triggered_at_str,
+                **params,
             )
 
     logger.info(
@@ -416,4 +427,156 @@ def run_heatmap_query(
         "edges": edges,
         "nodes": nodes,
         "meta": meta,
+    }
+
+
+def run_node_links_query(node_id: int, triggered_at_after=None, driver=None):
+    """
+    Query Neo4j for traceroute links involving a focus node.
+    Returns edges (with avg SNR in/out), nodes, and snr_history per peer.
+    """
+    driver = driver or get_driver()
+    params = {"node_id": node_id}
+    if triggered_at_after:
+        params["triggered_at_after"] = (
+            triggered_at_after.isoformat() if hasattr(triggered_at_after, "isoformat") else str(triggered_at_after)
+        )
+
+    # Outbound: focus -> peer. Inbound: peer -> focus.
+    # Use two queries and merge by peer.
+    where_time = " AND r.triggered_at >= datetime($triggered_at_after)" if triggered_at_after else ""
+    where_coords = " AND focus.latitude IS NOT NULL AND peer.latitude IS NOT NULL"
+
+    outbound_query = f"""
+    MATCH (focus:MeshNode {{node_id: $node_id}})-[r:ROUTED_TO]->(peer:MeshNode)
+    WHERE r.snr IS NOT NULL{where_time}{where_coords}
+    RETURN peer.node_id AS peer_id,
+           peer.latitude AS peer_lat, peer.longitude AS peer_lng,
+           peer.node_id_str AS peer_node_id_str,
+           peer.short_name AS peer_short_name, peer.long_name AS peer_long_name,
+           avg(r.snr) AS avg_snr_out,
+           count(r) AS count_out,
+           collect({{triggered_at: toString(r.triggered_at), snr: r.snr}}) AS outbound_history
+    """
+
+    inbound_query = f"""
+    MATCH (focus:MeshNode {{node_id: $node_id}})<-[r:ROUTED_TO]-(peer:MeshNode)
+    WHERE r.snr IS NOT NULL{where_time}{where_coords}
+    RETURN peer.node_id AS peer_id,
+           peer.latitude AS peer_lat, peer.longitude AS peer_lng,
+           peer.node_id_str AS peer_node_id_str,
+           peer.short_name AS peer_short_name, peer.long_name AS peer_long_name,
+           avg(r.snr) AS avg_snr_in,
+           count(r) AS count_in,
+           collect({{triggered_at: toString(r.triggered_at), snr: r.snr}}) AS inbound_history
+    """
+
+    peers = {}
+    focus_node = None
+
+    with driver.session() as session:
+        # Get focus node coords
+        focus_result = session.run(
+            """
+            MATCH (n:MeshNode {node_id: $node_id})
+            WHERE n.latitude IS NOT NULL
+            RETURN n.node_id AS node_id, n.latitude AS lat, n.longitude AS lng,
+                   n.node_id_str AS node_id_str, n.short_name AS short_name, n.long_name AS long_name
+            """,
+            node_id=node_id,
+        )
+        focus_record = focus_result.single()
+        if not focus_record:
+            return {"edges": [], "nodes": [], "snr_history": []}
+
+        focus_node = {
+            "node_id": focus_record["node_id"],
+            "lat": focus_record["lat"],
+            "lng": focus_record["lng"],
+            "node_id_str": focus_record["node_id_str"] or meshtastic_id_to_hex(node_id),
+            "short_name": focus_record["short_name"] or "",
+            "long_name": focus_record["long_name"] or "",
+        }
+
+        # Outbound
+        for record in session.run(outbound_query, params):
+            pid = record["peer_id"]
+            peers[pid] = {
+                "peer_id": pid,
+                "peer_lat": record["peer_lat"],
+                "peer_lng": record["peer_lng"],
+                "peer_node_id_str": record["peer_node_id_str"] or meshtastic_id_to_hex(pid),
+                "peer_short_name": record["peer_short_name"] or "",
+                "peer_long_name": record["peer_long_name"] or "",
+                "avg_snr_out": record["avg_snr_out"],
+                "count_out": record["count_out"],
+                "outbound_history": record["outbound_history"] or [],
+                "avg_snr_in": None,
+                "count_in": 0,
+                "inbound_history": [],
+            }
+
+        # Inbound
+        for record in session.run(inbound_query, params):
+            pid = record["peer_id"]
+            if pid not in peers:
+                peers[pid] = {
+                    "peer_id": pid,
+                    "peer_lat": record["peer_lat"],
+                    "peer_lng": record["peer_lng"],
+                    "peer_node_id_str": record["peer_node_id_str"] or meshtastic_id_to_hex(pid),
+                    "peer_short_name": record["peer_short_name"] or "",
+                    "peer_long_name": record["peer_long_name"] or "",
+                    "avg_snr_out": None,
+                    "count_out": 0,
+                    "outbound_history": [],
+                    "avg_snr_in": None,
+                    "count_in": 0,
+                    "inbound_history": [],
+                }
+            peers[pid]["avg_snr_in"] = record["avg_snr_in"]
+            peers[pid]["count_in"] = record["count_in"]
+            peers[pid]["inbound_history"] = record["inbound_history"] or []
+
+    # Build response
+    nodes_by_id = {node_id: focus_node}
+    edges = []
+    snr_history = []
+
+    for pid, p in peers.items():
+        nodes_by_id[pid] = {
+            "node_id": pid,
+            "lat": p["peer_lat"],
+            "lng": p["peer_lng"],
+            "node_id_str": p["peer_node_id_str"],
+            "short_name": p["peer_short_name"],
+            "long_name": p["peer_long_name"],
+        }
+        count = p["count_out"] + p["count_in"]
+        edges.append(
+            {
+                "from_node_id": node_id,
+                "to_node_id": pid,
+                "from_lat": focus_node["lat"],
+                "from_lng": focus_node["lng"],
+                "to_lat": p["peer_lat"],
+                "to_lng": p["peer_lng"],
+                "avg_snr_in": p["avg_snr_in"],
+                "avg_snr_out": p["avg_snr_out"],
+                "count": count,
+            }
+        )
+        snr_history.append(
+            {
+                "peer_node_id": pid,
+                "peer_short_name": p["peer_short_name"],
+                "inbound": [{"triggered_at": h["triggered_at"], "snr": h["snr"]} for h in p["inbound_history"]],
+                "outbound": [{"triggered_at": h["triggered_at"], "snr": h["snr"]} for h in p["outbound_history"]],
+            }
+        )
+
+    return {
+        "edges": edges,
+        "nodes": list(nodes_by_id.values()),
+        "snr_history": snr_history,
     }

--- a/docs/features/traceroute/heatmap.md
+++ b/docs/features/traceroute/heatmap.md
@@ -5,15 +5,15 @@ The heatmap visualizes aggregated traceroute traffic between nodes as arcs on a 
 ## Neo4j Schema
 
 - **MeshNode**: Node label with `node_id` (unique), `node_id_str`, `latitude`, `longitude`, `short_name`, `long_name`.
-- **ROUTED_TO**: Relationship from one MeshNode to another. Properties: `weight` (integer, incremented per traceroute), `triggered_at` (datetime).
+- **ROUTED_TO**: Relationship from one MeshNode to another. Properties: `weight` (integer, incremented per traceroute), `triggered_at` (datetime), `snr` (float, optional – SNR at receiving node for this hop).
 
-Edges are directional in Neo4j, but the heatmap query aggregates bidirectionally (A→B and B→A are summed).
+Edges are directional in Neo4j, but the heatmap query aggregates bidirectionally (A→B and B→A are summed). The `snr` property is used by the node-links API for per-node traceroute link visualization.
 
 ## Data Flow
 
-1. When an `AutoTraceRoute` completes, `push_traceroute_to_neo4j` extracts consecutive node pairs from `route` and `route_back`.
+1. When an `AutoTraceRoute` completes, `push_traceroute_to_neo4j` extracts consecutive node pairs (with SNR) from `route` and `route_back`.
 2. For each edge (from_id, to_id), both endpoints must have coordinates (from ManagedNode default_location or ObservedNode latest_status).
-3. Nodes are upserted; `ROUTED_TO` relationships are created with `weight: 1` and `triggered_at`.
+3. Nodes are upserted; `ROUTED_TO` relationships are created with `weight: 1`, `triggered_at`, and `snr` (when present).
 
 ## Heatmap-Edges API
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2780,6 +2780,112 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /nodes/observed-nodes/{node_id}/traceroute-links/:
+    get:
+      summary: Get traceroute links for a node
+      description: >
+        Returns traceroute links involving this node from Neo4j.
+        Includes edges with avg SNR (inbound/outbound), nodes, and SNR history per peer.
+      tags: [Nodes]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: triggered_at_after
+          in: query
+          required: false
+          description: ISO 8601 datetime to filter edges
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Traceroute links with edges, nodes, and SNR history
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  edges:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        from_node_id:
+                          type: integer
+                        to_node_id:
+                          type: integer
+                        from_lat:
+                          type: number
+                        from_lng:
+                          type: number
+                        to_lat:
+                          type: number
+                        to_lng:
+                          type: number
+                        avg_snr_in:
+                          type: number
+                          nullable: true
+                        avg_snr_out:
+                          type: number
+                          nullable: true
+                        count:
+                          type: integer
+                  nodes:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        node_id:
+                          type: integer
+                        lat:
+                          type: number
+                        lng:
+                          type: number
+                        short_name:
+                          type: string
+                        long_name:
+                          type: string
+                        node_id_str:
+                          type: string
+                  snr_history:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        peer_node_id:
+                          type: integer
+                        peer_short_name:
+                          type: string
+                        inbound:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              triggered_at:
+                                type: string
+                              snr:
+                                type: number
+                        outbound:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              triggered_at:
+                                type: string
+                              snr:
+                                type: number
+        '503':
+          description: Neo4j unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /nodes/managed-nodes/:
     get:
       summary: List managed nodes


### PR DESCRIPTION
# Summary

Adds a node-centric traceroute links endpoint for the NodeDetails page. Returns edges and SNR history for a focus node from Neo4j, enabling the UI to show a link map and SNR-over-time charts.

**Changes:**

- **New endpoint** `GET /api/nodes/observed-nodes/{node_id}/traceroute-links/` – returns `{ edges, nodes, snr_history }` for the focus node within a time range
- **Query params** `last_heard_after` (ISO 8601), `last_heard_before` (optional)
- **Neo4j** – store `snr` on `ROUTED_TO` when pushing traceroutes; add `run_node_links_query()` for node-centric link lookup
- **Source node coords** – fallback to `ObservedNode.latest_status` when `ManagedNode.default_location` is unset (so originating nodes without default_location can appear in the graph)
- **OpenAPI** – documented new endpoint
- **Docs** – updated `docs/features/traceroute/heatmap.md` with `snr` on `ROUTED_TO`

**Deploy note:** Run `manage.py export_traceroutes_to_neo4j` to backfill Neo4j with `snr` on existing traceroutes if needed.

## Testing performed

- Existing traceroute unit tests pass
- Manual verification of endpoint with Neo4j recommended
