### PR TITLE
fix(traceroute): add source->first-hop edge so originating nodes show

### DIFF
--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -207,7 +207,8 @@ def on_traceroute_packet_received(sender, packet: TraceroutePacket, observer, ob
             status=AutoTraceRoute.STATUS_PENDING,
         )
 
-    # Build route/route_back with SNR: TraceroutePacket has route, route_back (node_ids) and snr_towards, snr_back
+    # Build route/route_back with SNR: 1:1 mapping route[i] <-> snr_towards[i] (SNR at which route[i] received).
+    # Per Meshtastic firmware PR #4485; firmware may send snr longer than route in edge cases — we use i < len.
     route = []
     for i, nid in enumerate(packet.route):
         snr = packet.snr_towards[i] if i < len(packet.snr_towards) else None

--- a/Meshflow/packets/serializers.py
+++ b/Meshflow/packets/serializers.py
@@ -1092,12 +1092,13 @@ class TraceroutePacketSerializer(BasePacketSerializer):
         """Flatten decoded traceroute data."""
         validated_data = super().to_internal_value(data)
 
-        # Flatten the nested traceroute data (Meshtastic uses route, routeBack, snrTowards, snrBack)
+        # Flatten the nested traceroute data (Meshtastic uses route, routeBack, snrTowards, snrBack).
+        # SNR 1:1 with route indices: snr_towards[i] = SNR at which route[i] received (firmware PR #4485).
         if "decoded" in data and "traceroute" in data["decoded"]:
             traceroute_data = data["decoded"]["traceroute"]
             validated_data["route"] = traceroute_data.get("route", []) or []
             validated_data["route_back"] = traceroute_data.get("route_back", traceroute_data.get("routeBack", [])) or []
-            # SNR values are scaled by 4 in protocol; convert to dB. -128 = unknown (omit or use None)
+            # SNR values scaled by 4 in protocol; convert to dB. -128 = unknown (omit or use None)
             validated_data["snr_towards"] = self._parse_snr_list(
                 traceroute_data.get("snrTowards", traceroute_data.get("snr_towards", []))
             )

--- a/Meshflow/packets/tests/test_packet_serializers.py
+++ b/Meshflow/packets/tests/test_packet_serializers.py
@@ -675,6 +675,35 @@ class PacketIngestSerializerTest(BasePacketSerializerTestCase):
         self.assertEqual(packet.observations.count(), 1)
         self.assertEqual(packet.observations.first().observer, self.observer)
 
+    def test_traceroute_packet_ingest_snr_longer_than_route(self):
+        """Test TRACEROUTE_APP with snrTowards one element longer than route (firmware edge case)."""
+        data = {
+            "id": 987654324,
+            "from": 1623194643,
+            "fromId": "!60b0e093",
+            "to": 123456789,
+            "toId": "!499602d",
+            "decoded": {
+                "portnum": "TRACEROUTE_APP",
+                "traceroute": {
+                    "route": [111111, 222222],
+                    "routeBack": [222222, 111111],
+                    "snrTowards": [18, -12, 4],  # 3 values for 2 route nodes
+                    "snrBack": [8, 0, -4],
+                },
+            },
+            "rxTime": 1745330931,
+            "hopLimit": 6,
+            "hopStart": 6,
+        }
+        serializer = PacketIngestSerializer(data=data, context=self.context)
+        assert_serializer_valid(serializer)
+        packet = serializer.save()
+        self.assertIsInstance(packet, TraceroutePacket)
+        self.assertEqual(packet.route, [111111, 222222])
+        self.assertEqual(packet.snr_towards, [4.5, -3.0, 1.0])  # Extra value stored, receiver uses i < len
+        self.assertEqual(packet.snr_back, [2.0, 0.0, -1.0])
+
     def test_invalid_packet_type(self):
         """Test handling of invalid packet type."""
         data = {

--- a/Meshflow/packets/tests/test_traceroute_receiver.py
+++ b/Meshflow/packets/tests/test_traceroute_receiver.py
@@ -137,6 +137,40 @@ def test_traceroute_receiver_inferred_creation(
 
 
 @pytest.mark.django_db
+def test_traceroute_receiver_snr_mapping_route_longer_than_snr(
+    create_traceroute_packet, create_managed_node, create_packet_observation_for_tr
+):
+    """When route is longer than snr_towards, extra nodes get snr: None (1:1 mapping, no index error)."""
+    source_node = create_managed_node()
+    target_node_id = 0xABCDEF12
+    packet = create_traceroute_packet(
+        observer=source_node,
+        from_int=target_node_id,
+        route=[0x11111111, 0x22222222, 0x33333333],
+        route_back=[0x33333333, 0x22222222, 0x11111111],
+        snr_towards=[-5.0, -3.0],  # Only 2 values for 3 route nodes
+        snr_back=[-4.0, -2.0],  # Only 2 values for 3 route_back nodes
+    )
+    observation = create_packet_observation_for_tr(packet=packet, observer=source_node)
+
+    with patch("traceroute.tasks.push_traceroute_to_neo4j"):
+        with patch("traceroute.ws_notify.notify_traceroute_status_changed"):
+            traceroute_packet_received.send(sender=None, packet=packet, observer=source_node, observation=observation)
+
+    auto_tr = AutoTraceRoute.objects.get(source_node=source_node, target_node__node_id=target_node_id)
+    assert auto_tr.route == [
+        {"node_id": 0x11111111, "snr": -5.0},
+        {"node_id": 0x22222222, "snr": -3.0},
+        {"node_id": 0x33333333, "snr": None},
+    ]
+    assert auto_tr.route_back == [
+        {"node_id": 0x33333333, "snr": -4.0},
+        {"node_id": 0x22222222, "snr": -2.0},
+        {"node_id": 0x11111111, "snr": None},
+    ]
+
+
+@pytest.mark.django_db
 def test_traceroute_receiver_late_response_updates_failed(
     create_traceroute_packet,
     create_managed_node,

--- a/Meshflow/traceroute/neo4j_service.py
+++ b/Meshflow/traceroute/neo4j_service.py
@@ -192,6 +192,14 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None):
     if auto_tr.route_back:
         edges.extend(_extract_edges(auto_tr.route_back))
 
+    # Prepend edge (source -> route[0]) — source is not in route per Meshtastic format
+    if auto_tr.route and len(auto_tr.route) > 0:
+        first_hop = auto_tr.route[0]
+        src_id = auto_tr.source_node.node_id
+        first_id = first_hop["node_id"]
+        if first_id != UNKNOWN_NODE_ID:
+            edges.insert(0, (src_id, first_id, first_hop.get("snr")))
+
     # Filter: both endpoints must have coords
     valid_edges = [(a, b, snr) for a, b, snr in edges if a in coords and b in coords]
     if not valid_edges:

--- a/Meshflow/traceroute/tests/test_neo4j_service.py
+++ b/Meshflow/traceroute/tests/test_neo4j_service.py
@@ -1,0 +1,122 @@
+"""Tests for traceroute neo4j_service."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401 - load fixtures
+import users.tests.conftest  # noqa: F401 - load fixtures
+from traceroute.neo4j_service import UNKNOWN_NODE_ID, _extract_edges, add_traceroute_edges
+
+
+class TestExtractEdges:
+    """Tests for _extract_edges."""
+
+    def test_extract_edges_basic(self):
+        """Consecutive pairs with SNR at receiving node."""
+        route_data = [
+            {"node_id": 0x11111111, "snr": -5.0},
+            {"node_id": 0x22222222, "snr": -3.0},
+            {"node_id": 0x33333333, "snr": 2.0},
+        ]
+        result = _extract_edges(route_data)
+        assert result == [
+            (0x11111111, 0x22222222, -3.0),
+            (0x22222222, 0x33333333, 2.0),
+        ]
+
+    def test_extract_edges_skips_unknown_node_id(self):
+        """UNKNOWN_NODE_ID (0xFFFFFFFF) filtered out - edges involving it yield nothing."""
+        route_data = [
+            {"node_id": 0x11111111, "snr": -5.0},
+            {"node_id": UNKNOWN_NODE_ID, "snr": -3.0},
+            {"node_id": 0x33333333, "snr": 2.0},
+        ]
+        result = _extract_edges(route_data)
+        # Consecutive pairs: (A, UNKNOWN) and (UNKNOWN, B) - both filtered due to UNKNOWN
+        assert result == []
+
+    def test_extract_edges_single_hop(self):
+        """One element yields no edges (no consecutive pair)."""
+        route_data = [{"node_id": 0x11111111, "snr": -5.0}]
+        result = _extract_edges(route_data)
+        assert result == []
+
+    def test_extract_edges_none_snr(self):
+        """Missing SNR yields None in edge."""
+        route_data = [
+            {"node_id": 0x11111111},
+            {"node_id": 0x22222222},
+        ]
+        result = _extract_edges(route_data)
+        assert result == [(0x11111111, 0x22222222, None)]
+
+
+@pytest.mark.django_db
+class TestAddTracerouteEdges:
+    """Tests for add_traceroute_edges including source-edge logic."""
+
+    def test_add_traceroute_edges_includes_source_to_first_hop(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """With mocked Neo4j, verify edge (source, route[0]) is created when both have coords."""
+        from nodes.models import NodeLatestStatus, ObservedNode
+
+        user = create_user()
+        source_node = create_managed_node(
+            node_id=0xAAAAAAAA,
+            default_location_latitude=55.86,
+            default_location_longitude=-4.25,
+        )
+        target_node = create_observed_node(node_id=0xBBBBBBBB)
+        NodeLatestStatus.objects.create(
+            node=target_node,
+            latitude=55.85,
+            longitude=-4.26,
+        )
+        # ObservedNode for peer (route[0]) - need coords via NodeLatestStatus
+        peer_node_id = 0xCCCCCCCC
+        peer_obs = ObservedNode.objects.create(
+            node_id=peer_node_id,
+            node_id_str="!cccccccc",
+            short_name="PEER",
+            long_name="Peer Node",
+        )
+        NodeLatestStatus.objects.create(
+            node=peer_obs,
+            latitude=55.87,
+            longitude=-4.25,
+        )
+
+        from traceroute.models import AutoTraceRoute
+
+        auto_tr = AutoTraceRoute.objects.create(
+            source_node=source_node,
+            target_node=target_node,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_USER,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            route=[{"node_id": peer_node_id, "snr": -5.0}],
+            route_back=[{"node_id": peer_node_id, "snr": -4.0}],
+        )
+
+        mock_session = MagicMock()
+        mock_driver = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_session
+        mock_cm.__exit__.return_value = False
+        mock_driver.session.return_value = mock_cm
+
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        # Should have created edge (source, peer) - our synthetic edge for source -> route[0]
+        # route has one element (peer); route_back has one element - no consecutive pairs from _extract_edges
+        calls = mock_session.run.call_args_list
+        assert len(calls) >= 1
+        param_pairs = []
+        for call in calls:
+            kwargs = call[1] if len(call) > 1 and isinstance(call[1], dict) else {}
+            if "a_id" in kwargs and "b_id" in kwargs:
+                param_pairs.append((kwargs["a_id"], kwargs["b_id"]))
+        assert (0xAAAAAAAA, 0xCCCCCCCC) in param_pairs, "Expected edge (source, peer) to be created"

--- a/docs/features/traceroute/heatmap.md
+++ b/docs/features/traceroute/heatmap.md
@@ -12,8 +12,9 @@ Edges are directional in Neo4j, but the heatmap query aggregates bidirectionally
 ## Data Flow
 
 1. When an `AutoTraceRoute` completes, `push_traceroute_to_neo4j` extracts consecutive node pairs (with SNR) from `route` and `route_back`.
-2. For each edge (from_id, to_id), both endpoints must have coordinates (from ManagedNode default_location or ObservedNode latest_status).
-3. Nodes are upserted; `ROUTED_TO` relationships are created with `weight: 1`, `triggered_at`, and `snr` (when present).
+2. **Meshtastic format:** `route` excludes the source (contains `[hop1, hop2, ..., target]`); `route_back` includes the source as the last element `[hop1', ..., source]`. SNR is 1:1 with route indices (SNR at receiving node per firmware PR #4485). A synthetic edge `(source, route[0])` is added in `add_traceroute_edges` so the originating node has outbound links.
+3. For each edge (from_id, to_id), both endpoints must have coordinates (from ManagedNode default_location or ObservedNode latest_status).
+4. Nodes are upserted; `ROUTED_TO` relationships are created with `weight: 1`, `triggered_at`, and `snr` (when present).
 
 ## Heatmap-Edges API
 


### PR DESCRIPTION
# Summary

Fixes traceroute link data for originating nodes (e.g. PDYb, PDYt) and validates the packet parsing flow. The Meshtastic `route` array excludes the source node, so we add a synthetic edge `(source, route[0])` when pushing to Neo4j.

**Changes:**

- **Source→first-hop edge:** Add synthetic edge in `add_traceroute_edges` so nodes that always originate traceroutes appear in the traceroute-links API
- **SNR semantics:** Document 1:1 mapping `route[i]` ↔ `snr_towards[i]` (SNR at receiving node) in receivers.py and serializers.py
- **Tests:** New `test_neo4j_service.py` for `_extract_edges` and source-edge logic; receiver test for route longer than snr_towards; serializer test for snrTowards longer than route
- **Docs:** Update `docs/features/traceroute/heatmap.md` with Meshtastic format and synthetic edge

**Deploy note:** Run `manage.py export_traceroutes_to_neo4j` to backfill Neo4j with the new source edges. Existing traceroutes will then show links for originating nodes.

## Testing performed

- Unit tests for `_extract_edges` (basic, unknown node, single hop, None SNR)
- Unit test for `add_traceroute_edges` with mocked Neo4j (source→peer edge created)
- Receiver test: route longer than snr_towards → extra nodes get snr: None
- Serializer test: snrTowards longer than route
- All traceroute and packet tests pass
