### PR TITLE
fix(packets): complete traceroute on empty route (direct path)

### DIFF
--- a/Meshflow/mesh_monitoring/services.py
+++ b/Meshflow/mesh_monitoring/services.py
@@ -41,33 +41,23 @@ def clear_presence_on_packet_from_node(observed_node: ObservedNode) -> None:
 
 
 def monitoring_traceroute_succeeded_since(observed_node: ObservedNode, since) -> bool:
-    """True if a monitoring TR completed with a non-empty route since `since`."""
-    qs = AutoTraceRoute.objects.filter(
+    """True if a monitoring TR completed since `since` (including direct path with empty route/route_back)."""
+    return AutoTraceRoute.objects.filter(
         target_node=observed_node,
         trigger_type=AutoTraceRoute.TRIGGER_TYPE_MONITOR,
         status=AutoTraceRoute.STATUS_COMPLETED,
         triggered_at__gte=since,
-    )
-    for tr in qs.only("route", "route_back"):
-        route = tr.route or []
-        route_back = tr.route_back or []
-        if len(route) > 0 or len(route_back) > 0:
-            return True
-    return False
+    ).exists()
 
 
 def on_monitoring_traceroute_completed(auto_tr: AutoTraceRoute) -> None:
     """
-    When a monitoring TR completes with a non-empty route, end verification early.
+    When a monitoring TR completes, end verification early (including direct path with empty hops).
     Called from packets receiver after route fields are saved.
     """
     if auto_tr.trigger_type != AutoTraceRoute.TRIGGER_TYPE_MONITOR:
         return
     if auto_tr.status != AutoTraceRoute.STATUS_COMPLETED:
-        return
-    route = auto_tr.route or []
-    route_back = auto_tr.route_back or []
-    if not route and not route_back:
         return
 
     from django.db import transaction

--- a/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
+++ b/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
@@ -10,6 +10,7 @@ import pytest
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
 from mesh_monitoring.models import NodePresence, NodeWatch
+from mesh_monitoring.services import monitoring_traceroute_succeeded_since, on_monitoring_traceroute_completed
 from mesh_monitoring.tasks import process_node_watch_presence, send_monitoring_traceroute_command
 from nodes.models import NodeLatestStatus
 from traceroute.models import AutoTraceRoute
@@ -65,3 +66,52 @@ def test_process_node_watch_presence_starts_verification_and_creates_monitor_tr(
         trigger_source="mesh_monitoring",
     ).exists()
     channel_layer.group_send.assert_called()
+
+
+@pytest.mark.django_db
+def test_monitoring_traceroute_succeeded_since_true_when_route_empty(
+    create_user, create_observed_node, create_managed_node
+):
+    """Completed monitor TR with direct path (empty route lists) counts as success."""
+    user = create_user()
+    obs = create_observed_node(node_id=0x11223344, claimed_by=user)
+    source = create_managed_node()
+    since = timezone.now() - timedelta(minutes=10)
+    AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=obs,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_MONITOR,
+        triggered_by=None,
+        trigger_source="mesh_monitoring",
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        route=[],
+        route_back=[],
+        triggered_at=timezone.now() - timedelta(minutes=1),
+    )
+    assert monitoring_traceroute_succeeded_since(obs, since) is True
+
+
+@pytest.mark.django_db
+def test_on_monitoring_traceroute_completed_clears_verification_when_routes_empty(
+    create_user, create_observed_node, create_managed_node
+):
+    """Direct-path monitor completion clears verification_started_at."""
+    user = create_user()
+    obs = create_observed_node(node_id=0x22334455, claimed_by=user)
+    vs = timezone.now() - timedelta(minutes=2)
+    NodePresence.objects.create(observed_node=obs, verification_started_at=vs)
+    source = create_managed_node()
+    auto_tr = AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=obs,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_MONITOR,
+        triggered_by=None,
+        trigger_source="mesh_monitoring",
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        route=[],
+        route_back=[],
+        triggered_at=timezone.now() - timedelta(seconds=30),
+    )
+    on_monitoring_traceroute_completed(auto_tr)
+    presence = NodePresence.objects.get(observed_node=obs)
+    assert presence.verification_started_at is None

--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -212,7 +212,12 @@ def on_traffic_management_stats_packet_received(
 
 @receiver(traceroute_packet_received)
 def on_traceroute_packet_received(sender, packet: TraceroutePacket, observer, observation: PacketObservation, **kwargs):
-    """Handle a traceroute packet received signal. Link to AutoTraceRoute if match, or infer one for cross-env."""
+    """Handle a traceroute packet received signal. Link to AutoTraceRoute if match, or infer one for cross-env.
+
+    Any ingested traceroute response is treated as completed: empty ``route``/``route_back`` means a direct RF
+    path (no intermediate hops per Meshtastic firmware), not a timeout. True no-response remains ``pending``/``sent``
+    until ``mark_stale_traceroutes_failed`` runs.
+    """
     logger.info(f"Traceroute packet received: {packet.id}")
 
     from traceroute.models import AutoTraceRoute
@@ -275,33 +280,21 @@ def on_traceroute_packet_received(sender, packet: TraceroutePacket, observer, ob
         snr = packet.snr_back[i] if i < len(packet.snr_back) else None
         route_back.append({"node_id": nid, "snr": snr})
 
-    # Empty route+route_back indicates timeout/failure from device; mark failed rather than completed
-    if not route and not route_back:
-        auto_tr.status = AutoTraceRoute.STATUS_FAILED
-        auto_tr.route = route
-        auto_tr.route_back = route_back
-        auto_tr.raw_packet = packet
-        auto_tr.completed_at = timezone.now()
-        auto_tr.error_message = "Timed out"
-        auto_tr.save(update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"])
+    auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
+    auto_tr.route = route
+    auto_tr.route_back = route_back
+    auto_tr.raw_packet = packet
+    auto_tr.completed_at = timezone.now()
+    auto_tr.error_message = None
+    auto_tr.save(
+        update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
+    )
 
-        from traceroute.ws_notify import notify_traceroute_status_changed
+    from mesh_monitoring.services import on_monitoring_traceroute_completed
+    from traceroute.tasks import push_traceroute_to_neo4j
+    from traceroute.ws_notify import notify_traceroute_status_changed
 
-        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_FAILED)
-        logger.info(f"Linked TraceroutePacket {packet.id} to AutoTraceRoute {auto_tr.id} (failed: empty route)")
-    else:
-        auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
-        auto_tr.route = route
-        auto_tr.route_back = route_back
-        auto_tr.raw_packet = packet
-        auto_tr.completed_at = timezone.now()
-        auto_tr.save(update_fields=["status", "route", "route_back", "raw_packet", "completed_at"])
-
-        from mesh_monitoring.services import on_monitoring_traceroute_completed
-        from traceroute.tasks import push_traceroute_to_neo4j
-        from traceroute.ws_notify import notify_traceroute_status_changed
-
-        on_monitoring_traceroute_completed(auto_tr)
-        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
-        push_traceroute_to_neo4j.delay(auto_tr.id)
-        logger.info(f"Linked TraceroutePacket {packet.id} to AutoTraceRoute {auto_tr.id}")
+    on_monitoring_traceroute_completed(auto_tr)
+    notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
+    push_traceroute_to_neo4j.delay(auto_tr.id)
+    logger.info(f"Linked TraceroutePacket {packet.id} to AutoTraceRoute {auto_tr.id}")

--- a/Meshflow/packets/tests/test_traceroute_receiver.py
+++ b/Meshflow/packets/tests/test_traceroute_receiver.py
@@ -211,4 +211,77 @@ def test_traceroute_receiver_late_response_updates_failed(
     assert auto_tr.status == AutoTraceRoute.STATUS_COMPLETED
     assert auto_tr.trigger_type != AutoTraceRoute.TRIGGER_TYPE_EXTERNAL  # Original record, not external
     assert auto_tr.raw_packet_id == packet.id
+    assert auto_tr.error_message is None
     mock_push.delay.assert_called_once_with(auto_tr.id)
+
+
+@pytest.mark.django_db
+def test_traceroute_receiver_external_inferred_empty_routes_completed(
+    create_traceroute_packet, create_managed_node, create_packet_observation_for_tr
+):
+    """Direct path (no relay hops): external inferred AutoTraceRoute is completed, not failed."""
+    source_node = create_managed_node()
+    target_node_id = 0xABCDEF12
+    packet = create_traceroute_packet(
+        observer=source_node,
+        from_int=target_node_id,
+        route=[],
+        route_back=[],
+        snr_towards=[],
+        snr_back=[],
+    )
+    observation = create_packet_observation_for_tr(packet=packet, observer=source_node)
+
+    with patch("traceroute.tasks.push_traceroute_to_neo4j") as mock_push:
+        with patch("traceroute.ws_notify.notify_traceroute_status_changed"):
+            traceroute_packet_received.send(sender=None, packet=packet, observer=source_node, observation=observation)
+
+    auto_tr = AutoTraceRoute.objects.get(source_node=source_node, target_node__node_id=target_node_id)
+    assert auto_tr.trigger_type == AutoTraceRoute.TRIGGER_TYPE_EXTERNAL
+    assert auto_tr.status == AutoTraceRoute.STATUS_COMPLETED
+    assert auto_tr.route == []
+    assert auto_tr.route_back == []
+    assert auto_tr.error_message is None
+    mock_push.delay.assert_called_once_with(auto_tr.id)
+
+
+@pytest.mark.django_db
+def test_traceroute_receiver_late_response_empty_routes_updates_failed_to_completed(
+    create_traceroute_packet,
+    create_managed_node,
+    create_observed_node,
+    create_auto_traceroute,
+    create_packet_observation_for_tr,
+):
+    """Late response with empty route/route_back clears error_message and completes."""
+    source_node = create_managed_node()
+    target_node = create_observed_node(node_id=0xCAFEBABE)
+    auto_tr = create_auto_traceroute(
+        source_node=source_node,
+        target_node=target_node,
+        status=AutoTraceRoute.STATUS_FAILED,
+        error_message="Timed out after 180s",
+        triggered_by=None,
+    )
+    auto_tr.triggered_at = timezone.now() - timedelta(minutes=2)
+    auto_tr.save(update_fields=["triggered_at", "error_message"])
+
+    packet = create_traceroute_packet(
+        observer=source_node,
+        from_int=target_node.node_id,
+        route=[],
+        route_back=[],
+        snr_towards=[],
+        snr_back=[],
+    )
+    observation = create_packet_observation_for_tr(packet=packet, observer=source_node)
+
+    with patch("traceroute.tasks.push_traceroute_to_neo4j"):
+        with patch("traceroute.ws_notify.notify_traceroute_status_changed"):
+            traceroute_packet_received.send(sender=None, packet=packet, observer=source_node, observation=observation)
+
+    auto_tr.refresh_from_db()
+    assert auto_tr.status == AutoTraceRoute.STATUS_COMPLETED
+    assert auto_tr.error_message is None
+    assert auto_tr.route == []
+    assert auto_tr.route_back == []

--- a/docs/features/mesh-monitoring/README.md
+++ b/docs/features/mesh-monitoring/README.md
@@ -35,7 +35,7 @@ A node is **watched** when there is at least one **`NodeWatch`** row: a user has
 
 ### When a node is treated as offline
 
-**Offline** is **confirmed** only after a **verification window** (on the order of a few minutes): traceroutes are attempted from up to **three** geographically close **managed** sources (with rate limits such as **`MONITORING_TRIGGER_MIN_INTERVAL_SEC`**), and success means either fresh **`last_heard`** after verification started **or** a completed TR with a **non-empty** route (reachability despite sparse packets).
+**Offline** is **confirmed** only after a **verification window** (on the order of a few minutes): traceroutes are attempted from up to **three** geographically close **managed** sources (with rate limits such as **`MONITORING_TRIGGER_MIN_INTERVAL_SEC`**), and success means either fresh **`last_heard`** after verification started **or** a **completed** monitoring traceroute (including a direct path with empty hop lists; reachability despite sparse packets).
 
 If the deadline passes without success, **`NodePresence.offline_confirmed_at`** is set, **`verification_started_at`** is cleared, and **watchers** are notified (deduped per user). **Discord** delivery uses **`push_notifications.discord.send_dm`** and the same verified-user rules as the test endpoint ([Discord notifications](../discord/notifications.md)).
 

--- a/docs/features/mesh-monitoring/flow.md
+++ b/docs/features/mesh-monitoring/flow.md
@@ -40,7 +40,7 @@ sequenceDiagram
     Bot->>Pkt: ingest TR response packet
     Pkt->>DB: complete AutoTraceRoute on_match
   end
-  alt Success last_heard or non_empty route
+  alt Success last_heard or completed monitor TR
     Celery->>DB: clear verification clear offline if_set
   else Deadline expired
     Celery->>DB: set offline_confirmed_at clear verification

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -50,6 +50,8 @@ When a node feeds data to multiple API instances (e.g. prod and pre-prod), a TR 
 
 Late responses: if a TR was marked `failed` (timeout) but the response arrives later, the receiver finds the failed record within the window and updates it to `completed`.
 
+**Direct path:** `route` and `route_back` may both be empty when the source and target are in direct RF range (no repeaters on the path). Inferred `external` completions can therefore have empty hop lists; that is still a successful traceroute, not a timeout.
+
 ## Code map (shared helpers)
 
 Auto-scheduler and permission checks share one notion of a **live** source node (recent packet ingestion as observer). Canonical implementation: **`nodes.managed_node_liveness`** (`eligible_auto_traceroute_sources_queryset`, etc.). **`traceroute.source_eligibility`** re-exports the same API for existing imports.

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -51,10 +51,11 @@ When the traceroute response is received, the bot reports it as a packet. The pa
 1. Finds a matching `AutoTraceRoute` (same source, target, triggered within configurable window, status pending/sent/failed). Window: `STALE_TR_TIMEOUT_SECONDS` (default 180s). Includes `failed` so late responses can update a previously timed-out record.
 2. If no match: creates an **external** `AutoTraceRoute` (cross-env or orphaned response). Use case: prod triggers a TR, but the response is ingested by pre-prod (shared node feeding both APIs). Pre-prod has no prior record, so it creates one with `trigger_type="external"`, `triggered_at=now()`. Target `ObservedNode` is created if missing.
 3. Builds `route` and `route_back` from packet data (node_ids + SNR).
-4. If route is empty: marks `STATUS_FAILED`, `error_message="Timed out"`.
-5. If route has data: marks `STATUS_COMPLETED`, saves route/route_back, links `raw_packet`.
-6. Broadcasts status via `notify_traceroute_status_changed()` to WebSocket clients.
-7. Queues `push_traceroute_to_neo4j.delay(auto_tr.id)` for completed traceroutes.
+4. Marks `STATUS_COMPLETED`, saves route/route_back (possibly empty for a direct RF path), links `raw_packet`, clears any prior `error_message`. Empty hop lists match Meshtastic firmware’s “no intermediate hops” case; they are not treated as failure once a response packet is ingested.
+5. Broadcasts status via `notify_traceroute_status_changed()` to WebSocket clients.
+6. Queues `push_traceroute_to_neo4j.delay(auto_tr.id)` for completed traceroutes.
+
+True no-response for API-triggered traceroutes remains `pending` or `sent` until Celery marks them failed (see §6).
 
 ## 6. Stale Timeout
 


### PR DESCRIPTION
# Summary

Traceroute responses ingested by the API are always treated as **completed**, including when `route` and `route_back` are empty. That matches Meshtastic firmware’s **direct RF path** (no intermediate hops). Previously those rows were marked **failed** with `error_message="Timed out"`, which incorrectly affected inferred **`trigger_type=external`** traceroutes.

Mesh monitoring now treats **any completed** monitoring traceroute as reachability proof: `monitoring_traceroute_succeeded_since` no longer requires non-empty routes, and `on_monitoring_traceroute_completed` clears verification for direct-path completions too.

Documentation updates cover traceroute flow/README and mesh-monitoring docs for consistency.

Closes #158

## Testing performed

- `python -m pytest packets/tests/test_traceroute_receiver.py mesh_monitoring/tests/test_process_node_watch_presence.py -v`
- `black`, `isort`, `flake8` on the modified Python modules