### PR TITLE
feat(mesh_monitoring): watches REST API, OpenAPI, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Meshflow/
 - **ManagedNode**: User-owned node linked to a Constellation. Part of system infrastucture. Matched to ObservedNode by `node_id`.
 - **Constellation**: Subset of nodes representing a region. Has `ConstellationUserMembership` (admin/editor/viewer).
 - **NodeAPIKey**: API keys for node authentication, scoped to a Constellation.
-- **Mesh monitoring** (`mesh_monitoring`): `NodeWatch` / `NodePresence`, Celery `process_node_watch_presence`, `trigger_type=monitor` traceroutes; integrates with `packets` and `traceroute`; watch REST in a later phase.
+- **Mesh monitoring** (`mesh_monitoring`): `NodeWatch` / `NodePresence`, Celery `process_node_watch_presence`, `trigger_type=monitor` traceroutes; integrates with `packets` and `traceroute`; authenticated watch CRUD at `api/monitoring/watches/`.
 
 ## API Layout
 
@@ -36,6 +36,7 @@ All endpoints under `/api/`:
 - `api/nodes/observed-nodes/mine/` – User's claimed nodes
 - `api/nodes/managed-nodes/` – Managed nodes
 - `api/constellations/` – Constellations, memberships, channels
+- `api/monitoring/watches/` – User's mesh monitoring watches (NodeWatch CRUD)
 - `api/packets/` – Packet ingestion
 - `api/stats/` – Packet statistics
 - `api/messages/` – Text messages

--- a/Meshflow/mesh_monitoring/serializers.py
+++ b/Meshflow/mesh_monitoring/serializers.py
@@ -1,0 +1,92 @@
+"""DRF serializers for mesh monitoring."""
+
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework import serializers
+
+from mesh_monitoring.eligibility import user_can_watch
+from mesh_monitoring.models import NodeWatch
+from nodes.models import ObservedNode
+
+
+class ObservedNodeWatchSummarySerializer(serializers.ModelSerializer):
+    """Minimal observed node + monitoring presence hints for watch payloads."""
+
+    monitoring_verification_started_at = serializers.SerializerMethodField()
+    monitoring_offline_confirmed_at = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ObservedNode
+        fields = [
+            "internal_id",
+            "node_id_str",
+            "long_name",
+            "last_heard",
+            "monitoring_verification_started_at",
+            "monitoring_offline_confirmed_at",
+        ]
+
+    def get_monitoring_verification_started_at(self, obj):
+        rel = getattr(obj, "mesh_presence", None)
+        if rel is None:
+            return None
+        return rel.verification_started_at
+
+    def get_monitoring_offline_confirmed_at(self, obj):
+        rel = getattr(obj, "mesh_presence", None)
+        if rel is None:
+            return None
+        return rel.offline_confirmed_at
+
+
+class NodeWatchSerializer(serializers.ModelSerializer):
+    observed_node = ObservedNodeWatchSummarySerializer(read_only=True)
+    observed_node_id = serializers.PrimaryKeyRelatedField(
+        queryset=ObservedNode.objects.all(),
+        source="observed_node",
+        write_only=True,
+        required=False,
+    )
+
+    class Meta:
+        model = NodeWatch
+        fields = [
+            "id",
+            "observed_node",
+            "observed_node_id",
+            "offline_after",
+            "enabled",
+            "created_at",
+        ]
+        read_only_fields = ["id", "observed_node", "created_at"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance is None:
+            self.fields["observed_node_id"].required = True
+        else:
+            self.fields["observed_node_id"].read_only = True
+
+    def validate_observed_node_id(self, value):
+        request = self.context.get("request")
+        if request and request.user.is_authenticated and value is not None:
+            if not user_can_watch(request.user, value):
+                raise serializers.ValidationError(
+                    _("You may only watch nodes you claimed or infrastructure nodes."),
+                )
+        return value
+
+    def validate(self, attrs):
+        request = self.context.get("request")
+        observed = attrs.get("observed_node")
+        if self.instance is None and observed is not None and request and request.user.is_authenticated:
+            if NodeWatch.objects.filter(user=request.user, observed_node=observed).exists():
+                raise serializers.ValidationError(
+                    {"observed_node_id": _("You already have a watch for this node.")},
+                )
+        return attrs
+
+    def validate_offline_after(self, value):
+        if value is not None and value < 1:
+            raise serializers.ValidationError(_("offline_after must be at least 1 second."))
+        return value

--- a/Meshflow/mesh_monitoring/tests/test_watch_api.py
+++ b/Meshflow/mesh_monitoring/tests/test_watch_api.py
@@ -1,0 +1,144 @@
+"""HTTP API tests for NodeWatch CRUD."""
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import nodes.tests.conftest  # noqa: F401
+from mesh_monitoring.models import NodeWatch
+from nodes.constants import INFRASTRUCTURE_ROLES
+from nodes.models import RoleSource
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_watch_list_requires_auth(api_client):
+    r = api_client.get("/api/monitoring/watches/")
+    assert r.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_watch_create_requires_auth(api_client, create_observed_node):
+    obs = create_observed_node()
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id), "offline_after": 60, "enabled": True},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+@pytest.mark.django_db
+def test_watch_crud_claimed_node(api_client, create_user, create_observed_node):
+    user = create_user()
+    obs = create_observed_node(claimed_by=user)
+    api_client.force_authenticate(user=user)
+
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id), "offline_after": 90, "enabled": True},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_201_CREATED
+    wid = r.data["id"]
+    assert r.data["offline_after"] == 90
+    assert r.data["enabled"] is True
+    assert r.data["observed_node"]["node_id_str"] == obs.node_id_str
+    assert r.data["observed_node"]["monitoring_verification_started_at"] is None
+
+    r = api_client.get("/api/monitoring/watches/")
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["count"] == 1
+    assert r.data["results"][0]["id"] == wid
+
+    r = api_client.patch(f"/api/monitoring/watches/{wid}/", {"enabled": False}, format="json")
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["enabled"] is False
+
+    r = api_client.delete(f"/api/monitoring/watches/{wid}/")
+    assert r.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_watch_infrastructure_node_any_user(api_client, create_user, create_observed_node):
+    user = create_user()
+    obs = create_observed_node(role=INFRASTRUCTURE_ROLES[0], claimed_by=None)
+    api_client.force_authenticate(user=user)
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id)},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.django_db
+def test_watch_reject_ineligible_node(api_client, create_user, create_observed_node):
+    user = create_user()
+    obs = create_observed_node(role=RoleSource.CLIENT, claimed_by=None)
+    api_client.force_authenticate(user=user)
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id)},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST
+    assert "observed_node_id" in r.data or "non_field_errors" in r.data
+
+
+@pytest.mark.django_db
+def test_watch_duplicate(api_client, create_user, create_observed_node):
+    user = create_user()
+    obs = create_observed_node(claimed_by=user)
+    api_client.force_authenticate(user=user)
+    api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id)},
+        format="json",
+    )
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id)},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_watch_other_user_404(api_client, create_user, create_observed_node):
+    owner = create_user()
+    other = create_user()
+    obs = create_observed_node(claimed_by=owner)
+    w = NodeWatch.objects.create(user=owner, observed_node=obs, offline_after=60, enabled=True)
+
+    api_client.force_authenticate(user=other)
+    r = api_client.get(f"/api/monitoring/watches/{w.pk}/")
+    assert r.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_watch_presence_hints(api_client, create_user, create_observed_node):
+    from django.utils import timezone
+
+    from mesh_monitoring.models import NodePresence
+
+    user = create_user()
+    obs = create_observed_node(claimed_by=user)
+    now = timezone.now()
+    NodePresence.objects.create(
+        observed_node=obs,
+        verification_started_at=now,
+        offline_confirmed_at=None,
+    )
+    api_client.force_authenticate(user=user)
+    r = api_client.post(
+        "/api/monitoring/watches/",
+        {"observed_node_id": str(obs.internal_id)},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_201_CREATED
+    assert r.data["observed_node"]["monitoring_verification_started_at"] is not None

--- a/Meshflow/mesh_monitoring/urls.py
+++ b/Meshflow/mesh_monitoring/urls.py
@@ -1,3 +1,14 @@
-"""URL include target for mesh monitoring; watch REST lands in phase 04."""
+"""URL include target for mesh monitoring."""
 
-urlpatterns = []
+from django.urls import include, path
+
+from rest_framework.routers import DefaultRouter
+
+from mesh_monitoring.views import NodeWatchViewSet
+
+router = DefaultRouter()
+router.register(r"watches", NodeWatchViewSet, basename="nodewatch")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/Meshflow/mesh_monitoring/views.py
+++ b/Meshflow/mesh_monitoring/views.py
@@ -1,0 +1,30 @@
+"""REST API for mesh monitoring."""
+
+from rest_framework import permissions, viewsets
+
+from mesh_monitoring.models import NodeWatch
+from mesh_monitoring.serializers import NodeWatchSerializer
+
+
+class NodeWatchViewSet(viewsets.ModelViewSet):
+    """
+    CRUD for the current user's NodeWatch rows.
+
+    List/create: GET/POST /api/monitoring/watches/
+    Detail: GET/PATCH/PUT/DELETE /api/monitoring/watches/{id}/
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+    serializer_class = NodeWatchSerializer
+    http_method_names = ["get", "post", "put", "patch", "delete", "head", "options"]
+
+    def get_queryset(self):
+        return (
+            NodeWatch.objects.filter(user=self.request.user)
+            .select_related("observed_node")
+            .select_related("observed_node__mesh_presence")
+            .order_by("-created_at", "-id")
+        )
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)

--- a/docs/features/mesh-monitoring/README.md
+++ b/docs/features/mesh-monitoring/README.md
@@ -10,9 +10,9 @@ This document describes the **intended design** (models, Celery, APIs, and integ
 |------|-------------------|
 | Shared helpers (`nodes.managed_node_liveness`, `common.geo`, `nodes.positioning`, `traceroute.trigger_intervals`, random auto TR) | Shipped in API (refactor / traceroute) |
 | Verified Discord DMs (prefs, test, `push_notifications.discord`) | Shipped (`users` + `push_notifications`) |
-| Django app **`mesh_monitoring`** (`NodeWatch`, `NodePresence`), Celery **`process_node_watch_presence`**, `AutoTraceRoute.trigger_type=monitor`, hooks in **`packets`** + **`traceroute.target_selection`** | **Shipped** (phase 03b); URL include stub at **`/api/monitoring/`** (empty until phase 04) |
-| Watch **REST** CRUD (e.g. `/api/monitoring/watches/`) | Planned (API phase) |
-| **UI** (My Nodes watch toggles) | Planned (frontend phase) |
+| Django app **`mesh_monitoring`** (`NodeWatch`, `NodePresence`), Celery **`process_node_watch_presence`**, `AutoTraceRoute.trigger_type=monitor`, hooks in **`packets`** + **`traceroute.target_selection`** | **Shipped** (phase 03b) |
+| Watch **REST** CRUD | **`GET/POST /api/monitoring/watches/`**, **`GET/PATCH/PUT/DELETE …/watches/{id}/`** — authenticated; see **`openapi.yaml`** (`Mesh Monitoring` tag) |
+| **UI** (My Nodes watch toggles) | **meshtastic-bot-ui** My Nodes page + `meshtastic-api` client (phase 04) |
 
 Env: **`MESH_MONITORING_VERIFICATION_SECONDS`** (default `180`) for the verification window after silence.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,8 @@ tags:
     description: WebSocket endpoints for real-time node commands
   - name: Traceroutes
     description: Traceroute history and manual triggering
+  - name: Mesh Monitoring
+    description: User watches on observed nodes for silence detection and offline verification
 
 components:
   parameters:
@@ -795,6 +797,75 @@ components:
           description: >
             The current user's claim for this node, if any. Only present for authenticated requests.
             Null when the user has no claim. Use accepted_at to distinguish pending vs accepted claims.
+
+    ObservedNodeWatchSummary:
+      type: object
+      description: >
+        Observed node fields included on NodeWatch responses for My Nodes / monitoring UI.
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id_str:
+          type: string
+        long_name:
+          type: string
+          nullable: true
+        last_heard:
+          type: string
+          format: date-time
+          nullable: true
+        monitoring_verification_started_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Present when mesh monitoring is verifying reachability for this node.
+        monitoring_offline_confirmed_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Present when mesh monitoring has confirmed offline after failed verification.
+
+    NodeWatch:
+      type: object
+      properties:
+        id:
+          type: integer
+        observed_node:
+          $ref: '#/components/schemas/ObservedNodeWatchSummary'
+        offline_after:
+          type: integer
+          description: Seconds without packets (last_heard) before verification may start.
+        enabled:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+
+    NodeWatchCreate:
+      type: object
+      required: [observed_node_id]
+      properties:
+        observed_node_id:
+          type: string
+          format: uuid
+          description: Target ObservedNode primary key (internal_id).
+        offline_after:
+          type: integer
+          minimum: 1
+          default: 7200
+        enabled:
+          type: boolean
+          default: true
+
+    NodeWatchUpdate:
+      type: object
+      properties:
+        offline_after:
+          type: integer
+          minimum: 1
+        enabled:
+          type: boolean
 
     ObservedNodeEnvironmentSettingsPatch:
       type: object
@@ -4522,6 +4593,141 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AutoTraceRoute'
+        '404':
+          description: Not found
+
+  /monitoring/watches/:
+    get:
+      summary: List mesh monitoring watches for the current user
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationPageSize'
+      responses:
+        '200':
+          description: Paginated list of watches
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      results:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/NodeWatch'
+        '401':
+          description: Unauthorized
+    post:
+      summary: Create a watch on an observed node
+      description: >
+        User must be allowed to watch the node (claimed by user or infrastructure role).
+        One watch per (user, observed_node).
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeWatchCreate'
+      responses:
+        '201':
+          description: Watch created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeWatch'
+        '400':
+          description: Invalid or duplicate watch / ineligible node
+        '401':
+          description: Unauthorized
+
+  /monitoring/watches/{id}/:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+        description: NodeWatch primary key
+    get:
+      summary: Get a watch by id
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Watch detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeWatch'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not found (or not owned by the current user)
+    put:
+      summary: Replace a watch
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeWatchUpdate'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeWatch'
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not found
+    patch:
+      summary: Partially update a watch
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeWatchUpdate'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeWatch'
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not found
+    delete:
+      summary: Delete a watch
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          description: Unauthorized
         '404':
           description: Not found
 


### PR DESCRIPTION
# Summary

Adds **user-scoped mesh monitoring watches** so clients can list, create, update, and delete `NodeWatch` rows via the API.

- **`/api/monitoring/watches/`** — ViewSet (current user only), serializers with observed-node summary and monitoring status hints for the UI.
- **`openapi.yaml`** — Mesh Monitoring tag, `NodeWatch` schemas, CRUD paths.
- **Docs** — mesh-monitoring feature README / AGENTS alignment where touched.
- **Tests** — `test_watch_api.py` (per commit).

Pairs with **meshtastic-bot-ui** [PR #143](https://github.com/pskillen/meshtastic-bot-ui/pull/143) (My Nodes + Infrastructure watch UI). Deploy or merge API before relying on those UI flows in an environment.

**Manual steps:** run migrations if any new mesh_monitoring migrations ship with this branch (verify `manage.py migrate` in release notes for this PR).

Closes #149

## Testing performed

- `python -m pytest Meshflow/ -v` (or project-standard unit test command) including new watch API tests
- OpenAPI contract updated for clients
