### PR TITLE
fix(packets): update ObservedNode.last_heard on traceroute response

### DIFF
--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -290,7 +290,15 @@ def on_traceroute_packet_received(sender, packet: TraceroutePacket, observer, ob
         update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
     )
 
-    from mesh_monitoring.services import on_monitoring_traceroute_completed
+    # TR reply is from the target (packet.from_int); treat like other telemetry for last_heard + mesh monitoring.
+    from mesh_monitoring.services import clear_presence_on_packet_from_node, on_monitoring_traceroute_completed
+
+    target_observed = auto_tr.target_node
+    if packet.first_reported_time:
+        target_observed.last_heard = packet.first_reported_time
+        target_observed.save(update_fields=["last_heard"])
+        clear_presence_on_packet_from_node(target_observed)
+
     from traceroute.tasks import push_traceroute_to_neo4j
     from traceroute.ws_notify import notify_traceroute_status_changed
 

--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -1,8 +1,6 @@
 import logging
-import os
 
 from django.dispatch import receiver
-from django.utils import timezone
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import ConstellationUserMembership
@@ -31,6 +29,7 @@ from .services.node_info import NodeInfoPacketService
 from .services.position import PositionPacketService
 from .services.power_metrics import PowerMetricsPacketService
 from .services.text_message import TextMessagePacketService
+from .services.traceroute import TraceroutePacketService
 from .signals import (
     air_quality_metrics_packet_received,
     device_metrics_packet_received,
@@ -38,7 +37,6 @@ from .signals import (
     health_metrics_packet_received,
     host_metrics_packet_received,
     message_packet_received,
-    new_node_observed,
     node_claim_authorized,
     node_info_packet_received,
     packet_received,
@@ -49,8 +47,6 @@ from .signals import (
 )
 
 logger = logging.getLogger(__name__)
-
-STALE_TR_TIMEOUT_SECONDS = os.environ.get("STALE_TR_TIMEOUT_SECONDS", 180)
 
 
 # Packet types that already update NodeLatestStatus (and set inferred_max_hops there)
@@ -92,10 +88,6 @@ def on_packet_received_update_inferred_max_hops(sender, packet, observer, observ
     if not created and node_status.inferred_max_hops != hop_start:
         node_status.inferred_max_hops = hop_start
         node_status.save(update_fields=["inferred_max_hops"])
-
-
-STALE_TR_TIMEOUT_SECONDS = os.environ.get("STALE_TR_TIMEOUT_SECONDS", 180)
-STALE_TR_TIMEOUT_SECONDS = int(STALE_TR_TIMEOUT_SECONDS)
 
 
 @receiver(position_packet_received)
@@ -220,89 +212,5 @@ def on_traceroute_packet_received(sender, packet: TraceroutePacket, observer, ob
     """
     logger.info(f"Traceroute packet received: {packet.id}")
 
-    from traceroute.models import AutoTraceRoute
-
-    # observer is ManagedNode (from PacketObservation)
-    source_node = observer
-    target_node_id = packet.from_int  # TR response: from = target (who sent the response)
-    cutoff = timezone.now() - timezone.timedelta(seconds=STALE_TR_TIMEOUT_SECONDS)  # 5 minutes
-
-    auto_tr = (
-        AutoTraceRoute.objects.filter(
-            source_node=source_node,
-            target_node__node_id=target_node_id,
-            triggered_at__gte=cutoff,
-            status__in=[
-                AutoTraceRoute.STATUS_PENDING,
-                AutoTraceRoute.STATUS_SENT,
-                AutoTraceRoute.STATUS_FAILED,
-            ],
-        )
-        .order_by("-triggered_at")
-        .first()
-    )
-
-    if not auto_tr:
-        # No match within window: create external AutoTraceRoute (cross-env or orphaned response)
-        logger.info(
-            f"No AutoTraceRoute found for packet {packet.id} from {source_node.node_id_str} to {target_node_id}; "
-            "creating external record"
-        )
-        node_id_str = packet.from_str if packet.from_str else meshtastic_id_to_hex(target_node_id)
-        target_node, created = ObservedNode.objects.get_or_create(
-            node_id=target_node_id,
-            defaults={
-                "node_id_str": node_id_str,
-                "long_name": "Unknown Node " + node_id_str,
-                "short_name": node_id_str[-4:] if len(node_id_str) >= 4 else "????",
-            },
-        )
-        if created:
-            new_node_observed.send(sender=None, node=target_node, observer=source_node)
-        auto_tr = AutoTraceRoute.objects.create(
-            source_node=source_node,
-            target_node=target_node,
-            trigger_type=AutoTraceRoute.TRIGGER_TYPE_EXTERNAL,
-            trigger_source=None,
-            triggered_by=None,
-            triggered_at=timezone.now(),
-            status=AutoTraceRoute.STATUS_PENDING,
-        )
-
-    # Build route/route_back with SNR: 1:1 mapping route[i] <-> snr_towards[i] (SNR at which route[i] received).
-    # Per Meshtastic firmware PR #4485; firmware may send snr longer than route in edge cases — we use i < len.
-    route = []
-    for i, nid in enumerate(packet.route):
-        snr = packet.snr_towards[i] if i < len(packet.snr_towards) else None
-        route.append({"node_id": nid, "snr": snr})
-    route_back = []
-    for i, nid in enumerate(packet.route_back):
-        snr = packet.snr_back[i] if i < len(packet.snr_back) else None
-        route_back.append({"node_id": nid, "snr": snr})
-
-    auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
-    auto_tr.route = route
-    auto_tr.route_back = route_back
-    auto_tr.raw_packet = packet
-    auto_tr.completed_at = timezone.now()
-    auto_tr.error_message = None
-    auto_tr.save(
-        update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
-    )
-
-    # TR reply is from the target (packet.from_int); treat like other telemetry for last_heard + mesh monitoring.
-    from mesh_monitoring.services import clear_presence_on_packet_from_node, on_monitoring_traceroute_completed
-
-    target_observed = auto_tr.target_node
-    if packet.first_reported_time:
-        target_observed.last_heard = packet.first_reported_time
-        target_observed.save(update_fields=["last_heard"])
-        clear_presence_on_packet_from_node(target_observed)
-
-    from traceroute.tasks import push_traceroute_to_neo4j
-    from traceroute.ws_notify import notify_traceroute_status_changed
-
-    on_monitoring_traceroute_completed(auto_tr)
-    notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
-    push_traceroute_to_neo4j.delay(auto_tr.id)
-    logger.info(f"Linked TraceroutePacket {packet.id} to AutoTraceRoute {auto_tr.id}")
+    service = TraceroutePacketService()
+    service.process_packet(packet, observer, observation, user=None)

--- a/Meshflow/packets/services/traceroute.py
+++ b/Meshflow/packets/services/traceroute.py
@@ -1,0 +1,89 @@
+"""Service for processing traceroute response packets."""
+
+import logging
+import os
+from datetime import timedelta
+
+from django.utils import timezone
+
+from packets.models import TraceroutePacket
+from packets.services.base import BasePacketService
+from traceroute.models import AutoTraceRoute
+
+logger = logging.getLogger(__name__)
+
+STALE_TR_TIMEOUT_SECONDS = int(os.environ.get("STALE_TR_TIMEOUT_SECONDS", "180"))
+
+
+class TraceroutePacketService(BasePacketService):
+    """Link traceroute responses to AutoTraceRoute and complete them (same pattern as other packet services)."""
+
+    packet: TraceroutePacket
+
+    def _process_packet(self) -> None:
+        if not isinstance(self.packet, TraceroutePacket):
+            raise ValueError("Packet must be a TraceroutePacket")
+
+        source_node = self.observer
+        cutoff = timezone.now() - timedelta(seconds=STALE_TR_TIMEOUT_SECONDS)
+
+        auto_tr = (
+            AutoTraceRoute.objects.filter(
+                source_node=source_node,
+                target_node=self.from_node,
+                triggered_at__gte=cutoff,
+                status__in=[
+                    AutoTraceRoute.STATUS_PENDING,
+                    AutoTraceRoute.STATUS_SENT,
+                    AutoTraceRoute.STATUS_FAILED,
+                ],
+            )
+            .order_by("-triggered_at")
+            .first()
+        )
+
+        if not auto_tr:
+            logger.info(
+                "No AutoTraceRoute found for packet %s from %s to %s; creating external record",
+                self.packet.id,
+                source_node.node_id_str,
+                self.from_node.node_id,
+            )
+            auto_tr = AutoTraceRoute.objects.create(
+                source_node=source_node,
+                target_node=self.from_node,
+                trigger_type=AutoTraceRoute.TRIGGER_TYPE_EXTERNAL,
+                trigger_source=None,
+                triggered_by=None,
+                triggered_at=timezone.now(),
+                status=AutoTraceRoute.STATUS_PENDING,
+            )
+
+        route = []
+        for i, nid in enumerate(self.packet.route):
+            snr = self.packet.snr_towards[i] if i < len(self.packet.snr_towards) else None
+            route.append({"node_id": nid, "snr": snr})
+        route_back = []
+        for i, nid in enumerate(self.packet.route_back):
+            snr = self.packet.snr_back[i] if i < len(self.packet.snr_back) else None
+            route_back.append({"node_id": nid, "snr": snr})
+
+        auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
+        auto_tr.route = route
+        auto_tr.route_back = route_back
+        auto_tr.raw_packet = self.packet
+        auto_tr.completed_at = timezone.now()
+        auto_tr.error_message = None
+        auto_tr.save(
+            update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
+        )
+
+        # Lazy imports so tests can patch traceroute.tasks / traceroute.ws_notify / mesh_monitoring.services.
+        from mesh_monitoring.services import on_monitoring_traceroute_completed
+        from traceroute.tasks import push_traceroute_to_neo4j
+        from traceroute.ws_notify import notify_traceroute_status_changed
+
+        on_monitoring_traceroute_completed(auto_tr)
+        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
+        push_traceroute_to_neo4j.delay(auto_tr.id)
+        logger.info("Linked TraceroutePacket %s to AutoTraceRoute %s", self.packet.id, auto_tr.id)

--- a/Meshflow/packets/tests/test_traceroute_receiver.py
+++ b/Meshflow/packets/tests/test_traceroute_receiver.py
@@ -216,6 +216,50 @@ def test_traceroute_receiver_late_response_updates_failed(
 
 
 @pytest.mark.django_db
+def test_traceroute_response_updates_target_last_heard(
+    create_traceroute_packet,
+    create_managed_node,
+    create_observed_node,
+    create_auto_traceroute,
+    create_packet_observation_for_tr,
+):
+    """Ingested TR response advances target ObservedNode.last_heard (same as other packet services)."""
+    source_node = create_managed_node()
+    target_node = create_observed_node(node_id=0xBEEFCAFE)
+    old_last = timezone.now() - timedelta(days=1)
+    target_node.last_heard = old_last
+    target_node.save(update_fields=["last_heard"])
+
+    auto_tr = create_auto_traceroute(
+        source_node=source_node,
+        target_node=target_node,
+        status=AutoTraceRoute.STATUS_SENT,
+        triggered_by=None,
+    )
+    auto_tr.triggered_at = timezone.now() - timedelta(minutes=1)
+    auto_tr.save(update_fields=["triggered_at"])
+
+    rx_time = timezone.now() - timedelta(seconds=30)
+    packet = create_traceroute_packet(
+        observer=source_node,
+        from_int=target_node.node_id,
+        route=[0x11111111],
+        route_back=[0x11111111],
+        snr_towards=[-5.0],
+        snr_back=[-4.0],
+        first_reported_time=rx_time,
+    )
+    observation = create_packet_observation_for_tr(packet=packet, observer=source_node)
+
+    with patch("traceroute.tasks.push_traceroute_to_neo4j"):
+        with patch("traceroute.ws_notify.notify_traceroute_status_changed"):
+            traceroute_packet_received.send(sender=None, packet=packet, observer=source_node, observation=observation)
+
+    target_node.refresh_from_db()
+    assert target_node.last_heard == rx_time
+
+
+@pytest.mark.django_db
 def test_traceroute_receiver_external_inferred_empty_routes_completed(
     create_traceroute_packet, create_managed_node, create_packet_observation_for_tr
 ):

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -44,16 +44,17 @@ The Meshtastic device performs the traceroute on the mesh. The firmware enforces
 
 When the traceroute response is received, the bot reports it as a packet. The packet ingestion pipeline creates a `TraceroutePacket` and emits `traceroute_packet_received`.
 
-## 5. Receiver: Match and Complete
+## 5. `TraceroutePacketService`: match, complete, `last_heard`
 
-`packets.receivers.on_traceroute_packet_received`:
+`packets.receivers.on_traceroute_packet_received` delegates to `TraceroutePacketService` — the same `BasePacketService` pattern as other packet types: resolve the sender (`from_int`) as `ObservedNode`, run `_process_packet`, then `_update_node_last_heard` and `clear_presence_on_packet_from_node` for mesh monitoring.
 
-1. Finds a matching `AutoTraceRoute` (same source, target, triggered within configurable window, status pending/sent/failed). Window: `STALE_TR_TIMEOUT_SECONDS` (default 180s). Includes `failed` so late responses can update a previously timed-out record.
-2. If no match: creates an **external** `AutoTraceRoute` (cross-env or orphaned response). Use case: prod triggers a TR, but the response is ingested by pre-prod (shared node feeding both APIs). Pre-prod has no prior record, so it creates one with `trigger_type="external"`, `triggered_at=now()`. Target `ObservedNode` is created if missing.
+`TraceroutePacketService._process_packet`:
+
+1. Finds a matching `AutoTraceRoute` (same source, target, triggered within configurable window, status pending/sent/failed). Window: `STALE_TR_TIMEOUT_SECONDS` in `packets.services.traceroute` (default 180s). Includes `failed` so late responses can update a previously timed-out record.
+2. If no match: creates an **external** `AutoTraceRoute` (cross-env or orphaned response). Use case: prod triggers a TR, but the response is ingested by pre-prod (shared node feeding both APIs). Pre-prod has no prior record, so it creates one with `trigger_type="external"`, `triggered_at=now()`. The target `ObservedNode` is ensured by `BasePacketService._get_or_create_from_node` before this step.
 3. Builds `route` and `route_back` from packet data (node_ids + SNR).
 4. Marks `STATUS_COMPLETED`, saves route/route_back (possibly empty for a direct RF path), links `raw_packet`, clears any prior `error_message`. Empty hop lists match Meshtastic firmware’s “no intermediate hops” case; they are not treated as failure once a response packet is ingested.
-5. Broadcasts status via `notify_traceroute_status_changed()` to WebSocket clients.
-6. Queues `push_traceroute_to_neo4j.delay(auto_tr.id)` for completed traceroutes.
+5. Calls `on_monitoring_traceroute_completed` for monitor traceroutes, `notify_traceroute_status_changed()` for WebSocket clients, and `push_traceroute_to_neo4j.delay(auto_tr.id)`.
 
 True no-response for API-triggered traceroutes remains `pending` or `sent` until Celery marks them failed (see §6).
 


### PR DESCRIPTION
# Summary

Traceroute response ingestion now goes through **`TraceroutePacketService`** (`BasePacketService`), matching position, metrics, and other packet handlers. That means **`_update_node_last_heard`** runs after the AutoTraceRoute row is completed: the TR target (`packet.from_int`) gets **`ObservedNode.last_heard`** from **`first_reported_time`**, and **`clear_presence_on_packet_from_node`** runs so mesh monitoring silence state stays consistent with other packet types.

Implementation notes:

- New module: [`Meshflow/packets/services/traceroute.py`](Meshflow/packets/services/traceroute.py) — match/complete `AutoTraceRoute`, external inferred row when needed, route/SNR JSON, `on_monitoring_traceroute_completed`, WS notify, Neo4j queue.
- [`Meshflow/packets/receivers.py`](Meshflow/packets/receivers.py) — thin `traceroute_packet_received` receiver delegating to the service.
- **`STALE_TR_TIMEOUT_SECONDS`** is read in the service module (removed duplicate `os` usage from the receiver).
- Side-effect imports (`traceroute.tasks`, `traceroute.ws_notify`, `mesh_monitoring.services`) stay **lazy inside `_process_packet`** so existing tests that patch those symbols keep working.
- External TR path uses **`self.from_node`** from the base class instead of a second `ObservedNode.get_or_create` on the target.

Docs: [`docs/features/traceroute/flow.md`](docs/features/traceroute/flow.md) §5 updated for the service and `last_heard`.

No API contract changes. No manual migration or deploy steps.

Closes #161.

## Testing performed

- `python -m pytest Meshflow/packets/tests/test_traceroute_receiver.py -v`
- `python -m pytest Meshflow/packets/tests/test_packet_serializers.py -k traceroute -v`
- `black` / `isort` / `flake8` on touched Python files