### PR TITLE
feat(nodes): managed node channel PATCH and owner retrieve (#138)

### DIFF
--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -464,6 +464,35 @@ class OwnedManagedNodeSerializer(ManagedNodeSerializer):
         queryset=MessageChannel.objects.all(), required=False, allow_null=True
     )
 
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        constellation = attrs.get("constellation")
+        if constellation is None and self.instance is not None:
+            constellation = self.instance.constellation
+        if constellation is None:
+            return attrs
+
+        errors = {}
+        for i in range(8):
+            key = f"channel_{i}"
+            if key not in attrs:
+                continue
+            ch = attrs[key]
+            if ch is None:
+                continue
+            if ch.constellation_id != constellation.id:
+                errors[key] = "Message channel must belong to the managed node's constellation."
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
+
+    def update(self, instance, validated_data):
+        request = self.context.get("request")
+        if request is not None and not request.user.is_staff:
+            validated_data.pop("owner", None)
+            validated_data.pop("constellation", None)
+        return super().update(instance, validated_data)
+
     # For read, override to_representation
     # (or use a SerializerMethodField if you want to return the nested object)
 

--- a/Meshflow/nodes/tests/test_managed_node_channel_patch.py
+++ b/Meshflow/nodes/tests/test_managed_node_channel_patch.py
@@ -1,0 +1,128 @@
+"""Tests for managed node channel mapping updates (PATCH) and permissions."""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from constellations.models import MessageChannel
+
+
+@pytest.mark.django_db
+def test_managed_node_patch_channels_owner_success(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    other_constellation = create_constellation()
+    ch_ok = MessageChannel.objects.create(name="map-me", constellation=constellation)
+    MessageChannel.objects.create(name="other", constellation=other_constellation)
+
+    node = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        channel_0=None,
+        channel_1=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("managed-nodes-detail", kwargs={"node_id": node.node_id})
+
+    response = client.patch(url, {"channel_0": ch_ok.id}, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["channel_0"] == {"id": ch_ok.id, "name": ch_ok.name}
+
+    node.refresh_from_db()
+    assert node.channel_0_id == ch_ok.id
+
+
+@pytest.mark.django_db
+def test_managed_node_patch_channel_wrong_constellation_returns_400(
+    create_user, create_constellation, create_managed_node
+):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    other_constellation = create_constellation()
+    ch_wrong = MessageChannel.objects.create(name="foreign", constellation=other_constellation)
+
+    node = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        channel_0=None,
+        channel_1=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("managed-nodes-detail", kwargs={"node_id": node.node_id})
+
+    response = client.patch(url, {"channel_0": ch_wrong.id}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "channel_0" in response.data
+
+
+@pytest.mark.django_db
+def test_managed_node_patch_channels_non_owner_forbidden(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    other = create_user()
+    constellation = create_constellation(created_by=owner)
+    ch = MessageChannel.objects.create(name="ok", constellation=constellation)
+
+    node = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        channel_0=None,
+        channel_1=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=other)
+    url = reverse("managed-nodes-detail", kwargs={"node_id": node.node_id})
+
+    response = client.patch(url, {"channel_0": ch.id}, format="json")
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_managed_node_retrieve_owner_includes_channels(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    ch = MessageChannel.objects.create(name="primary", constellation=constellation)
+
+    node = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        channel_0=ch,
+        channel_1=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("managed-nodes-detail", kwargs={"node_id": node.node_id})
+
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["channel_0"] == {"id": ch.id, "name": ch.name}
+
+
+@pytest.mark.django_db
+def test_managed_node_retrieve_non_owner_omits_channels(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    viewer = create_user()
+    constellation = create_constellation(created_by=owner)
+    ch = MessageChannel.objects.create(name="primary", constellation=constellation)
+
+    node = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        channel_0=ch,
+        channel_1=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=viewer)
+    url = reverse("managed-nodes-detail", kwargs={"node_id": node.node_id})
+
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert "channel_0" not in response.data

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -721,15 +721,39 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         """Return different serializers based on the action."""
-        if self.action == "mine":
-            return OwnedManagedNodeSerializer
-        if self.action == "create":
+        if self.action in ("mine", "create", "update", "partial_update"):
             return OwnedManagedNodeSerializer
         return ManagedNodeSerializer
+
+    def _managed_node_mutate_allowed(self, managed_node):
+        user = self.request.user
+        if user.is_staff or managed_node.owner_id == user.id:
+            return
+        self.permission_denied(
+            self.request,
+            message="You do not have permission to modify this managed node.",
+        )
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        context = self.get_serializer_context()
+        if request.user.is_staff or instance.owner_id == request.user.id:
+            serializer = OwnedManagedNodeSerializer(instance, context=context)
+        else:
+            serializer = ManagedNodeSerializer(instance, context=context)
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         """Create a new managed node and set the owner."""
         serializer.save(owner=self.request.user)
+
+    def perform_update(self, serializer):
+        self._managed_node_mutate_allowed(serializer.instance)
+        serializer.save()
+
+    def perform_destroy(self, instance):
+        self._managed_node_mutate_allowed(instance)
+        super().perform_destroy(instance)
 
     @action(detail=False, methods=["get"])
     def mine(self, request):

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3416,6 +3416,9 @@ paths:
   /nodes/managed-nodes/{node_id}/:
     get:
       summary: Get managed node details
+      description: >-
+        Returns full details. If the current user is the node owner or staff, the response includes
+        OwnedManagedNode fields (e.g. channel_0–channel_7 as nested MessageChannel). Other authenticated users receive ManagedNodeRead without channel mappings.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -3427,7 +3430,7 @@ paths:
             type: integer
       responses:
         '200':
-          description: Node details
+          description: Node details (OwnedManagedNode shape for owner/staff; else ManagedNodeRead)
           content:
             application/json:
               schema:
@@ -3456,6 +3459,43 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OwnedManagedNode'
+        '403':
+          description: Not the node owner and not staff
+
+    patch:
+      summary: Partially update managed node
+      description: >-
+        Owner or staff only. Typical body fields include channel_0–channel_7 (nullable MessageChannel IDs),
+        name, allow_auto_traceroute, default location via position, etc. Non-owners receive 403.
+      tags: [Nodes]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+              description: >-
+                Any subset of OwnedManagedNode writable fields (e.g. channel_0–channel_7 as integer IDs or null).
+      responses:
+        '200':
+          description: Updated managed node
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OwnedManagedNode'
+        '400':
+          description: Validation error (e.g. channel not in node constellation)
+        '403':
+          description: Not the node owner and not staff
 
     delete:
       summary: Delete managed node


### PR DESCRIPTION
# Summary

Managed node **channel mapping** is now editable via API for the owning user (or staff), with validation that each referenced channel belongs to the node’s constellation. **Retrieve** returns channel details for owners (and staff); other callers keep the existing public shape. OpenAPI documents PATCH behaviour and error responses.

Part of epic #138.

Closes #135
Closes #136
Closes #137

## Changes

- `OwnedManagedNodeSerializer`: validate `channel_0`…`channel_7` against constellation message channels; strip `owner` / `constellation` from `validated_data` for non-staff updates.
- `ManagedNodeViewSet`: use owned serializer for `partial_update` / `update`; custom `retrieve` for owner vs non-owner; `perform_update` / `perform_destroy` restricted to owner or staff.
- Tests in `Meshflow/nodes/tests/test_managed_node_channel_patch.py`; `openapi.yaml` PATCH/GET notes.

## Testing performed

- `pytest Meshflow/nodes/tests/test_managed_node_channel_patch.py -v`
- black, isort, flake8 on touched Python files