### PR TITLE
feat(auth): add Discord OAuth provider

### DIFF
--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
     "allauth.socialaccount.providers.github",
+    "allauth.socialaccount.providers.discord",
     "dj_rest_auth",
     "dj_rest_auth.registration",
     # Project apps
@@ -290,6 +291,13 @@ SOCIALACCOUNT_PROVIDERS = {
             "client_id": os.environ.get("GITHUB_CLIENT_ID", ""),
             "secret": os.environ.get("GITHUB_CLIENT_SECRET", ""),
         }
+    },
+    "discord": {
+        "APP": {
+            "client_id": os.environ.get("DISCORD_CLIENT_ID", ""),
+            "secret": os.environ.get("DISCORD_CLIENT_SECRET", ""),
+        },
+        "SCOPE": ["identify", "email"],
     },
 }
 

--- a/Meshflow/users/social_auth.py
+++ b/Meshflow/users/social_auth.py
@@ -6,6 +6,7 @@ from django.shortcuts import redirect
 
 import requests
 from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.providers.discord.views import DiscordOAuth2Adapter
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
@@ -92,6 +93,17 @@ class GithubLoginRedirectView(BaseLoginRedirectView):
         self.adapter_class = GitHubOAuth2Adapter
 
 
+class DiscordLoginRedirectView(BaseLoginRedirectView):
+    """
+    View for Discord OAuth2 authentication.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.provider_name = "discord"
+        self.adapter_class = DiscordOAuth2Adapter
+
+
 class CompatibleOAuth2Client(OAuth2Client):
     """
     Compatibility shim for dj-rest-auth and django-allauth OAuth2Client.
@@ -135,6 +147,12 @@ class GithubLoginView(SocialLoginView):
     adapter_class = GitHubOAuth2Adapter
     client_class = CompatibleOAuth2Client
     callback_url = settings.CALLBACK_URL_BASE + "/api/auth/social/github/callback/"
+
+
+class DiscordLoginView(SocialLoginView):
+    adapter_class = DiscordOAuth2Adapter
+    client_class = CompatibleOAuth2Client
+    callback_url = settings.CALLBACK_URL_BASE + "/api/auth/social/discord/callback/"
 
 
 class BaseCallbackView(APIView):
@@ -261,6 +279,17 @@ class GithubCallbackRedirectView(BaseCallbackRedirectView):
         self.adapter_class = GitHubOAuth2Adapter
 
 
+class DiscordCallbackRedirectView(BaseCallbackRedirectView):
+    """
+    Handles Discord OAuth2 callback: verified state and forwards code to frontend.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.provider_name = "discord"
+        self.adapter_class = DiscordOAuth2Adapter
+
+
 class GoogleCallbackView(BaseCallbackView):
     """
     Handles Google OAuth2 callback: exchanges code for access token, logs in user, issues JWT, redirects to frontend.
@@ -281,3 +310,14 @@ class GithubCallbackView(BaseCallbackView):
         super().__init__(*args, **kwargs)
         self.provider_name = "github"
         self.adapter_class = GitHubOAuth2Adapter
+
+
+class DiscordCallbackView(BaseCallbackView):
+    """
+    Handles Discord OAuth2 callback: exchanges code for access token, logs in user, issues JWT, redirects to frontend.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.provider_name = "discord"
+        self.adapter_class = DiscordOAuth2Adapter

--- a/Meshflow/users/urls.py
+++ b/Meshflow/users/urls.py
@@ -1,6 +1,9 @@
 from django.urls import include, path
 
 from users.social_auth import (
+    DiscordCallbackRedirectView,
+    DiscordLoginRedirectView,
+    DiscordLoginView,
     GithubCallbackRedirectView,
     GithubLoginRedirectView,
     GithubLoginView,
@@ -21,4 +24,7 @@ urlpatterns = [
     path("social/github/", GithubLoginRedirectView.as_view(), name="github_login"),
     path("social/github/callback/", GithubCallbackRedirectView.as_view(), name="github_login_callback"),
     path("social/github/token/", GithubLoginView.as_view(), name="github_token"),
+    path("social/discord/", DiscordLoginRedirectView.as_view(), name="discord_login"),
+    path("social/discord/callback/", DiscordCallbackRedirectView.as_view(), name="discord_login_callback"),
+    path("social/discord/token/", DiscordLoginView.as_view(), name="discord_token"),
 ]

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -1,6 +1,6 @@
-# Social Authentication Flow (Google/GitHub)
+# Social Authentication Flow (Google/GitHub/Discord)
 
-This document explains how social authentication (Google/GitHub OAuth2) is implemented in this project, including the flow between the frontend (React) and backend (Django REST Framework with dj-rest-auth/allauth).
+This document explains how social authentication (Google/GitHub/Discord OAuth2) is implemented in this project, including the flow between the frontend (React) and backend (Django REST Framework with dj-rest-auth/allauth).
 
 ---
 
@@ -20,9 +20,9 @@ sequenceDiagram
     participant User
     participant Frontend
     participant Backend
-    participant Provider as Google/GitHub
+    participant Provider as Google/GitHub/Discord
 
-    User->>Frontend: Clicks "Login with Google/GitHub"
+    User->>Frontend: Clicks "Login with Google/GitHub/Discord"
     Frontend->>Backend: GET /api/auth/social/google/ (get auth URL)
     Backend->>Frontend: Returns provider auth URL
     Frontend->>Provider: Redirect user to provider
@@ -45,7 +45,7 @@ sequenceDiagram
 - Backend returns the URL with proper state and redirect_uri.
 
 ### 2. **User Authenticates with Provider**
-- User is redirected to Google/GitHub and authenticates.
+- User is redirected to Google/GitHub/Discord and authenticates.
 
 ### 3. **Provider Redirects to Backend Callback**
 - Provider redirects to backend callback URL (e.g., `/api/auth/social/google/callback/`) with `?code=...&state=...`.
@@ -55,7 +55,7 @@ sequenceDiagram
 - Instead, it redirects the user to the frontend (e.g., `/social-callback?code=...&state=...`).
 
 ### 5. **Frontend Exchanges Code for JWT**
-- Frontend reads the code from the URL and POSTs it to `/api/auth/google/` (or `/api/auth/github/`).
+- Frontend reads the code from the URL and POSTs it to `/api/auth/social/google/token/`, `/api/auth/social/github/token/`, or `/api/auth/social/discord/token/`.
 - Backend (dj-rest-auth/allauth) exchanges the code for an access token, authenticates/creates the user, and issues a JWT.
 - Backend returns the JWT (and user info) to the frontend.
 

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -45,6 +45,8 @@ This document describes all environment variables used by the Meshflow Django pr
 | `GOOGLE_CLIENT_SECRET`  | (empty) | Google OAuth client secret.                  | Any string              |
 | `GITHUB_CLIENT_ID`      | (empty) | GitHub OAuth client ID.                      | Any string              |
 | `GITHUB_CLIENT_SECRET`  | (empty) | GitHub OAuth client secret.                  | Any string              |
+| `DISCORD_CLIENT_ID`     | (empty) | Discord OAuth client ID.                      | Any string              |
+| `DISCORD_CLIENT_SECRET` | (empty) | Discord OAuth client secret.                  | Any string              |
 
 ---
 
@@ -105,6 +107,7 @@ This document describes all environment variables used by the Meshflow Django pr
 - **SITE_ID**: Used by django-allauth for multi-site support.
 - **GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET**: Credentials for Google OAuth.
 - **GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET**: Credentials for GitHub OAuth.
+- **DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET**: Credentials for Discord OAuth. Create an app at [Discord Developer Portal](https://discord.com/developers/applications) and add redirect URI `{CALLBACK_URL_BASE}/api/auth/social/discord/callback/`.
 
 ## 5. URLs & Frontend
 
@@ -149,6 +152,8 @@ GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
+DISCORD_CLIENT_ID=your-discord-client-id
+DISCORD_CLIENT_SECRET=your-discord-client-secret
 
 CALLBACK_URL_BASE=https://api.yourdomain.com
 FRONTEND_URL=https://yourdomain.com


### PR DESCRIPTION
# Summary

Add Discord as an OAuth provider alongside Google and GitHub. Users can sign in with their Discord account.

**Changes:**
- Add `allauth.socialaccount.providers.discord` to INSTALLED_APPS
- Add Discord to SOCIALACCOUNT_PROVIDERS with `identify` and `email` scopes
- Add Discord OAuth views: `DiscordLoginRedirectView`, `DiscordLoginView`, `DiscordCallbackRedirectView`, `DiscordCallbackView`
- Add routes: `social/discord/`, `social/discord/callback/`, `social/discord/token/`
- Update docs/AUTH.md and docs/ENV_VARS.md with Discord setup and env vars

**Manual steps for deployment:**
- Create a Discord application at [Discord Developer Portal](https://discord.com/developers/applications)
- Add redirect URI: `{CALLBACK_URL_BASE}/api/auth/social/discord/callback/`
- Set `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET` in environment

## Testing performed

- `python manage.py check` succeeds
- Django starts without errors
