### PR TITLE
feat(messages): add packet_id and sender_node_id filter

### DIFF
--- a/Meshflow/text_messages/serializers.py
+++ b/Meshflow/text_messages/serializers.py
@@ -17,12 +17,17 @@ class TextMessageSerializer(serializers.ModelSerializer):
     sender = ObservedNodeSerializer(read_only=True)
     channel = serializers.PrimaryKeyRelatedField(queryset=MessageChannel.objects.all())
     heard = serializers.SerializerMethodField()
+    packet_id = serializers.SerializerMethodField()
+
+    def get_packet_id(self, obj):
+        return obj.original_packet.packet_id if obj.original_packet else None
 
     class Meta:
         model = TextMessage
         fields = [
             "id",
             "original_packet_id",
+            "packet_id",
             "sender",
             "recipient_node_id",
             "channel",
@@ -36,6 +41,7 @@ class TextMessageSerializer(serializers.ModelSerializer):
         read_only_fields = [
             "id",
             "original_packet_id",
+            "packet_id",
             "sender",
             "recipient_node_id",
             "channel",

--- a/Meshflow/text_messages/views.py
+++ b/Meshflow/text_messages/views.py
@@ -21,10 +21,13 @@ class TextMessageViewSet(viewsets.ModelViewSet):
 
         constellation_id = self.request.query_params.get("constellation_id")
         channel_id = self.request.query_params.get("channel_id")
+        sender_node_id = self.request.query_params.get("sender_node_id")
         if constellation_id:
             queryset = queryset.filter(channel__constellation_id=constellation_id)
         if channel_id:
             queryset = queryset.filter(channel_id=channel_id)
+        if sender_node_id:
+            queryset = queryset.filter(sender__node_id=int(sender_node_id))
 
         # filter out any DMs (i.e. recipient_node_id must be '^all')
         queryset = queryset.filter(recipient_node_id=BROADCAST_ID)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4250,6 +4250,12 @@ paths:
           schema:
             type: integer
           description: Filter messages by message channel ID
+        - name: sender_node_id
+          in: query
+          required: false
+          schema:
+            type: integer
+          description: Filter messages by sender node ID (for "By Node" view)
       responses:
         '200':
           description: List of text messages


### PR DESCRIPTION
# Summary

Adds `packet_id` to the TextMessage API response and `sender_node_id` query parameter for filtering messages by sender. Supports the Messages page rework in meshtastic-bot-ui (#107).

- **packet_id**: Exposed from `original_packet.packet_id` so the UI can group emoji reactions (which use `reply_to_message_id` = parent's packet_id)
- **sender_node_id**: Optional query param to filter messages by sender node (for "By Node" view)

No breaking changes. `packet_id` is additive.

## Testing performed

- Serializer returns packet_id when original_packet exists
- sender_node_id filter applied in view queryset
- openapi.yaml updated