### PR TITLE
feat: add weather nodes and bulk environment metrics API endpoints

### DIFF
--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -678,6 +678,49 @@ class DeviceMetricsSerializer(serializers.ModelSerializer):
         return super().to_representation(instance)
 
 
+class EnvironmentMetricsBulkSerializer(serializers.ModelSerializer):
+    """
+    Lightweight serializer for bulk environment metrics response.
+    Includes node_id, node_id_str, short_name for frontend grouping by node.
+    """
+
+    node_id = serializers.IntegerField(source="node.node_id", read_only=True)
+    node_id_str = serializers.CharField(source="node.node_id_str", read_only=True)
+    short_name = serializers.CharField(source="node.short_name", read_only=True, allow_null=True)
+
+    class Meta:
+        model = EnvironmentMetrics
+        fields = [
+            "node_id",
+            "node_id_str",
+            "short_name",
+            "reported_time",
+            "logged_time",
+            "temperature",
+            "relative_humidity",
+            "barometric_pressure",
+            "gas_resistance",
+            "iaq",
+            "voltage",
+            "current",
+            "distance",
+            "lux",
+            "white_lux",
+            "ir_lux",
+            "uv_lux",
+            "wind_direction",
+            "wind_speed",
+            "weight",
+            "wind_gust",
+            "wind_lull",
+            "radiation",
+            "rainfall_1h",
+            "rainfall_24h",
+            "soil_moisture",
+            "soil_temperature",
+        ]
+
+
 class EnvironmentMetricsSerializer(serializers.ModelSerializer):
     """Serializer for environment metrics (history endpoint)."""
 

--- a/Meshflow/nodes/services/environment_metrics.py
+++ b/Meshflow/nodes/services/environment_metrics.py
@@ -1,0 +1,43 @@
+"""Reusable service for environment metrics queries."""
+
+from datetime import datetime
+from typing import Optional
+
+from django.utils import timezone
+
+from nodes.models import EnvironmentMetrics
+
+
+def get_environment_metrics_bulk(
+    node_ids: list[int],
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+):
+    """
+    Return EnvironmentMetrics for multiple nodes in one query.
+
+    Reusable by any endpoint that needs bulk environment metrics (weather page, etc.).
+
+    Args:
+        node_ids: List of ObservedNode.node_id values to filter by.
+        start_date: Optional start of date range (inclusive).
+        end_date: Optional end of date range (inclusive).
+
+    Returns:
+        QuerySet of EnvironmentMetrics ordered by node_id, reported_time.
+    """
+    if not node_ids:
+        return EnvironmentMetrics.objects.none()
+
+    qs = EnvironmentMetrics.objects.filter(node__node_id__in=node_ids).select_related("node")
+
+    if start_date:
+        if timezone.is_naive(start_date):
+            start_date = timezone.make_aware(start_date)
+        qs = qs.filter(reported_time__gte=start_date)
+    if end_date:
+        if timezone.is_naive(end_date):
+            end_date = timezone.make_aware(end_date)
+        qs = qs.filter(reported_time__lte=end_date)
+
+    return qs.order_by("node__node_id", "reported_time")

--- a/Meshflow/nodes/urls.py
+++ b/Meshflow/nodes/urls.py
@@ -5,6 +5,7 @@ from rest_framework.routers import DefaultRouter
 from nodes.views import (
     APIKeyViewSet,
     DeviceMetricsBulkView,
+    EnvironmentMetricsBulkView,
     ManagedNodeViewSet,
     ObservedNodeClaimView,
     ObservedNodeViewSet,
@@ -24,6 +25,11 @@ urlpatterns = [
         "device-metrics-bulk/",
         DeviceMetricsBulkView.as_view(),
         name="device-metrics-bulk",
+    ),
+    path(
+        "environment-metrics-bulk/",
+        EnvironmentMetricsBulkView.as_view(),
+        name="environment-metrics-bulk",
     ),
     path("observed-nodes/<int:node_id>/claim/", ObservedNodeClaimView.as_view(), name="observed-node-claim"),
     path("claims/mine/", UserNodeClaimsView.as_view(), name="user-node-claims"),

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -30,6 +30,7 @@ from nodes.serializers import (
     APIKeySerializer,
     DeviceMetricsBulkSerializer,
     DeviceMetricsSerializer,
+    EnvironmentMetricsBulkSerializer,
     EnvironmentMetricsSerializer,
     ManagedNodeSerializer,
     NodeOwnerClaimSerializer,
@@ -40,6 +41,7 @@ from nodes.serializers import (
     PowerMetricsSerializer,
 )
 from nodes.services.device_metrics import get_device_metrics_bulk
+from nodes.services.environment_metrics import get_environment_metrics_bulk
 
 from .utils import generate_claim_key
 
@@ -501,6 +503,41 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(qs, many=True)
         return Response(serializer.data)
 
+    @action(detail=False, methods=["get"], url_path="weather")
+    def weather(self, request):
+        """
+        Get observed nodes that have reported environment metrics within the cutoff.
+
+        Query params: environment_reported_after (ISO 8601, default 24h ago), page, page_size
+        """
+        default_cutoff = timezone.now() - timedelta(hours=24)
+        environment_reported_after = request.query_params.get("environment_reported_after")
+        if environment_reported_after:
+            try:
+                cutoff = timezone.datetime.fromisoformat(environment_reported_after.replace("Z", "+00:00"))
+                if timezone.is_naive(cutoff):
+                    cutoff = timezone.make_aware(cutoff)
+            except ValueError, TypeError:
+                cutoff = default_cutoff
+        else:
+            cutoff = default_cutoff
+
+        qs = (
+            ObservedNode.objects.filter(
+                latest_status__environment_reported_time__isnull=False,
+                latest_status__environment_reported_time__gte=cutoff,
+            )
+            .order_by("-latest_status__environment_reported_time", "node_id")
+            .select_related("latest_status")
+        )
+
+        page = self.paginate_queryset(qs)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(qs, many=True)
+        return Response(serializer.data)
+
 
 class DeviceMetricsBulkView(APIView):
     """
@@ -568,6 +605,75 @@ class DeviceMetricsBulkView(APIView):
         end_date = self._parse_date(request.data.get("end_date"))
         metrics = get_device_metrics_bulk(node_ids, start_date, end_date)
         serializer = DeviceMetricsBulkSerializer(metrics, many=True)
+        return Response({"results": serializer.data})
+
+
+class EnvironmentMetricsBulkView(APIView):
+    """
+    Bulk environment metrics for multiple nodes in one request.
+    Used by Weather page for mini charts.
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def _parse_node_ids(self, request):
+        """Extract node_ids from GET (comma-separated) or POST body."""
+        if request.method == "GET":
+            node_ids_param = request.query_params.get("node_ids", "")
+            if not node_ids_param:
+                return None
+            try:
+                return [int(x.strip()) for x in node_ids_param.split(",") if x.strip()]
+            except ValueError:
+                return None
+        # POST
+        node_ids = request.data.get("node_ids", [])
+        if not isinstance(node_ids, list):
+            return None
+        try:
+            return [int(x) for x in node_ids]
+        except ValueError, TypeError:
+            return None
+
+    def _parse_date(self, value):
+        """Parse ISO 8601 or YYYY-MM-DD date."""
+        if not value:
+            return None
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            if timezone.is_naive(dt):
+                dt = timezone.make_aware(dt)
+            return dt
+        except ValueError:
+            try:
+                return timezone.datetime.strptime(str(value), "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            except ValueError:
+                return None
+
+    def get(self, request):
+        node_ids = self._parse_node_ids(request)
+        if not node_ids:
+            return Response(
+                {"error": "node_ids query parameter required (comma-separated integers)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        start_date = self._parse_date(request.query_params.get("start_date"))
+        end_date = self._parse_date(request.query_params.get("end_date"))
+        metrics = get_environment_metrics_bulk(node_ids, start_date, end_date)
+        serializer = EnvironmentMetricsBulkSerializer(metrics, many=True)
+        return Response({"results": serializer.data})
+
+    def post(self, request):
+        node_ids = self._parse_node_ids(request)
+        if not node_ids:
+            return Response(
+                {"error": "node_ids required in body (array of integers)"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        start_date = self._parse_date(request.data.get("start_date"))
+        end_date = self._parse_date(request.data.get("end_date"))
+        metrics = get_environment_metrics_bulk(node_ids, start_date, end_date)
+        serializer = EnvironmentMetricsBulkSerializer(metrics, many=True)
         return Response({"results": serializer.data})
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2764,6 +2764,40 @@ paths:
                         items:
                           $ref: '#/components/schemas/ObservedNode'
 
+  /nodes/observed-nodes/weather/:
+    get:
+      summary: List weather nodes
+      description: >
+        Get observed nodes that have reported environment metrics within the cutoff.
+        Returns nodes with latest_environment_metrics and latest_position for map/cards.
+      tags: [Nodes]
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationPageSize'
+        - name: environment_reported_after
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+            description: Filter nodes with environment metrics reported after this time (ISO 8601). Default 24h ago.
+      responses:
+        '200':
+          description: List of weather nodes with environment metrics
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      results:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/ObservedNode'
+
   /nodes/device-metrics-bulk/:
     get:
       summary: Bulk device metrics for multiple nodes
@@ -2828,6 +2862,96 @@ paths:
           description: Invalid request (e.g. missing node_ids)
     post:
       summary: Bulk device metrics (POST)
+      description: Same as GET but with node_ids, start_date, end_date in request body
+      tags: [Nodes]
+      security:
+        - BearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                node_ids:
+                  type: array
+                  items:
+                    type: integer
+                start_date:
+                  type: string
+                  format: date-time
+                end_date:
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          description: Same as GET
+        '400':
+          description: Invalid request
+
+  /nodes/environment-metrics-bulk/:
+    get:
+      summary: Bulk environment metrics for multiple nodes
+      description: >
+        Get environment metrics (temperature, humidity, pressure, etc.) for multiple nodes in one request.
+        Returns flat list; frontend groups by node_id for per-node charts. Used by Weather page.
+      tags: [Nodes]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: node_ids
+          in: query
+          required: true
+          schema:
+            type: string
+            description: Comma-separated node IDs (e.g. "1,2,3,4,5")
+        - name: start_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+        - name: end_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Flat list of environment metrics with node_id, node_id_str, short_name per item
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        node_id:
+                          type: integer
+                        node_id_str:
+                          type: string
+                        short_name:
+                          type: string
+                          nullable: true
+                        reported_time:
+                          type: string
+                          format: date-time
+                        temperature:
+                          type: number
+                          nullable: true
+                        relative_humidity:
+                          type: number
+                          nullable: true
+                        barometric_pressure:
+                          type: number
+                          nullable: true
+        '400':
+          description: Invalid request (e.g. missing node_ids)
+    post:
+      summary: Bulk environment metrics (POST)
       description: Same as GET but with node_ids, start_date, end_date in request body
       tags: [Nodes]
       security:


### PR DESCRIPTION
# Summary

Add Weather page API support: new endpoints to fetch nodes with environment metrics and bulk environment metrics for mini charts.

**Changes:**
- **Weather nodes endpoint**: `GET /nodes/observed-nodes/weather/` – returns nodes that have reported environment metrics within a configurable cutoff (`environment_reported_after`, default 24h ago). Paginated, same serializer as infrastructure.
- **Bulk environment metrics**: `GET /nodes/environment-metrics-bulk/` – returns environment metrics for multiple nodes in one request (node_ids, start_date, end_date). Used by Weather page for per-node mini charts.
- **Service**: `get_environment_metrics_bulk()` in `nodes/services/environment_metrics.py`
- **Serializer**: `EnvironmentMetricsBulkSerializer` – extends EnvironmentMetrics with node_id, node_id_str, short_name for frontend grouping
- **OpenAPI**: Documented both endpoints

## Testing performed

- `python -m pytest Meshflow/nodes/` passes
