### PR TITLE
feat(traceroutes): add by_source to traceroute stats API

### DIFF
--- a/.cursor/skills/meshflow-git-workflow/SKILL.md
+++ b/.cursor/skills/meshflow-git-workflow/SKILL.md
@@ -39,13 +39,15 @@ When executing the plan:
 
 ## 2. Branch Naming
 
-Format: `{repo-prefix}-{issue-number}/{author}/{short-description}`
+Format: `{issue-repo-prefix}-{issue-number}/{author}/{short-description}`
 
-| Repo | Prefix | Example |
-|------|--------|---------|
-| meshflow-api | `api` | `api-456/paddy/fix-endpoint-bug` |
-| meshtastic-bot | `bot` | `bot-123/paddy/add-traceroute-command` |
-| meshtastic-bot-ui | `ui` | `ui-78/paddy/add-cool-new-page` |
+**Which prefix?** Use the prefix for the **GitHub repository where the tracking issue lives**, not the repo you are committing in. That keeps one issue number traceable across Meshflow repos.
+
+| Issue filed in | Prefix | Use that prefix in every repo that has a branch for the work |
+|----------------|--------|----------------------------------------------------------------|
+| meshtastic-bot-ui | `ui` | e.g. UI #136 → `ui-136/paddy/...` in **both** meshtastic-bot-ui **and** meshflow-api (and meshtastic-bot if needed) |
+| meshflow-api | `api` | e.g. API #456 → `api-456/paddy/...` in every affected repo |
+| meshtastic-bot | `bot` | e.g. bot #123 → `bot-123/paddy/...` in every affected repo |
 
 Use kebab-case for the description. Keep it short.
 
@@ -127,7 +129,7 @@ When the work is done:
 | Step | Action |
 |------|--------|
 | Plan | Issue in relevant repo(s); parent in meshflow-api if multi-repo |
-| Branch | `{prefix}-{num}/{author}/{description}` |
+| Branch | `{issue-repo-prefix}-{num}/{author}/{description}` (prefix = repo where the issue lives) |
 | Pre-commit | meshflow-api/meshtastic-bot: venv + black, isort, flake8; meshtastic-bot-ui: `npm run format` |
 | Commit | Conventional commits, no "enhance" |
 | PR | Open in all affected repos, link issues and related PRs |

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -1,5 +1,7 @@
 """Tests for traceroute views."""
 
+from datetime import timedelta
+
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
@@ -462,3 +464,96 @@ class TestTracerouteTrigger:
         )
         assert resp.status_code == 400
         assert "ingestion" in resp.json().get("detail", "").lower()
+
+
+@pytest.mark.django_db
+class TestTracerouteStats:
+    def test_stats_requires_auth(self, api_client):
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 401
+
+    def test_stats_includes_by_source_for_two_sources(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn_a = create_managed_node(node_id=111_111_111)
+        mn_b = create_managed_node(node_id=222_222_222)
+        on = create_observed_node()
+        api_client.force_authenticate(user=user)
+
+        create_auto_traceroute(
+            source_node=mn_a, target_node=on, triggered_by=user, status=AutoTraceRoute.STATUS_COMPLETED
+        )
+        create_auto_traceroute(
+            source_node=mn_a, target_node=on, triggered_by=user, status=AutoTraceRoute.STATUS_COMPLETED
+        )
+        create_auto_traceroute(source_node=mn_a, target_node=on, triggered_by=user, status=AutoTraceRoute.STATUS_FAILED)
+        create_auto_traceroute(
+            source_node=mn_b, target_node=on, triggered_by=user, status=AutoTraceRoute.STATUS_PENDING
+        )
+        create_auto_traceroute(source_node=mn_b, target_node=on, triggered_by=user, status=AutoTraceRoute.STATUS_SENT)
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "by_source" in data
+        by_internal_id = {row["managed_node_id"]: row for row in data["by_source"]}
+
+        row_a = by_internal_id[str(mn_a.internal_id)]
+        assert row_a["total"] == 3
+        assert row_a["completed"] == 2
+        assert row_a["failed"] == 1
+        assert row_a["success_rate"] == pytest.approx(2 / 3)
+        assert row_a["node_id"] == mn_a.node_id
+        assert row_a["name"] == mn_a.name
+
+        row_b = by_internal_id[str(mn_b.internal_id)]
+        assert row_b["total"] == 2
+        assert row_b["completed"] == 0
+        assert row_b["failed"] == 0
+        assert row_b["success_rate"] is None
+
+    def test_by_source_respects_triggered_at_after(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn = create_managed_node(node_id=333_333_333)
+        on = create_observed_node()
+        api_client.force_authenticate(user=user)
+
+        old_time = timezone.now() - timedelta(days=30)
+        tr_old = create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+        AutoTraceRoute.objects.filter(pk=tr_old.pk).update(triggered_at=old_time)
+
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+
+        resp_all = api_client.get("/api/traceroutes/stats/")
+        assert resp_all.status_code == 200
+        rows_all = {r["managed_node_id"]: r for r in resp_all.json()["by_source"]}
+        assert rows_all[str(mn.internal_id)]["total"] == 2
+
+        since = (timezone.now() - timedelta(days=7)).isoformat()
+        resp_filtered = api_client.get("/api/traceroutes/stats/", {"triggered_at_after": since})
+        assert resp_filtered.status_code == 200
+        rows_f = {r["managed_node_id"]: r for r in resp_filtered.json()["by_source"]}
+        assert rows_f[str(mn.internal_id)]["total"] == 1

--- a/Meshflow/traceroute/views.py
+++ b/Meshflow/traceroute/views.py
@@ -3,7 +3,7 @@
 from collections import Counter
 from datetime import timedelta
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.db.models.functions import TruncDate
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -312,7 +312,7 @@ def heatmap_edges(request):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def traceroute_stats(request):
-    """Traceroute statistics: sources, success/failure, top routers, success over time."""
+    """Traceroute statistics: sources, success/failure, top routers, by source, success over time."""
     from django.utils.dateparse import parse_datetime
 
     from common.mesh_node_helpers import meshtastic_id_to_hex
@@ -367,6 +367,47 @@ def traceroute_stats(request):
         for nid in top_router_node_ids
     ]
 
+    # Per source managed node (same triggered_at window as qs)
+    by_source_rows = list(
+        qs.values("source_node_id").annotate(
+            total=Count("id"),
+            completed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_COMPLETED)),
+            failed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_FAILED)),
+        )
+    )
+    source_internal_ids = [r["source_node_id"] for r in by_source_rows]
+    managed_by_internal_id = {m.internal_id: m for m in ManagedNode.objects.filter(internal_id__in=source_internal_ids)}
+    mesh_node_ids = [m.node_id for m in managed_by_internal_id.values()]
+    observed_short_by_mesh_id = {}
+    if mesh_node_ids:
+        for o in ObservedNode.objects.filter(node_id__in=mesh_node_ids).values("node_id", "short_name"):
+            observed_short_by_mesh_id[o["node_id"]] = o["short_name"]
+
+    by_source = []
+    for row in by_source_rows:
+        mn = managed_by_internal_id.get(row["source_node_id"])
+        if mn is None:
+            continue
+        completed_n = row["completed"]
+        failed_n = row["failed"]
+        finished = completed_n + failed_n
+        success_rate = None if finished == 0 else completed_n / finished
+        short_name = observed_short_by_mesh_id.get(mn.node_id) or mn.name
+        by_source.append(
+            {
+                "managed_node_id": str(mn.internal_id),
+                "node_id": mn.node_id,
+                "node_id_str": meshtastic_id_to_hex(mn.node_id),
+                "name": mn.name,
+                "short_name": short_name,
+                "total": row["total"],
+                "completed": completed_n,
+                "failed": failed_n,
+                "success_rate": success_rate,
+            }
+        )
+    by_source.sort(key=lambda x: (-x["total"], x["node_id_str"]))
+
     # Success over time: last 14 days, from StatsSnapshot or on-demand
     fourteen_days_ago = timezone.now() - timedelta(days=14)
     success_over_time = _get_success_over_time(fourteen_days_ago)
@@ -376,6 +417,7 @@ def traceroute_stats(request):
             "sources": sources,
             "success_failure": success_failure,
             "top_routers": top_routers,
+            "by_source": by_source,
             "success_over_time": success_over_time,
         }
     )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4181,7 +4181,8 @@ paths:
       summary: Get traceroute statistics
       description: >
         Returns traceroute stats for the given timeframe: sources (by trigger_type),
-        success/failure counts, top routers (intermediate nodes), and success over time (14d).
+        success/failure counts, top routers (intermediate nodes), per-source managed node
+        totals (with success rate among finished runs only), and success over time (14d).
         All authenticated users.
       tags: [Traceroutes]
       security:
@@ -4201,7 +4202,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [sources, success_failure, top_routers, success_over_time]
+                required: [sources, success_failure, top_routers, by_source, success_over_time]
                 properties:
                   sources:
                     type: array
@@ -4234,6 +4235,51 @@ paths:
                           type: string
                         count:
                           type: integer
+                  by_source:
+                    type: array
+                    description: >
+                      One row per source ManagedNode in the filtered period, ordered by total
+                      runs descending. success_rate is completed / (completed + failed) when
+                      that sum is positive; null if there are no finished runs (pending/sent
+                      count toward total only).
+                    items:
+                      type: object
+                      required:
+                        - managed_node_id
+                        - node_id
+                        - node_id_str
+                        - name
+                        - short_name
+                        - total
+                        - completed
+                        - failed
+                        - success_rate
+                      properties:
+                        managed_node_id:
+                          type: string
+                          format: uuid
+                        node_id:
+                          type: integer
+                        node_id_str:
+                          type: string
+                        name:
+                          type: string
+                        short_name:
+                          type: string
+                        total:
+                          type: integer
+                          description: All runs in the period (any status).
+                        completed:
+                          type: integer
+                        failed:
+                          type: integer
+                        success_rate:
+                          type: number
+                          format: float
+                          nullable: true
+                          description: >
+                            Fraction of finished runs that completed successfully.
+                            Denominator is completed + failed only.
                   success_over_time:
                     type: array
                     items:


### PR DESCRIPTION
## Summary

Adds `by_source` to `GET /api/traceroutes/stats/`: one row per source `ManagedNode` with `total`, `completed`, `failed`, and `success_rate` (completed ÷ (completed + failed) when there are finished runs; pending/sent count toward `total` only). Uses the same `triggered_at_after` window as the existing stats fields. OpenAPI and `TestTracerouteStats` are updated.

Companion UI PR: [pskillen/meshtastic-bot-ui#142](https://github.com/pskillen/meshtastic-bot-ui/pull/142). Tracks [meshtastic-bot-ui#136](https://github.com/pskillen/meshtastic-bot-ui/issues/136).

## Testing performed

- `pytest traceroute/tests/test_views.py::TestTracerouteStats -v`
- black / isort / flake8 on touched files