### PR TITLE
Add user to Constellation as viewer on successful node claim

### DIFF
--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -5,6 +5,7 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
+from constellations.models import ConstellationUserMembership
 from nodes.models import NodeLatestStatus, ObservedNode
 
 from .models import (
@@ -38,6 +39,7 @@ from .signals import (
     host_metrics_packet_received,
     message_packet_received,
     new_node_observed,
+    node_claim_authorized,
     node_info_packet_received,
     packet_received,
     position_packet_received,
@@ -127,6 +129,16 @@ def message_packet_received(
 
     service = TextMessagePacketService()
     service.process_packet(packet, observer, observation, user=None)
+
+
+@receiver(node_claim_authorized)
+def on_node_claim_authorized_add_user_to_constellation(sender, node, claim, observer, **kwargs):
+    """Add the claiming user to the observer's constellation as a viewer."""
+    ConstellationUserMembership.objects.get_or_create(
+        user=claim.user,
+        constellation=observer.constellation,
+        defaults={"role": "viewer"},
+    )
 
 
 @receiver(node_info_packet_received)

--- a/Meshflow/packets/tests/test_text_message_service.py
+++ b/Meshflow/packets/tests/test_text_message_service.py
@@ -1,7 +1,7 @@
 import pytest
 
 from common.mesh_node_helpers import BROADCAST_ID
-from constellations.models import MessageChannel
+from constellations.models import ConstellationUserMembership, MessageChannel
 from nodes.models import NodeOwnerClaim, ObservedNode
 from packets.services.text_message import TextMessagePacketService
 from text_messages.models import TextMessage
@@ -177,3 +177,30 @@ def test_authorize_node_claim_success(
     # Verify the node was claimed
     from_node.refresh_from_db()
     assert from_node.claimed_by == user
+
+
+@pytest.mark.django_db
+def test_authorize_node_claim_adds_user_to_constellation_as_viewer(
+    create_message_packet, create_managed_node, create_packet_observation, create_user
+):
+    """When a claim is accepted, add the user to the observer's constellation as a viewer."""
+    service = TextMessagePacketService()
+    packet = create_message_packet(message_text="word word word 123")
+    observer = create_managed_node()
+    observation = create_packet_observation(packet=packet, observer=observer)
+    user = create_user()
+
+    from_node = ObservedNode.objects.get_or_create(node_id=packet.from_int)[0]
+    NodeOwnerClaim.objects.create(
+        node=from_node,
+        user=user,
+        claim_key="word word word 123",
+        accepted_at=None,
+    )
+
+    assert not ConstellationUserMembership.objects.filter(user=user, constellation=observer.constellation).exists()
+
+    service.process_packet(packet, observer, observation, user)
+
+    membership = ConstellationUserMembership.objects.get(user=user, constellation=observer.constellation)
+    assert membership.role == "viewer"


### PR DESCRIPTION
# Summary

When a user successfully claims a node (claim key sent via radio and accepted), add that user to the Constellation of the ManagedNode that received the claim message as a viewer.

- Added `node_claim_authorized` signal receiver in `packets/receivers.py` that creates a `ConstellationUserMembership` with role `"viewer"` for the claiming user in the observer's constellation
- Uses `get_or_create` so existing admin/editor memberships are preserved
- Added unit test `test_authorize_node_claim_adds_user_to_constellation_as_viewer`

Closes #131

## Testing performed

- `pytest Meshflow/packets/tests/test_text_message_service.py -v` — all 10 tests pass including new test
- `pytest Meshflow/packets/ -v` — all 70 packet tests pass
- black, isort, flake8