### PR TITLE
fix(traceroute): add missing neo4j heatmap edges (#159)

### DIFF
--- a/Meshflow/traceroute/management/commands/export_traceroutes_to_neo4j.py
+++ b/Meshflow/traceroute/management/commands/export_traceroutes_to_neo4j.py
@@ -1,8 +1,8 @@
 """Management command to export completed traceroutes to Neo4j."""
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
-from traceroute.neo4j_service import export_all_traceroutes_to_neo4j
+from traceroute.neo4j_service import clear_all_routed_to_edges, export_all_traceroutes_to_neo4j
 
 
 class Command(BaseCommand):
@@ -15,9 +15,43 @@ class Command(BaseCommand):
             dest="async_mode",
             help="Queue the export as a Celery task instead of running synchronously.",
         )
+        parser.add_argument(
+            "--clear",
+            action="store_true",
+            help=(
+                "Delete every ROUTED_TO relationship before exporting. "
+                "Useful when re-running a full backfill; requires the sync path."
+            ),
+        )
+        parser.add_argument(
+            "--yes",
+            action="store_true",
+            help="Skip the interactive confirmation prompt for --clear.",
+        )
 
     def handle(self, *args, **options):
-        if options.get("async_mode"):
+        clear = options.get("clear")
+        async_mode = options.get("async_mode")
+
+        if clear and async_mode:
+            raise CommandError(
+                "--clear cannot be combined with --async; the destructive delete must "
+                "run synchronously so an operator can confirm it."
+            )
+
+        if clear:
+            if not options.get("yes"):
+                self.stdout.write(
+                    self.style.WARNING("About to DELETE every ROUTED_TO relationship in Neo4j before re-export.")
+                )
+                answer = input("Type 'yes' to continue: ")
+                if answer.strip().lower() != "yes":
+                    self.stdout.write(self.style.NOTICE("Aborted; no changes made."))
+                    return
+            deleted = clear_all_routed_to_edges()
+            self.stdout.write(self.style.SUCCESS(f"Cleared {deleted} ROUTED_TO relationships."))
+
+        if async_mode:
             from traceroute.tasks import export_traceroutes_to_neo4j
 
             result = export_traceroutes_to_neo4j.delay()

--- a/Meshflow/traceroute/neo4j_service.py
+++ b/Meshflow/traceroute/neo4j_service.py
@@ -256,6 +256,8 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
     else:
         triggered_at_str = datetime.utcnow().isoformat() + "Z"
 
+    auto_tr_id = auto_tr.id
+
     with driver.session() as session:
         for a_id, b_id, snr in valid_edges:
             a_str = meshtastic_id_to_hex(a_id)
@@ -265,8 +267,6 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
             a_short, a_long = names.get(a_id, (a_str, a_str))
             b_short, b_long = names.get(b_id, (b_str, b_str))
 
-            # Build relationship props: weight, triggered_at always; snr when present
-            rel_props = "weight: 1, triggered_at: datetime($triggered_at)"
             params = {
                 "a_id": a_id,
                 "a_str": a_str,
@@ -281,20 +281,31 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
                 "b_short_name": b_short,
                 "b_long_name": b_long,
                 "triggered_at": triggered_at_str,
+                "auto_tr_id": auto_tr_id,
+                "snr": float(snr) if snr is not None else None,
             }
-            if snr is not None:
-                rel_props += ", snr: $snr"
-                params["snr"] = float(snr)
 
+            # MERGE keyed on (auto_tr_id, a_id, b_id, triggered_at) so a re-export
+            # of the same AutoTraceRoute is idempotent: the existing relationship
+            # is updated in place rather than duplicated. weight stays at 1 per TR
+            # so bidirectional aggregation in run_heatmap_query continues to count
+            # one unit per distinct traceroute-hop.
             session.run(
-                f"""
-                MERGE (a:MeshNode {{node_id: $a_id}})
+                """
+                MERGE (a:MeshNode {node_id: $a_id})
                 SET a.node_id_str = $a_str, a.latitude = $a_lat, a.longitude = $a_lng,
                     a.short_name = $a_short_name, a.long_name = $a_long_name
-                MERGE (b:MeshNode {{node_id: $b_id}})
+                MERGE (b:MeshNode {node_id: $b_id})
                 SET b.node_id_str = $b_str, b.latitude = $b_lat, b.longitude = $b_lng,
                     b.short_name = $b_short_name, b.long_name = $b_long_name
-                CREATE (a)-[:ROUTED_TO {{{rel_props}}}]->(b)
+                MERGE (a)-[r:ROUTED_TO {
+                    auto_tr_id: $auto_tr_id,
+                    a_id: $a_id,
+                    b_id: $b_id,
+                    triggered_at: datetime($triggered_at)
+                }]->(b)
+                ON CREATE SET r.weight = 1, r.snr = $snr
+                ON MATCH SET r.weight = 1, r.snr = $snr
                 """,
                 **params,
             )
@@ -305,6 +316,29 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
             len(valid_edges),
             auto_tr.id,
         )
+
+
+def clear_all_routed_to_edges(driver=None) -> int:
+    """
+    Delete every ROUTED_TO relationship in Neo4j. Returns the number deleted.
+
+    Intended for bulk backfill workflows (``export_traceroutes_to_neo4j --clear``)
+    where an operator wants a clean slate before re-exporting the full history.
+    Nodes are left untouched - they'll be re-upserted by the subsequent export.
+    """
+    driver = driver or get_driver()
+    logger.warning("clear_all_routed_to_edges: deleting ALL ROUTED_TO relationships")
+    with driver.session() as session:
+        result = session.run("""
+            MATCH ()-[r:ROUTED_TO]->()
+            WITH r
+            DELETE r
+            RETURN count(r) AS deleted
+            """)
+        record = result.single()
+        deleted = record["deleted"] if record else 0
+    logger.info("clear_all_routed_to_edges: deleted %d ROUTED_TO relationships", deleted)
+    return int(deleted or 0)
 
 
 def export_all_traceroutes_to_neo4j(driver=None, batch_size: int = 100):

--- a/Meshflow/traceroute/neo4j_service.py
+++ b/Meshflow/traceroute/neo4j_service.py
@@ -72,6 +72,16 @@ def upsert_node(
         )
 
 
+def _safe_latest_status(obs):
+    """Return obs.latest_status or None (reverse one-to-one raises RelatedObjectDoesNotExist otherwise)."""
+    if obs is None:
+        return None
+    try:
+        return obs.latest_status
+    except Exception:
+        return None
+
+
 def _get_node_coords(
     node_id: int,
     source_node: ManagedNode,
@@ -89,24 +99,22 @@ def _get_node_coords(
                 source_node.default_location_latitude,
                 source_node.default_location_longitude,
             )
-        obs = observed_by_id.get(node_id)
-        if obs and obs.latest_status and obs.latest_status.latitude is not None:
-            return obs.latest_status.latitude, obs.latest_status.longitude
+        status = _safe_latest_status(observed_by_id.get(node_id))
+        if status is not None and status.latitude is not None:
+            return status.latitude, status.longitude
         return None
 
     # Target node: ObservedNode.latest_status
     if node_id == target_node.node_id:
-        if target_node.latest_status and target_node.latest_status.latitude is not None:
-            return (
-                target_node.latest_status.latitude,
-                target_node.latest_status.longitude,
-            )
+        status = _safe_latest_status(target_node)
+        if status is not None and status.latitude is not None:
+            return status.latitude, status.longitude
         return None
 
     # Intermediate nodes: ObservedNode.latest_status
-    obs = observed_by_id.get(node_id)
-    if obs and obs.latest_status and obs.latest_status.latitude is not None:
-        return obs.latest_status.latitude, obs.latest_status.longitude
+    status = _safe_latest_status(observed_by_id.get(node_id))
+    if status is not None and status.latitude is not None:
+        return status.latitude, status.longitude
     return None
 
 
@@ -154,20 +162,32 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
     Extract edges from route/route_back, upsert nodes, create ROUTED_TO relationships.
     Only creates edges where both endpoints have coordinates.
     When quiet=True, suppresses success logging (for bulk export to avoid clashing with tqdm).
+
+    Route format (Meshtastic): ``route`` and ``route_back`` are relay-only lists of
+    ``{node_id, snr}`` dicts. The source is ``auto_tr.source_node`` (ManagedNode); the
+    target/responder is ``auto_tr.target_node`` (ObservedNode, = packet ``from_node``).
+    Neither endpoint is stored in ``route`` / ``route_back``. This function emits the
+    full chain of edges for both directions, including the synthetic bookends
+    (``source → route[0]``, ``route[-1] → target`` and mirror on the return path),
+    plus a ``source ↔ target`` pair for direct (zero-relay) traceroutes when both
+    endpoints have coordinates.
     """
     driver = driver or get_driver()
 
     auto_tr = (
         AutoTraceRoute.objects.filter(pk=auto_traceroute.pk)
-        .select_related("source_node", "target_node", "target_node__latest_status")
+        .select_related("source_node", "target_node", "target_node__latest_status", "raw_packet")
         .first()
     )
-    if not auto_tr or not auto_tr.route and not auto_tr.route_back:
+    if not auto_tr:
         return
 
-    # Collect all node_ids from route and route_back
+    route = auto_tr.route or []
+    route_back = auto_tr.route_back or []
+
+    # Collect all node_ids from route, route_back, source and target
     node_ids = set()
-    for item in (auto_tr.route or []) + (auto_tr.route_back or []):
+    for item in route + route_back:
         nid = item["node_id"]
         if nid != UNKNOWN_NODE_ID:
             node_ids.add(nid)
@@ -187,20 +207,37 @@ def add_traceroute_edges(auto_traceroute: AutoTraceRoute, driver=None, *, quiet:
             coords[nid] = pos
             names[nid] = _get_node_names(nid, auto_tr.source_node, auto_tr.target_node, observed_by_id)
 
-    # Extract edges (from_id, to_id, snr)
-    edges = []
-    if auto_tr.route:
-        edges.extend(_extract_edges(auto_tr.route))
-    if auto_tr.route_back:
-        edges.extend(_extract_edges(auto_tr.route_back))
+    # Trailing SNR values from the raw packet (firmware sometimes sends one extra
+    # value per direction: the SNR at the responding endpoint for the final hop).
+    # auto_tr.route only carries snr_towards[:len(route)], so pull the bookend
+    # SNR from raw_packet when available.
+    raw_packet = auto_tr.raw_packet
+    forward_target_snr = None
+    return_source_snr = None
+    if raw_packet is not None:
+        snr_towards = raw_packet.snr_towards or []
+        snr_back = raw_packet.snr_back or []
+        if len(snr_towards) > len(route):
+            forward_target_snr = snr_towards[len(route)]
+        if len(snr_back) > len(route_back):
+            return_source_snr = snr_back[len(route_back)]
 
-    # Prepend edge (source -> route[0]) — source is not in route per Meshtastic format
-    if auto_tr.route and len(auto_tr.route) > 0:
-        first_hop = auto_tr.route[0]
-        src_id = auto_tr.source_node.node_id
-        first_id = first_hop["node_id"]
-        if first_id != UNKNOWN_NODE_ID:
-            edges.insert(0, (src_id, first_id, first_hop.get("snr")))
+    source_id = auto_tr.source_node.node_id
+    target_id = auto_tr.target_node.node_id
+
+    # Build full chains (source/target are not in route); reuse _extract_edges which
+    # filters UNKNOWN_NODE_ID and picks SNR from the receiving end of each hop.
+    forward_chain = (
+        [{"node_id": source_id, "snr": None}] + list(route) + [{"node_id": target_id, "snr": forward_target_snr}]
+    )
+    return_chain = (
+        [{"node_id": target_id, "snr": None}] + list(route_back) + [{"node_id": source_id, "snr": return_source_snr}]
+    )
+
+    edges = _extract_edges(forward_chain) + _extract_edges(return_chain)
+
+    # Defensive: drop self-loops (pathological data where source/target collide with a relay).
+    edges = [(a, b, snr) for a, b, snr in edges if a != b]
 
     # Filter: both endpoints must have coords
     valid_edges = [(a, b, snr) for a, b, snr in edges if a in coords and b in coords]

--- a/Meshflow/traceroute/tests/test_export_command.py
+++ b/Meshflow/traceroute/tests/test_export_command.py
@@ -1,0 +1,65 @@
+"""Tests for the export_traceroutes_to_neo4j management command."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+import pytest
+
+
+class TestExportTraceroutesToNeo4jCommand:
+    """Cover --clear / --yes / --async flag interactions (neo4j is mocked)."""
+
+    def test_clear_yes_runs_clear_then_export(self):
+        with (
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.clear_all_routed_to_edges",
+                return_value=7,
+            ) as mock_clear,
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.export_all_traceroutes_to_neo4j",
+                return_value={"total": 10, "exported": 10},
+            ) as mock_export,
+        ):
+            out = StringIO()
+            call_command("export_traceroutes_to_neo4j", "--clear", "--yes", stdout=out)
+
+        mock_clear.assert_called_once()
+        mock_export.assert_called_once()
+        output = out.getvalue()
+        assert "Cleared 7 ROUTED_TO relationships" in output
+        assert "Exported 10 of 10 traceroutes" in output
+
+    def test_clear_without_yes_prompts_and_aborts_on_no(self):
+        with (
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.clear_all_routed_to_edges",
+            ) as mock_clear,
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.export_all_traceroutes_to_neo4j",
+            ) as mock_export,
+            patch("builtins.input", return_value="no"),
+        ):
+            out = StringIO()
+            call_command("export_traceroutes_to_neo4j", "--clear", stdout=out)
+
+        mock_clear.assert_not_called()
+        mock_export.assert_not_called()
+        assert "Aborted" in out.getvalue()
+
+    def test_clear_with_async_errors_without_touching_neo4j(self):
+        with (
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.clear_all_routed_to_edges",
+            ) as mock_clear,
+            patch(
+                "traceroute.management.commands.export_traceroutes_to_neo4j.export_all_traceroutes_to_neo4j",
+            ) as mock_export,
+        ):
+            with pytest.raises(CommandError):
+                call_command("export_traceroutes_to_neo4j", "--clear", "--async", "--yes")
+
+        mock_clear.assert_not_called()
+        mock_export.assert_not_called()

--- a/Meshflow/traceroute/tests/test_neo4j_service.py
+++ b/Meshflow/traceroute/tests/test_neo4j_service.py
@@ -57,74 +57,237 @@ class TestExtractEdges:
         assert result == [(0x11111111, 0x22222222, None)]
 
 
+def _mock_driver():
+    """Build a mocked Neo4j driver whose session() context yields a MagicMock session."""
+    mock_session = MagicMock()
+    mock_driver = MagicMock()
+    mock_cm = MagicMock()
+    mock_cm.__enter__.return_value = mock_session
+    mock_cm.__exit__.return_value = False
+    mock_driver.session.return_value = mock_cm
+    return mock_driver, mock_session
+
+
+def _edge_param_pairs(mock_session):
+    """Extract (a_id, b_id) tuples from every session.run(..., a_id=..., b_id=...) call."""
+    pairs = []
+    for call in mock_session.run.call_args_list:
+        kwargs = call[1] if len(call) > 1 and isinstance(call[1], dict) else {}
+        if "a_id" in kwargs and "b_id" in kwargs:
+            pairs.append((kwargs["a_id"], kwargs["b_id"]))
+    return pairs
+
+
+def _create_observed_with_coords(node_id: int, lat: float, lng: float, short_name: str = "PEER"):
+    """Create an ObservedNode with a NodeLatestStatus carrying coords."""
+    from common.mesh_node_helpers import meshtastic_id_to_hex
+    from nodes.models import NodeLatestStatus, ObservedNode
+
+    obs = ObservedNode.objects.create(
+        node_id=node_id,
+        node_id_str=meshtastic_id_to_hex(node_id),
+        short_name=short_name,
+        long_name=f"Node {short_name}",
+    )
+    NodeLatestStatus.objects.create(node=obs, latitude=lat, longitude=lng)
+    return obs
+
+
 @pytest.mark.django_db
 class TestAddTracerouteEdges:
-    """Tests for add_traceroute_edges including source-edge logic."""
+    """Tests for add_traceroute_edges edge construction."""
 
-    def test_add_traceroute_edges_includes_source_to_first_hop(
-        self, create_managed_node, create_observed_node, create_user
+    def _build_auto_tr(
+        self,
+        create_managed_node,
+        create_observed_node,
+        create_user,
+        *,
+        route,
+        route_back,
+        source_coords=(55.86, -4.25),
+        target_coords=(55.85, -4.26),
+        raw_packet=None,
     ):
-        """With mocked Neo4j, verify edge (source, route[0]) is created when both have coords."""
-        from nodes.models import NodeLatestStatus, ObservedNode
+        from nodes.models import NodeLatestStatus
+        from traceroute.models import AutoTraceRoute
 
         user = create_user()
         source_node = create_managed_node(
             node_id=0xAAAAAAAA,
-            default_location_latitude=55.86,
-            default_location_longitude=-4.25,
+            default_location_latitude=source_coords[0] if source_coords else None,
+            default_location_longitude=source_coords[1] if source_coords else None,
         )
         target_node = create_observed_node(node_id=0xBBBBBBBB)
-        NodeLatestStatus.objects.create(
-            node=target_node,
-            latitude=55.85,
-            longitude=-4.26,
-        )
-        # ObservedNode for peer (route[0]) - need coords via NodeLatestStatus
-        peer_node_id = 0xCCCCCCCC
-        peer_obs = ObservedNode.objects.create(
-            node_id=peer_node_id,
-            node_id_str="!cccccccc",
-            short_name="PEER",
-            long_name="Peer Node",
-        )
-        NodeLatestStatus.objects.create(
-            node=peer_obs,
-            latitude=55.87,
-            longitude=-4.25,
-        )
-
-        from traceroute.models import AutoTraceRoute
-
-        auto_tr = AutoTraceRoute.objects.create(
+        if target_coords is not None:
+            NodeLatestStatus.objects.create(
+                node=target_node,
+                latitude=target_coords[0],
+                longitude=target_coords[1],
+            )
+        return AutoTraceRoute.objects.create(
             source_node=source_node,
             target_node=target_node,
             trigger_type=AutoTraceRoute.TRIGGER_TYPE_USER,
             triggered_by=user,
             status=AutoTraceRoute.STATUS_COMPLETED,
-            route=[{"node_id": peer_node_id, "snr": -5.0}],
-            route_back=[{"node_id": peer_node_id, "snr": -4.0}],
+            route=route,
+            route_back=route_back,
+            raw_packet=raw_packet,
         )
 
-        mock_session = MagicMock()
-        mock_driver = MagicMock()
-        mock_cm = MagicMock()
-        mock_cm.__enter__.return_value = mock_session
-        mock_cm.__exit__.return_value = False
-        mock_driver.session.return_value = mock_cm
+    def test_forward_chain_single_relay_includes_peer_to_target(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """route=[peer] yields (source, peer) AND (peer, target)."""
+        peer_id = 0xCCCCCCCC
+        _create_observed_with_coords(peer_id, 55.87, -4.25)
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[{"node_id": peer_id, "snr": -5.0}],
+            route_back=[],
+        )
 
+        mock_driver, mock_session = _mock_driver()
         with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
             add_traceroute_edges(auto_tr, driver=mock_driver)
 
-        # Should have created edge (source, peer) - our synthetic edge for source -> route[0]
-        # route has one element (peer); route_back has one element - no consecutive pairs from _extract_edges
-        calls = mock_session.run.call_args_list
-        assert len(calls) >= 1
-        param_pairs = []
-        for call in calls:
+        pairs = _edge_param_pairs(mock_session)
+        assert (0xAAAAAAAA, peer_id) in pairs
+        assert (peer_id, 0xBBBBBBBB) in pairs
+
+    def test_forward_chain_multi_relay_includes_all_hops(self, create_managed_node, create_observed_node, create_user):
+        """route=[p1, p2] yields (source, p1), (p1, p2), (p2, target)."""
+        p1, p2 = 0xC1C1C1C1, 0xC2C2C2C2
+        _create_observed_with_coords(p1, 55.87, -4.25, short_name="P1")
+        _create_observed_with_coords(p2, 55.88, -4.26, short_name="P2")
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[
+                {"node_id": p1, "snr": -5.0},
+                {"node_id": p2, "snr": -3.0},
+            ],
+            route_back=[],
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        pairs = _edge_param_pairs(mock_session)
+        assert (0xAAAAAAAA, p1) in pairs
+        assert (p1, p2) in pairs
+        assert (p2, 0xBBBBBBBB) in pairs
+
+    def test_return_chain_adds_bookends(self, create_managed_node, create_observed_node, create_user):
+        """route_back=[p1, p2] yields (target, p1), (p1, p2), (p2, source)."""
+        p1, p2 = 0xD1D1D1D1, 0xD2D2D2D2
+        _create_observed_with_coords(p1, 55.87, -4.25, short_name="P1")
+        _create_observed_with_coords(p2, 55.88, -4.26, short_name="P2")
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[],
+            route_back=[
+                {"node_id": p1, "snr": -4.0},
+                {"node_id": p2, "snr": -2.0},
+            ],
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        pairs = _edge_param_pairs(mock_session)
+        assert (0xBBBBBBBB, p1) in pairs
+        assert (p1, p2) in pairs
+        assert (p2, 0xAAAAAAAA) in pairs
+
+    def test_direct_traceroute_creates_source_target_edges(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """Empty route and route_back: (source, target) and (target, source) when coords present."""
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[],
+            route_back=[],
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        pairs = _edge_param_pairs(mock_session)
+        assert (0xAAAAAAAA, 0xBBBBBBBB) in pairs
+        assert (0xBBBBBBBB, 0xAAAAAAAA) in pairs
+
+    def test_direct_traceroute_skipped_when_no_coords(self, create_managed_node, create_observed_node, create_user):
+        """Empty route/route_back without endpoint coords: no edges written."""
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[],
+            route_back=[],
+            source_coords=None,
+            target_coords=None,
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        assert _edge_param_pairs(mock_session) == []
+
+    def test_target_snr_pulled_from_raw_packet_when_route_snr_shorter(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """
+        raw_packet.snr_towards has one more value than route: the trailing value is
+        the SNR at the target for the final (peer -> target) hop.
+        """
+        from packets.models import TraceroutePacket
+
+        peer_id = 0xCCCCCCCC
+        _create_observed_with_coords(peer_id, 55.87, -4.25)
+
+        tr_packet = TraceroutePacket.objects.create(
+            packet_id=987654321,
+            from_int=0xBBBBBBBB,
+            to_int=0xAAAAAAAA,
+            route=[peer_id],
+            route_back=[],
+            snr_towards=[-5.0, -1.5],
+            snr_back=[],
+        )
+
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[{"node_id": peer_id, "snr": -5.0}],
+            route_back=[],
+            raw_packet=tr_packet,
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        target_hop_snrs = []
+        for call in mock_session.run.call_args_list:
             kwargs = call[1] if len(call) > 1 and isinstance(call[1], dict) else {}
-            if "a_id" in kwargs and "b_id" in kwargs:
-                param_pairs.append((kwargs["a_id"], kwargs["b_id"]))
-        assert (0xAAAAAAAA, 0xCCCCCCCC) in param_pairs, "Expected edge (source, peer) to be created"
+            if kwargs.get("a_id") == peer_id and kwargs.get("b_id") == 0xBBBBBBBB:
+                target_hop_snrs.append(kwargs.get("snr"))
+        assert target_hop_snrs, "Expected (peer, target) edge to be written"
+        assert target_hop_snrs[0] == -1.5
 
 
 @pytest.mark.django_db

--- a/Meshflow/traceroute/tests/test_neo4j_service.py
+++ b/Meshflow/traceroute/tests/test_neo4j_service.py
@@ -10,6 +10,7 @@ from traceroute.neo4j_service import (
     UNKNOWN_NODE_ID,
     _extract_edges,
     add_traceroute_edges,
+    clear_all_routed_to_edges,
     run_heatmap_query,
 )
 
@@ -288,6 +289,87 @@ class TestAddTracerouteEdges:
                 target_hop_snrs.append(kwargs.get("snr"))
         assert target_hop_snrs, "Expected (peer, target) edge to be written"
         assert target_hop_snrs[0] == -1.5
+
+    def test_add_traceroute_edges_uses_merge_with_auto_tr_id(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """Edge writes are MERGE-based and include auto_tr_id in params (idempotent by design)."""
+        peer_id = 0xCCCCCCCC
+        _create_observed_with_coords(peer_id, 55.87, -4.25)
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[{"node_id": peer_id, "snr": -5.0}],
+            route_back=[],
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        edge_calls = [
+            call for call in mock_session.run.call_args_list if "a_id" in (call[1] or {}) and "b_id" in (call[1] or {})
+        ]
+        assert edge_calls, "Expected at least one edge write"
+        for call in edge_calls:
+            cypher = call[0][0] if call[0] else ""
+            params = call[1] or {}
+            assert "MERGE (a)-[r:ROUTED_TO" in cypher
+            assert "CREATE (a)-[:ROUTED_TO" not in cypher
+            assert "auto_tr_id: $auto_tr_id" in cypher
+            assert params.get("auto_tr_id") == auto_tr.id
+
+    def test_add_traceroute_edges_reexport_does_not_duplicate(
+        self, create_managed_node, create_observed_node, create_user
+    ):
+        """Re-invoking add_traceroute_edges with the same AutoTraceRoute keeps auto_tr_id stable."""
+        peer_id = 0xCCCCCCCC
+        _create_observed_with_coords(peer_id, 55.87, -4.25)
+        auto_tr = self._build_auto_tr(
+            create_managed_node,
+            create_observed_node,
+            create_user,
+            route=[{"node_id": peer_id, "snr": -5.0}],
+            route_back=[],
+        )
+
+        mock_driver, mock_session = _mock_driver()
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+            add_traceroute_edges(auto_tr, driver=mock_driver)
+
+        edge_calls = [
+            call for call in mock_session.run.call_args_list if "a_id" in (call[1] or {}) and "b_id" in (call[1] or {})
+        ]
+        auto_tr_ids = {(call[1] or {}).get("auto_tr_id") for call in edge_calls}
+        assert auto_tr_ids == {auto_tr.id}, "Second export should reuse the same auto_tr_id"
+        for call in edge_calls:
+            assert "MERGE (a)-[r:ROUTED_TO" in call[0][0]
+
+
+class TestClearAllRoutedToEdges:
+    """Tests for clear_all_routed_to_edges."""
+
+    def test_clear_all_routed_to_edges_runs_delete(self):
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"deleted": 42}
+        mock_session = MagicMock()
+        mock_session.run.return_value = mock_result
+        mock_driver = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_session
+        mock_cm.__exit__.return_value = False
+        mock_driver.session.return_value = mock_cm
+
+        with patch("traceroute.neo4j_service.get_driver", return_value=mock_driver):
+            deleted = clear_all_routed_to_edges(driver=mock_driver)
+
+        assert deleted == 42
+        assert mock_session.run.call_count == 1
+        cypher = mock_session.run.call_args[0][0]
+        assert "ROUTED_TO" in cypher
+        assert "DELETE r" in cypher
 
 
 @pytest.mark.django_db

--- a/docs/features/traceroute/heatmap.md
+++ b/docs/features/traceroute/heatmap.md
@@ -5,16 +5,24 @@ The heatmap visualizes aggregated traceroute traffic between nodes as arcs on a 
 ## Neo4j Schema
 
 - **MeshNode**: Node label with `node_id` (unique), `node_id_str`, `latitude`, `longitude`, `short_name`, `long_name`.
-- **ROUTED_TO**: Relationship from one MeshNode to another. Properties: `weight` (integer, incremented per traceroute), `triggered_at` (datetime), `snr` (float, optional – SNR at receiving node for this hop).
+- **ROUTED_TO**: Relationship from one MeshNode to another. Properties:
+  - `weight` (integer, one per traceroute hop – summed bidirectionally for the heatmap)
+  - `triggered_at` (datetime)
+  - `auto_tr_id`, `a_id`, `b_id` – merge key used for idempotent re-export
+  - `snr` (float, optional – SNR at the receiving node for this hop)
 
 Edges are directional in Neo4j, but the heatmap query aggregates bidirectionally (A→B and B→A are summed). The `snr` property is used by the node-links API for per-node traceroute link visualization.
 
 ## Data Flow
 
-1. When an `AutoTraceRoute` completes, `push_traceroute_to_neo4j` extracts consecutive node pairs (with SNR) from `route` and `route_back`.
-2. **Meshtastic format:** `route` excludes the source (contains `[hop1, hop2, ..., target]`); `route_back` includes the source as the last element `[hop1', ..., source]`. SNR is 1:1 with route indices (SNR at receiving node per firmware PR #4485). A synthetic edge `(source, route[0])` is added in `add_traceroute_edges` so the originating node has outbound links.
-3. For each edge (from_id, to_id), both endpoints must have coordinates (from ManagedNode default_location or ObservedNode latest_status).
-4. Nodes are upserted; `ROUTED_TO` relationships are created with `weight: 1`, `triggered_at`, and `snr` (when present).
+1. When an `AutoTraceRoute` completes, `push_traceroute_to_neo4j` calls `add_traceroute_edges`, which builds two full chains of `{node_id, snr}` entries and emits consecutive pairs.
+2. **Meshtastic format:** `AutoTraceRoute.route` and `AutoTraceRoute.route_back` are **relay-only** lists. Neither the source (`AutoTraceRoute.source_node`, a `ManagedNode`) nor the target/responder (`AutoTraceRoute.target_node`, an `ObservedNode` matching the packet `from_node`) is stored in those lists. SNR is 1:1 with route indices (SNR at receiving node per firmware PR #4485). Firmware sometimes sends one extra trailing value in `snr_towards` / `snr_back`; that is the SNR at the responding endpoint for the final bookend hop and is pulled from the linked `raw_packet` when building the bookend edges.
+3. `add_traceroute_edges` constructs:
+   - Forward chain: `[source, *route, target]` → edges `source → route[0] → … → route[-1] → target`.
+   - Return chain: `[target, *route_back, source]` → edges `target → route_back[0] → … → route_back[-1] → source`.
+   - Direct traceroutes (both route lists empty) collapse to `(source, target)` and `(target, source)` when both endpoints have coordinates.
+4. For each edge, both endpoints must have coordinates (from `ManagedNode.default_location_*` or `ObservedNode.latest_status`).
+5. Nodes are upserted, and each edge is written with `MERGE (a)-[r:ROUTED_TO {auto_tr_id, a_id, b_id, triggered_at}]->(b)`. Re-exporting the same `AutoTraceRoute` therefore updates the existing relationship in place rather than duplicating it.
 
 ## Heatmap-Edges API
 
@@ -66,4 +74,6 @@ The query aggregates `ROUTED_TO` relationships bidirectionally (canonical direct
 
 - **Neo4j**: `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD` in settings.
 - **Schema**: `ensure_schema()` creates the `MeshNode.node_id` unique constraint. Run on first use or via migration.
-- **Bulk export**: Use `manage.py export_traceroutes_to_neo4j` to backfill Neo4j from existing completed traceroutes.
+- **Bulk export**: Use `manage.py export_traceroutes_to_neo4j` to backfill Neo4j from existing completed traceroutes. The export is idempotent thanks to the `MERGE` semantics above, so re-runs safely pick up new synthetic edges without double-counting.
+  - `--clear` first deletes every `ROUTED_TO` relationship (nodes are left untouched and re-upserted by the export). Useful when you want a guaranteed clean slate before a full re-export. Prompts for confirmation unless `--yes` is also given.
+  - `--clear` is sync-only; combining it with `--async` raises `CommandError`.


### PR DESCRIPTION
# Summary

Fixes the Neo4j traceroute heatmap to include the edges it was previously missing, and makes the bulk backfill safe to re-run.

`AutoTraceRoute.route` / `route_back` are relay-only lists; the target/responder is `AutoTraceRoute.target_node`, not the last element of `route`. Before this change, `add_traceroute_edges` only emitted `source → route[0]` plus the inner relay hops, so the heatmap was missing:

- **Forward:** `route[-1] → target` (last hop to responder)
- **Return:** `target → route_back[0]` and `route_back[-1] → source` (the return-path bookends)
- **Direct traceroutes** (both route lists empty): all edges, because the function returned early.

### What changed

- `add_traceroute_edges` now builds two full chains and reuses `_extract_edges`:
  - Forward: `[source, *route, target]` with the target-side bookend SNR pulled from `raw_packet.snr_towards[len(route)]` when firmware sends it.
  - Return: `[target, *route_back, source]` with the source-side bookend SNR from `raw_packet.snr_back[len(route_back)]`.
  - Direct: both chains collapse to `(source, target)` / `(target, source)` when both endpoints have coordinates.
- Hardened `_get_node_coords` / `_get_node_names` against `RelatedObjectDoesNotExist` when an `ObservedNode` has no `latest_status` (previously masked by the empty-route early return).
- Switched ROUTED_TO writes from `CREATE` to `MERGE` keyed on `(auto_tr_id, a_id, b_id, triggered_at)` so re-exporting the same `AutoTraceRoute` updates the existing relationship instead of duplicating it. `weight` stays at 1 per TR hop, so `run_heatmap_query` aggregation is unchanged.
- Added `clear_all_routed_to_edges` helper and `--clear` / `--yes` flags on the `export_traceroutes_to_neo4j` management command for operators who want a clean slate before a full re-export. `--clear` is sync-only; combining it with `--async` raises `CommandError`.
- Corrected `docs/features/traceroute/heatmap.md` (the old text claimed `route` ended with the target and `route_back` ended with the source – both untrue) and documented the new synthetic edges, MERGE semantics, and `--clear` flag.

## Background

Details, evidence, and proposed behaviour all captured in #159.

Manual steps for deploy:

- To backfill the new synthetic edges into an existing Neo4j, run `python manage.py export_traceroutes_to_neo4j`. Thanks to MERGE semantics this is idempotent and safe to repeat.
- If preferred, `python manage.py export_traceroutes_to_neo4j --clear` will wipe ROUTED_TO relationships first (nodes are left intact and re-upserted). The command prompts for confirmation unless `--yes` is passed.

Closes #159

## Testing performed

- New unit coverage in `Meshflow/traceroute/tests/test_neo4j_service.py`:
  - Forward chain with single and multi-relay routes asserting `(source, peer)`, relay hops, and the new `(peer, target)` bookend.
  - Return chain asserting `(target, peer)` and `(peer, source)` bookends.
  - Direct traceroute: both endpoints with coords produce both `(source, target)` and `(target, source)`; no coords produces no edges.
  - Target SNR pulled from `raw_packet.snr_towards[len(route)]` when longer than the stored route.
  - MERGE cypher shape + `auto_tr_id` stability across a re-export, plus `clear_all_routed_to_edges` cypher shape.
- New `Meshflow/traceroute/tests/test_export_command.py` covering `--clear --yes`, `--clear` confirmation abort, and `--clear --async` → `CommandError`.
- `python -m pytest Meshflow/traceroute/ Meshflow/packets/` → 134 passed.
- `black . && isort . && flake8 .` clean on the touched files.
