### PR TITLE
feat(traceroute): manual trigger + triggerable list use ingestion eligibility

### DIFF
--- a/Meshflow/traceroute/permission_helpers.py
+++ b/Meshflow/traceroute/permission_helpers.py
@@ -5,6 +5,8 @@ from django.db.models import OuterRef, Q, Subquery
 from constellations.models import ConstellationUserMembership
 from nodes.models import ManagedNode, ObservedNode
 
+from .source_eligibility import eligible_auto_traceroute_sources_queryset
+
 
 def user_can_trigger_from_node(user, source_node):
     """Check if user can trigger a traceroute from the given ManagedNode."""
@@ -19,8 +21,11 @@ def user_can_trigger_from_node(user, source_node):
     ).exists()
 
 
-def get_triggerable_nodes_queryset(user):
-    """Return ManagedNodes the user can trigger traceroutes from (allow_auto_traceroute=True)."""
+def get_nodes_permitted_for_trigger_queryset(user):
+    """
+    ManagedNodes the user may attempt to trigger from (allow_auto_traceroute + role),
+    without requiring recent ingestion. Used for DRF object-level permission gate.
+    """
     base = ManagedNode.objects.filter(allow_auto_traceroute=True).select_related("constellation")
     if user.is_staff:
         qs = base
@@ -29,6 +34,23 @@ def get_triggerable_nodes_queryset(user):
             user=user, role__in=["admin", "editor"]
         ).values_list("constellation_id", flat=True)
         qs = base.filter(Q(owner=user) | Q(constellation_id__in=constellation_ids)).distinct()
+    return qs
+
+
+def get_triggerable_nodes_queryset(user):
+    """
+    Return ManagedNodes the user can trigger traceroutes from right now: allow_auto_traceroute,
+    recent packet ingestion as observer (same window as Celery schedule_traceroutes),
+    and permission (staff / owner / constellation admin|editor).
+    """
+    eligible = eligible_auto_traceroute_sources_queryset()
+    if user.is_staff:
+        qs = eligible
+    else:
+        constellation_ids = ConstellationUserMembership.objects.filter(
+            user=user, role__in=["admin", "editor"]
+        ).values_list("constellation_id", flat=True)
+        qs = eligible.filter(Q(owner=user) | Q(constellation_id__in=constellation_ids)).distinct()
     obs_short = ObservedNode.objects.filter(node_id=OuterRef("node_id")).values("short_name")[:1]
     obs_long = ObservedNode.objects.filter(node_id=OuterRef("node_id")).values("long_name")[:1]
     return qs.annotate(

--- a/Meshflow/traceroute/permissions.py
+++ b/Meshflow/traceroute/permissions.py
@@ -2,13 +2,13 @@
 
 from rest_framework import permissions
 
-from .permission_helpers import get_triggerable_nodes_queryset
+from .permission_helpers import get_nodes_permitted_for_trigger_queryset
 
 
 class CanTriggerTraceroute(permissions.BasePermission):
     """
-    Allow triggering traceroutes if user has at least one triggerable node
-    (staff, constellation admin/editor, or ManagedNode owner).
+    Allow POST if user has at least one allow_auto_traceroute node they own or can edit.
+    Recent ingestion is enforced in the view (400), not here, so offline sources get a clear error.
     """
 
     message = "You do not have permission to trigger traceroutes."
@@ -16,4 +16,4 @@ class CanTriggerTraceroute(permissions.BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
-        return get_triggerable_nodes_queryset(request.user).exists()
+        return get_nodes_permitted_for_trigger_queryset(request.user).exists()

--- a/Meshflow/traceroute/source_eligibility.py
+++ b/Meshflow/traceroute/source_eligibility.py
@@ -37,3 +37,8 @@ def eligible_auto_traceroute_sources_queryset():
         .filter(_has_recent_ingestion=True)
         .select_related("constellation")
     )
+
+
+def is_managed_node_eligible_traceroute_source(managed_node: ManagedNode) -> bool:
+    """True if this managed node may be used as a traceroute source (scheduler or API trigger)."""
+    return eligible_auto_traceroute_sources_queryset().filter(pk=managed_node.pk).exists()

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -2,14 +2,43 @@
 
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
 import pytest
 from rest_framework.test import APIClient
 
 import nodes.tests.conftest  # noqa: F401 - load fixtures
+import packets.tests.conftest  # noqa: F401 - load fixtures
 import users.tests.conftest  # noqa: F401 - load fixtures
-from constellations.models import ConstellationUserMembership
+from constellations.models import ConstellationUserMembership, MessageChannel
+from packets.models import PacketObservation
 from traceroute.models import AutoTraceRoute
+
+
+@pytest.fixture
+def add_traceroute_source_ingestion(create_raw_packet):
+    """Record a PacketObservation for observer (no extra ManagedNode). Depends only on create_raw_packet."""
+
+    def _add(observer):
+        packet = create_raw_packet()
+        channel = MessageChannel.objects.create(
+            name=f"tr-ingest-{observer.internal_id}",
+            constellation=observer.constellation,
+        )
+        return PacketObservation.objects.create(
+            packet=packet,
+            observer=observer,
+            channel=channel,
+            hop_limit=3,
+            hop_start=3,
+            rx_time=timezone.now(),
+            rx_rssi=-60.0,
+            rx_snr=10.0,
+            upload_time=timezone.now(),
+            relay_node=None,
+        )
+
+    return _add
 
 
 @pytest.fixture
@@ -36,15 +65,17 @@ def editor_user(create_user, create_constellation):
 
 
 @pytest.fixture
-def editor_managed_node(editor_user, create_constellation, create_managed_node):
+def editor_managed_node(editor_user, create_constellation, create_managed_node, add_traceroute_source_ingestion):
     """Managed node in a constellation where editor_user has editor role."""
     membership = ConstellationUserMembership.objects.filter(user=editor_user, role="editor").first()
     constellation = membership.constellation
-    return create_managed_node(
+    mn = create_managed_node(
         owner=membership.constellation.created_by,
         constellation=constellation,
         allow_auto_traceroute=True,
     )
+    add_traceroute_source_ingestion(mn)
+    return mn
 
 
 @pytest.fixture
@@ -141,15 +172,17 @@ class TestTracerouteDetail:
 
 
 @pytest.fixture
-def owner_managed_node(create_user, create_managed_node, create_constellation):
+def owner_managed_node(create_user, create_managed_node, create_constellation, add_traceroute_source_ingestion):
     """ManagedNode owned by owner_user with allow_auto_traceroute=True."""
     owner = create_user()
     constellation = create_constellation(created_by=owner)
-    return create_managed_node(
+    mn = create_managed_node(
         owner=owner,
         constellation=constellation,
         allow_auto_traceroute=True,
     )
+    add_traceroute_source_ingestion(mn)
+    return mn
 
 
 @pytest.mark.django_db
@@ -158,9 +191,12 @@ class TestTracerouteCanTrigger:
         resp = api_client.get("/api/traceroutes/can_trigger/")
         assert resp.status_code == 401
 
-    def test_can_trigger_true_for_staff(self, api_client, staff_user, create_managed_node):
-        """Staff has can_trigger=True when at least one node has allow_auto_traceroute."""
-        create_managed_node(allow_auto_traceroute=True)
+    def test_can_trigger_true_for_staff(
+        self, api_client, staff_user, create_managed_node, add_traceroute_source_ingestion
+    ):
+        """Staff has can_trigger=True when at least one eligible node exists."""
+        mn = create_managed_node(allow_auto_traceroute=True)
+        add_traceroute_source_ingestion(mn)
         api_client.force_authenticate(user=staff_user)
         resp = api_client.get("/api/traceroutes/can_trigger/")
         assert resp.status_code == 200
@@ -194,8 +230,11 @@ class TestTracerouteTriggerableNodes:
         resp = api_client.get("/api/traceroutes/triggerable-nodes/")
         assert resp.status_code == 401
 
-    def test_triggerable_nodes_returns_nodes_for_staff(self, api_client, staff_user, create_managed_node):
+    def test_triggerable_nodes_returns_nodes_for_staff(
+        self, api_client, staff_user, create_managed_node, add_traceroute_source_ingestion
+    ):
         mn = create_managed_node(allow_auto_traceroute=True)
+        add_traceroute_source_ingestion(mn)
         api_client.force_authenticate(user=staff_user)
         resp = api_client.get("/api/traceroutes/triggerable-nodes/")
         assert resp.status_code == 200
@@ -252,6 +291,15 @@ class TestTracerouteTriggerableNodes:
         assert "long_name" in node
         assert "allow_auto_traceroute" in node
         assert "constellation" in node
+
+    def test_triggerable_nodes_excludes_without_recent_ingestion(self, api_client, staff_user, create_managed_node):
+        """Nodes with allow_auto_traceroute but no recent PacketObservation as observer are omitted."""
+        mn = create_managed_node(allow_auto_traceroute=True)
+        api_client.force_authenticate(user=staff_user)
+        resp = api_client.get("/api/traceroutes/triggerable-nodes/")
+        assert resp.status_code == 200
+        node_ids = [n["node_id"] for n in resp.json()]
+        assert mn.node_id not in node_ids
 
 
 @pytest.mark.django_db
@@ -345,10 +393,11 @@ class TestTracerouteTrigger:
         assert "rate limited" in resp2.json().get("detail", "").lower()
 
     def test_trigger_staff_can_trigger_from_any_node(
-        self, api_client, staff_user, create_managed_node, create_observed_node
+        self, api_client, staff_user, create_managed_node, create_observed_node, add_traceroute_source_ingestion
     ):
-        """Staff can trigger from any ManagedNode with allow_auto_traceroute=True."""
+        """Staff can trigger from any eligible ManagedNode."""
         mn = create_managed_node(allow_auto_traceroute=True)
+        add_traceroute_source_ingestion(mn)
         on = create_observed_node()
         api_client.force_authenticate(user=staff_user)
         resp = api_client.post(
@@ -386,3 +435,30 @@ class TestTracerouteTrigger:
             format="json",
         )
         assert resp.status_code == 403
+
+    def test_trigger_rejects_without_recent_ingestion(
+        self,
+        api_client,
+        editor_user,
+        create_managed_node,
+        create_observed_node,
+    ):
+        """Trigger returns 400 when source has permission but no recent ingestion as observer."""
+        membership = ConstellationUserMembership.objects.filter(user=editor_user, role="editor").first()
+        constellation = membership.constellation
+        creator = constellation.created_by
+        mn = create_managed_node(
+            owner=creator,
+            constellation=constellation,
+            allow_auto_traceroute=True,
+            node_id=888_777_666,
+        )
+        on = create_observed_node()
+        api_client.force_authenticate(user=editor_user)
+        resp = api_client.post(
+            "/api/traceroutes/trigger/",
+            {"managed_node_id": mn.node_id, "target_node_id": on.node_id},
+            format="json",
+        )
+        assert resp.status_code == 400
+        assert "ingestion" in resp.json().get("detail", "").lower()

--- a/Meshflow/traceroute/views.py
+++ b/Meshflow/traceroute/views.py
@@ -27,6 +27,7 @@ from .serializers import (
     TriggerableNodeSerializer,
     TriggerTracerouteSerializer,
 )
+from .source_eligibility import is_managed_node_eligible_traceroute_source
 from .target_selection import pick_traceroute_target
 
 # Firmware enforces ~30s minimum between traceroutes per node. Reject requests within this window.
@@ -169,9 +170,8 @@ def traceroute_trigger(request):
     managed_node_id = serializer.validated_data["managed_node_id"]
     target_node_id = serializer.validated_data.get("target_node_id")
 
-    try:
-        source_node = ManagedNode.objects.get(node_id=managed_node_id)
-    except ManagedNode.DoesNotExist:
+    source_node = ManagedNode.objects.filter(node_id=managed_node_id).order_by("internal_id").first()
+    if source_node is None:
         return Response(
             {"managed_node_id": ["ManagedNode with this node_id not found."]},
             status=status.HTTP_404_NOT_FOUND,
@@ -180,6 +180,18 @@ def traceroute_trigger(request):
     if not source_node.allow_auto_traceroute:
         return Response(
             {"detail": "This managed node does not allow traceroutes (allow_auto_traceroute is disabled)."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if not is_managed_node_eligible_traceroute_source(source_node):
+        return Response(
+            {
+                "detail": (
+                    "This managed node has no recent packet ingestion from the monitor bot "
+                    "(within SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS). "
+                    "It cannot be used as a traceroute source until the bot reports packets again."
+                )
+            },
             status=status.HTTP_400_BAD_REQUEST,
         )
 

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -8,16 +8,16 @@ Who can trigger traceroutes and from which nodes:
 
 | Role | Can trigger from |
 |------|------------------|
-| System admin (`is_staff`) | Any ManagedNode with `allow_auto_traceroute=True` |
-| Constellation admin/editor | Nodes in constellations where user has admin/editor role |
-| ManagedNode owner | Nodes they own (`ManagedNode.owner == user`) |
+| System admin (`is_staff`) | ManagedNodes with `allow_auto_traceroute=True` and recent ingestion as `PacketObservation.observer` |
+| Constellation admin/editor | Same eligibility, in constellations where user has admin/editor role |
+| ManagedNode owner | Same eligibility for nodes they own |
 | All authenticated | View traceroute list, detail, heatmap |
 
-The UI fetches `GET /api/traceroutes/triggerable-nodes/` to show only nodes the user can trigger from. The trigger view validates `user_can_trigger_from_node(user, source_node)` before sending the command.
+The UI fetches `GET /api/traceroutes/triggerable-nodes/` to list sources that are both permitted and recently ingesting (same rule as the Celery scheduler). The trigger view validates eligibility, `user_can_trigger_from_node(user, source_node)`, and rate limits before sending the command.
 
 ## 1. Trigger
 
-**Manual**: User calls `POST /api/traceroutes/trigger/` with `managed_node_id` and optional `target_node_id`. Requires constellation admin/editor role. Rate limit: 60s per node.
+**Manual**: User calls `POST /api/traceroutes/trigger/` with `managed_node_id` and optional `target_node_id`. Source must match the same eligibility as auto-schedule (recent ingestion window `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`). Requires permission as above. Rate limit: 60s per node.
 
 **Automatic**: Celery task `schedule_traceroutes` runs periodically. Picks one random ManagedNode with `allow_auto_traceroute=True` **and** recent packet ingestion as `PacketObservation.observer` (within `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`, default 600s), uses `pick_traceroute_target()` to select a target (geography-aware, prioritises periphery and less-recently-traced nodes), creates `AutoTraceRoute` with `trigger_type=auto`.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4224,7 +4224,7 @@ paths:
   /traceroutes/can_trigger/:
     get:
       summary: Check if user can trigger traceroutes
-      description: Returns whether the current user has at least one triggerable node (staff, constellation admin/editor, or ManagedNode owner).
+      description: Returns whether the current user has at least one triggerable node (staff, constellation admin/editor, or ManagedNode owner). Nodes must have allow_auto_traceroute and recent packet ingestion as PacketObservation.observer (same window as SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS for the Celery scheduler).
       tags: [Traceroutes]
       security:
         - BearerAuth: []
@@ -4242,7 +4242,7 @@ paths:
   /traceroutes/triggerable-nodes/:
     get:
       summary: List nodes user can trigger traceroutes from
-      description: Returns ManagedNodes the current user can trigger traceroutes from (staff=all, constellation admin/editor=nodes in their constellations, owner=their nodes). Only nodes with allow_auto_traceroute=True.
+      description: Returns ManagedNodes the current user can trigger traceroutes from (staff=all, constellation admin/editor=nodes in their constellations, owner=their nodes). Only nodes with allow_auto_traceroute=True and recent packet ingestion as observer (SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS), matching Celery schedule_traceroutes source selection.
       tags: [Traceroutes]
       security:
         - BearerAuth: []
@@ -4280,7 +4280,7 @@ paths:
   /traceroutes/trigger/:
     post:
       summary: Trigger a traceroute
-      description: Manually trigger a traceroute. Requires permission to trigger from the source node (staff, constellation admin/editor, or ManagedNode owner).
+      description: Manually trigger a traceroute. Requires permission to trigger from the source node (staff, constellation admin/editor, or ManagedNode owner). The source must have allow_auto_traceroute and recent packet ingestion as observer (same eligibility as schedule_traceroutes).
       tags: [Traceroutes]
       security:
         - BearerAuth: []
@@ -4307,6 +4307,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AutoTraceRoute'
+        '400':
+          description: Bad request (e.g. allow_auto_traceroute disabled, or no recent packet ingestion from monitor bot)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
         '403':
           description: Forbidden
         '404':


### PR DESCRIPTION
## Summary

Aligns **manual** traceroute triggers with the Celery scheduler: a source must have **recent `PacketObservation` as `observer`** (`SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`, same as #141).

- `get_triggerable_nodes_queryset()` intersects role-based access with `eligible_auto_traceroute_sources_queryset()` — affects `GET /traceroutes/triggerable-nodes/` and `GET /traceroutes/can_trigger/` (UI hides Trigger buttons when no online sources).
- `POST /traceroutes/trigger/` returns **400** with a clear detail when the source lacks recent ingestion.
- `CanTriggerTraceroute` uses **`get_nodes_permitted_for_trigger_queryset()`** (no ingestion filter) so users who only have offline sources still pass the DRF gate and get **400** for a bad `managed_node_id` instead of **403**.
- `managed_node_id` lookup uses `.filter().order_by("internal_id").first()` to avoid `MultipleObjectsReturned` when duplicate `node_id` rows exist in tests/data.
- `is_managed_node_eligible_traceroute_source()` on `ManagedNode`.
- Tests, `openapi.yaml`, `docs/features/traceroute/flow.md`.

## Testing

- `pytest traceroute/tests/ -q`
- `black` / `isort` / `flake8` on touched Python files

Refs https://github.com/pskillen/meshtastic-bot-ui/issues/129