### PR TITLE
feat(mesh_monitoring): add short name and deep link to offline/verification DMs

### DIFF
--- a/Meshflow/mesh_monitoring/services.py
+++ b/Meshflow/mesh_monitoring/services.py
@@ -132,6 +132,25 @@ def on_monitoring_traceroute_completed(auto_tr: AutoTraceRoute) -> None:
         )
 
 
+def _node_details_url(observed_node: ObservedNode) -> str | None:
+    """Build a Meshflow UI deep link to the node details page, or None if unconfigured."""
+    from django.conf import settings
+
+    base_url = (getattr(settings, "FRONTEND_URL", None) or "").strip().rstrip("/")
+    if not base_url:
+        return None
+    return f"{base_url}/nodes/{observed_node.node_id}"
+
+
+def _format_node_label(observed_node: ObservedNode) -> str:
+    """Human-readable node label: '!aabbccdd SHRT (Long Name)'."""
+    short_name = (observed_node.short_name or "").strip()
+    long_name = observed_node.long_name or ""
+    if short_name:
+        return f"{observed_node.node_id_str} {short_name} ({long_name})"
+    return f"{observed_node.node_id_str} ({long_name})"
+
+
 def notify_watchers_node_offline(observed_node: ObservedNode) -> int:
     """
     DM each distinct watcher with verified Discord settings (deduped by user).
@@ -146,10 +165,10 @@ def notify_watchers_node_offline(observed_node: ObservedNode) -> int:
         NodeWatch.objects.filter(observed_node=observed_node, enabled=True).values_list("user_id", flat=True).distinct()
     )
     users = User.objects.filter(pk__in=user_ids)
-    text = (
-        f"Meshflow mesh monitoring: node {observed_node.node_id_str} "
-        f"({observed_node.long_name}) appears offline after verification."
-    )
+    text = f"Meshflow mesh monitoring: node {_format_node_label(observed_node)} appears offline after verification."
+    url = _node_details_url(observed_node)
+    if url:
+        text += f"\n\n{url}"
     attempted = 0
     for user in users:
         if not user_has_verified_discord_dm_target(user):
@@ -176,7 +195,6 @@ def notify_watchers_verification_started(observed_node: ObservedNode, silence_th
 
     Returns number of send_dm attempts (same semantics as notify_watchers_node_offline).
     """
-    from django.conf import settings
     from django.contrib.auth import get_user_model
 
     from .models import NodeWatch
@@ -188,12 +206,12 @@ def notify_watchers_verification_started(observed_node: ObservedNode, silence_th
     users = User.objects.filter(pk__in=user_ids)
     text = (
         f"Meshflow mesh monitoring: starting RF verification (monitoring traceroutes) for node "
-        f"{observed_node.node_id_str} ({observed_node.long_name}). "
+        f"{_format_node_label(observed_node)}. "
         f"Silence threshold for this watch is {silence_threshold_seconds} seconds."
     )
-    base_url = (getattr(settings, "FRONTEND_URL", None) or "").strip().rstrip("/")
-    if base_url:
-        text += f"\n\n{base_url}/nodes/{observed_node.node_id}"
+    url = _node_details_url(observed_node)
+    if url:
+        text += f"\n\n{url}"
     attempted = 0
     for user in users:
         if not user_has_verified_discord_dm_target(user):

--- a/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
@@ -1,0 +1,90 @@
+"""DM text formatting for mesh_monitoring notify_watchers_* services (#164)."""
+
+from unittest.mock import patch
+
+from django.test.utils import override_settings
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from mesh_monitoring.models import NodeWatch
+from mesh_monitoring.services import notify_watchers_node_offline, notify_watchers_verification_started
+
+
+@pytest.mark.django_db
+def test_offline_dm_includes_short_name_and_deep_link(create_user, create_observed_node):
+    user = create_user()
+    node_id = 0x11223344
+    obs = create_observed_node(
+        node_id=node_id,
+        node_id_str=meshtastic_id_to_hex(node_id),
+        long_name="My Long Node Name",
+        short_name="MLNN",
+        claimed_by=user,
+    )
+    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+
+    with override_settings(FRONTEND_URL="https://mesh.example/"):
+        with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
+            with patch("mesh_monitoring.services.send_dm") as send_dm:
+                attempted = notify_watchers_node_offline(obs)
+
+    assert attempted == 1
+    send_dm.assert_called_once()
+    body = send_dm.call_args[0][1]
+    assert obs.node_id_str in body
+    assert "MLNN" in body
+    assert "My Long Node Name" in body
+    assert f"https://mesh.example/nodes/{obs.node_id}" in body
+    assert "appears offline" in body
+
+
+@pytest.mark.django_db
+def test_offline_dm_omits_url_when_frontend_unset(create_user, create_observed_node):
+    user = create_user()
+    node_id = 0x22334455
+    obs = create_observed_node(
+        node_id=node_id,
+        node_id_str=meshtastic_id_to_hex(node_id),
+        long_name="Another Node",
+        short_name="ANOD",
+        claimed_by=user,
+    )
+    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+
+    with override_settings(FRONTEND_URL=""):
+        with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
+            with patch("mesh_monitoring.services.send_dm") as send_dm:
+                notify_watchers_node_offline(obs)
+
+    body = send_dm.call_args[0][1]
+    assert "ANOD" in body
+    assert "/nodes/" not in body
+
+
+@pytest.mark.django_db
+def test_verification_start_dm_includes_short_name_and_deep_link(create_user, create_observed_node):
+    user = create_user()
+    node_id = 0x33445566
+    obs = create_observed_node(
+        node_id=node_id,
+        node_id_str=meshtastic_id_to_hex(node_id),
+        long_name="Verify Me",
+        short_name="VFYM",
+        claimed_by=user,
+    )
+    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=90, enabled=True)
+
+    with override_settings(FRONTEND_URL="https://mesh.example"):
+        with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
+            with patch("mesh_monitoring.services.send_dm") as send_dm:
+                attempted = notify_watchers_verification_started(obs, silence_threshold_seconds=90)
+
+    assert attempted == 1
+    body = send_dm.call_args[0][1]
+    assert obs.node_id_str in body
+    assert "VFYM" in body
+    assert "Verify Me" in body
+    assert "90" in body
+    assert f"https://mesh.example/nodes/{obs.node_id}" in body

--- a/docs/features/mesh-monitoring/discord.md
+++ b/docs/features/mesh-monitoring/discord.md
@@ -7,6 +7,8 @@
 - **Who gets a DM:** Users with an **enabled** **`NodeWatch`** on that **`ObservedNode`**, who also have **verified** Discord notification settings (same anti-spam rules as the test endpoint).
 - **Deduping:** If one user has multiple watches on the same node, they should still receive at most **one** alert per offline event (per product design).
 - **Transport:** Server-side **`push_notifications.discord.send_dm`** — no duplicate Discord REST client inside **`mesh_monitoring`**.
+- **Node identity in DMs:** Both the verification-start and offline DMs include **`node_id_str`**, **`short_name`**, and **`long_name`** so watchers can disambiguate nodes with similar long names.
+- **Deep link in DMs:** Both the verification-start and offline DMs append **`{FRONTEND_URL}/nodes/{node_id}`** (decimal **`ObservedNode.node_id`**, consistent with the UI node route) when **`FRONTEND_URL`** is set. **`FRONTEND_URL`** must point at the correct UI for each deploy (pre-prod / prod) so the link lands on the matching stack.
 
 ## Verification-start DMs (#165)
 


### PR DESCRIPTION
# Summary

Closes #164.

Completes the mesh monitoring Discord DM work from #165. The **verification-start** DM already included a deep link to the node details page; this change brings the **offline** DM to parity and adds the node's **short name** to both messages so watchers can disambiguate nodes with similar long names.

- `notify_watchers_node_offline` now appends `{FRONTEND_URL}/nodes/{node_id}` (decimal, matching the SPA route) when `FRONTEND_URL` is set, mirroring `notify_watchers_verification_started`.
- Both notify paths now format the node as `node_id_str short_name (long_name)` via a shared `_format_node_label` helper.
- URL construction extracted to `_node_details_url` and reused by both paths. Trailing slash on `FRONTEND_URL` is stripped (same pattern as `users/social_auth.py`).
- `docs/features/mesh-monitoring/discord.md` updated to document short-name inclusion and the fact that both DMs now carry the deep link, plus the `FRONTEND_URL` per-deploy requirement.

## Testing performed

- New unit tests in `Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py`:
  - `test_offline_dm_includes_short_name_and_deep_link` – asserts offline DM body contains `node_id_str`, `short_name`, `long_name`, and `https://mesh.example/nodes/{node_id}` (also verifies trailing-slash stripping on `FRONTEND_URL`).
  - `test_offline_dm_omits_url_when_frontend_unset` – no `/nodes/` substring when `FRONTEND_URL=""`, but short name is still present.
  - `test_verification_start_dm_includes_short_name_and_deep_link` – same substrings for the verification-start path.
- Full `mesh_monitoring` suite passes: `python -m pytest Meshflow/mesh_monitoring/ -v` → 37 passed.
- Linters: `black`, `isort`, `flake8` clean on touched files.
