### PR TITLE
fix(stats): filter self-observed device metrics from stats endpoints

### DIFF
--- a/Meshflow/stats/tasks.py
+++ b/Meshflow/stats/tasks.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional
 
-from django.db.models import Count, Q
+from django.db.models import Count, Exists, OuterRef, Q
 from django.utils import timezone
 
 from celery import shared_task
@@ -147,6 +147,13 @@ def _collect_packet_volume(
     base_qs = RawPacket.objects.filter(
         first_reported_time__gte=recorded_at,
         first_reported_time__lt=hour_end,
+    )
+    # Exclude device metrics that were only observed by the sender (self-ingested)
+    base_qs = base_qs.exclude(
+        Q(devicemetricspacket__isnull=False)
+        & ~Exists(
+            PacketObservation.objects.filter(packet_id=OuterRef("id")).exclude(observer__node_id=OuterRef("from_int"))
+        )
     )
 
     annotate_kwargs = {f"_{k}": Count("id", filter=v) for k, v in PACKET_TYPE_FILTERS.items()}

--- a/Meshflow/stats/tests/test_tasks.py
+++ b/Meshflow/stats/tests/test_tasks.py
@@ -7,9 +7,9 @@ from django.utils import timezone
 
 import pytest
 
-from packets.models import PacketObservation
+from packets.models import DeviceMetricsPacket, PacketObservation
 from stats.models import StatsSnapshot
-from stats.tasks import backfill_stats_snapshots
+from stats.tasks import _collect_packet_volume, backfill_stats_snapshots
 
 
 @pytest.mark.django_db
@@ -145,3 +145,88 @@ def test_packet_volume_includes_by_type(create_managed_node):
     assert snap.value["count"] == 2
     assert snap.value["by_type"]["text_message"] == 1
     assert snap.value["by_type"]["position"] == 1
+
+
+@pytest.mark.django_db
+def test_packet_volume_excludes_self_only_device_metrics(create_managed_node):
+    """packet_volume excludes device metrics that were only observed by the sender."""
+    managed = create_managed_node(node_id=111111111)
+    channel = managed.channel_0
+
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+
+    # Device metrics from managed's node, observed only by managed (self-ingested)
+    dm_self = DeviceMetricsPacket.objects.create(
+        packet_id=1,
+        from_int=111111111,
+        from_str="!069f6b67",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TELEMETRY_APP",
+        first_reported_time=hour,
+        reading_time=hour,
+        battery_level=95.0,
+    )
+    PacketObservation.objects.create(
+        packet=dm_self,
+        observer=managed,
+        channel=channel,
+        rx_time=hour,
+        hop_limit=3,
+        hop_start=3,
+        rx_rssi=-60.0,
+        rx_snr=10.0,
+        upload_time=timezone.now(),
+        relay_node=None,
+    )
+
+    c, s = _collect_packet_volume(hour, run_id=None)
+    assert c == 1
+    assert s == 0
+
+    snap = StatsSnapshot.objects.get(stat_type="packet_volume", recorded_at=hour)
+    # Self-only device metrics should be excluded
+    assert snap.value["count"] == 0
+    assert snap.value["by_type"]["device_metrics"] == 0
+
+
+@pytest.mark.django_db
+def test_packet_volume_includes_device_metrics_with_other_observer(create_managed_node):
+    """packet_volume includes device metrics when observed by a non-sender."""
+    managed_b = create_managed_node(node_id=222222222)
+    channel_b = managed_b.channel_0
+
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+
+    # Device metrics from node A, observed by node B (mesh traffic)
+    dm = DeviceMetricsPacket.objects.create(
+        packet_id=1,
+        from_int=111111111,
+        from_str="!069f6b67",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TELEMETRY_APP",
+        first_reported_time=hour,
+        reading_time=hour,
+        battery_level=95.0,
+    )
+    PacketObservation.objects.create(
+        packet=dm,
+        observer=managed_b,
+        channel=channel_b,
+        rx_time=hour,
+        hop_limit=3,
+        hop_start=3,
+        rx_rssi=-60.0,
+        rx_snr=10.0,
+        upload_time=timezone.now(),
+        relay_node=None,
+    )
+
+    c, s = _collect_packet_volume(hour, run_id=None)
+    assert c == 1
+    assert s == 0
+
+    snap = StatsSnapshot.objects.get(stat_type="packet_volume", recorded_at=hour)
+    assert snap.value["count"] == 1
+    assert snap.value["by_type"]["device_metrics"] == 1

--- a/Meshflow/stats/tests/test_views.py
+++ b/Meshflow/stats/tests/test_views.py
@@ -10,7 +10,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from nodes.models import ObservedNode
-from packets.models import MessagePacket, PacketObservation
+from packets.models import DeviceMetricsPacket, MessagePacket, PacketObservation
 from stats.models import StatsSnapshot
 
 
@@ -325,6 +325,145 @@ def test_node_neighbour_stats_excludes_self_packets(create_managed_node, create_
     assert response.data["total_packets"] == 1
     assert len(response.data["by_source"]) == 1
     assert response.data["by_source"][0]["source"] == 111111111
+
+
+@pytest.mark.django_db
+def test_node_received_stats_excludes_self_device_metrics(create_managed_node, create_user):
+    """node_received_stats excludes observations of device metrics from self."""
+    user = create_user()
+    managed = create_managed_node(owner=user, node_id=111111111)
+    channel = managed.channel_0
+
+    rx_time = timezone.make_aware(datetime(2025, 6, 15, 12, 0, 0))
+
+    # Self device metrics: from_int == managed.node_id, observed by managed
+    dm_self = DeviceMetricsPacket.objects.create(
+        packet_id=1,
+        from_int=111111111,
+        from_str="!069f6b67",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TELEMETRY_APP",
+        first_reported_time=rx_time,
+        reading_time=rx_time,
+        battery_level=95.0,
+    )
+    PacketObservation.objects.create(
+        packet=dm_self,
+        observer=managed,
+        channel=channel,
+        rx_time=rx_time,
+        hop_limit=3,
+        hop_start=3,
+        rx_rssi=-60.0,
+        rx_snr=10.0,
+        upload_time=timezone.now(),
+        relay_node=None,
+    )
+
+    # Message from another node (should be included)
+    msg = MessagePacket.objects.create(
+        packet_id=2,
+        from_int=222222222,
+        from_str="!0d3b6cde",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TEXT_MESSAGE_APP",
+        message_text="Hello",
+        first_reported_time=rx_time,
+    )
+    PacketObservation.objects.create(
+        packet=msg,
+        observer=managed,
+        channel=channel,
+        rx_time=rx_time,
+        relay_node=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(
+        reverse("stats:node-received-stats", kwargs={"node_id": managed.node_id}),
+        {"start_date": "2025-01-01", "end_date": "2025-12-31"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["intervals"]) == 1
+    interval = response.data["intervals"][0]
+    packet_types = {p["packet_type"]: p["count"] for p in interval["packet_types"]}
+    assert packet_types["device_metrics"] == 0
+    assert packet_types["text_message"] == 1
+
+
+@pytest.mark.django_db
+def test_node_packet_stats_excludes_self_only_device_metrics(create_managed_node, create_observed_node, create_user):
+    """node_packet_stats excludes device metrics that were only self-observed for the node."""
+    user = create_user()
+    managed = create_managed_node(owner=user, node_id=111111111)
+    channel = managed.channel_0
+
+    # ObservedNode for the node (required by node_packet_stats)
+    create_observed_node(node_id=111111111)
+
+    rx_time = timezone.make_aware(datetime(2025, 6, 15, 12, 0, 0))
+
+    # Device metrics from node 111111111, observed only by itself (self-ingested)
+    dm_self = DeviceMetricsPacket.objects.create(
+        packet_id=1,
+        from_int=111111111,
+        from_str="!069f6b67",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TELEMETRY_APP",
+        first_reported_time=rx_time,
+        reading_time=rx_time,
+        battery_level=95.0,
+    )
+    PacketObservation.objects.create(
+        packet=dm_self,
+        observer=managed,
+        channel=channel,
+        rx_time=rx_time,
+        hop_limit=3,
+        hop_start=3,
+        rx_rssi=-60.0,
+        rx_snr=10.0,
+        upload_time=timezone.now(),
+        relay_node=None,
+    )
+
+    # Message from same node (should be included)
+    msg = MessagePacket.objects.create(
+        packet_id=2,
+        from_int=111111111,
+        from_str="!069f6b67",
+        to_int=4294967295,
+        to_str="^all",
+        port_num="TEXT_MESSAGE_APP",
+        message_text="Hello",
+        first_reported_time=rx_time,
+    )
+    PacketObservation.objects.create(
+        packet=msg,
+        observer=managed,
+        channel=channel,
+        rx_time=rx_time,
+        relay_node=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(
+        reverse("stats:node-packet-stats", kwargs={"node_id": 111111111}),
+        {"start_date": "2025-01-01", "end_date": "2025-12-31"},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["intervals"]) == 1
+    interval = response.data["intervals"][0]
+    packet_types = {p["packet_type"]: p["count"] for p in interval["packet_types"]}
+    assert packet_types["device_metrics"] == 0
+    assert packet_types["text_message"] == 1
 
 
 @pytest.mark.django_db

--- a/Meshflow/stats/views.py
+++ b/Meshflow/stats/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, Tuple
 
-from django.db.models import BigIntegerField, Case, Count, F, Q, When
+from django.db.models import BigIntegerField, Case, Count, Exists, F, OuterRef, Q, When
 from django.db.models.functions import Mod, Trunc
 
 from rest_framework import status
@@ -145,6 +145,13 @@ def node_packet_stats(request, node_id: int):
 
     # Build base query for packets from this node
     packets = RawPacket.objects.filter(from_int=node_id)
+    # Exclude device metrics that were only observed by the sender (self-ingested)
+    packets = packets.exclude(
+        Q(devicemetricspacket__isnull=False)
+        & ~Exists(
+            PacketObservation.objects.filter(packet_id=OuterRef("id")).exclude(observer__node_id=OuterRef("from_int"))
+        )
+    )
 
     # Apply date filters if provided
     if start_date:
@@ -225,8 +232,10 @@ def node_received_stats(request, node_id: int):
     except ValueError as e:
         return Response({"status": "error", "message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
-    # Build base query for packet observations by this node
-    observations = PacketObservation.objects.filter(observer=managed_node)
+    # Build base query for packet observations (exclude self device metrics)
+    observations = PacketObservation.objects.filter(observer=managed_node).exclude(
+        Q(packet__devicemetricspacket__isnull=False) & Q(packet__from_int=F("observer__node_id"))
+    )
 
     # Apply date filters if provided
     if start_date:
@@ -310,6 +319,7 @@ def node_neighbour_stats(request, node_id: int):
     try:
         observations = (
             PacketObservation.objects.filter(observer=managed_node)
+            .exclude(Q(packet__devicemetricspacket__isnull=False) & Q(packet__from_int=F("observer__node_id")))
             .select_related("packet")
             .annotate(
                 source_node_id=Case(


### PR DESCRIPTION
# Summary

Filter self-observed device metrics from stats endpoints so historical data is excluded. The bot filter (skip device metrics from self before API submission) only affects new packets; historical device metrics from bot nodes remain in the database.

Uses `PacketObservation` to detect when `observer.node_id == packet.from_int` (self-reported). Excludes:
- **packet_volume**: DeviceMetricsPackets that have no observation from a non-sender
- **node_packet_stats**: Same exclusion for packets from the node
- **node_received_stats**: Observations where packet is device metrics and observer == sender
- **node_neighbour_stats**: Same observation filter as node_received_stats

Closes #126

## Testing performed

* Added unit tests: `test_packet_volume_excludes_self_only_device_metrics`, `test_packet_volume_includes_device_metrics_with_other_observer`, `test_node_received_stats_excludes_self_device_metrics`, `test_node_packet_stats_excludes_self_only_device_metrics`
* All 16 stats tests pass