### PR TITLE
feat(mesh-monitoring): node-level offline_after on NodePresence (UI #148)

### DIFF
--- a/Meshflow/mesh_monitoring/admin.py
+++ b/Meshflow/mesh_monitoring/admin.py
@@ -5,7 +5,7 @@ from .models import NodePresence, NodeWatch
 
 @admin.register(NodeWatch)
 class NodeWatchAdmin(admin.ModelAdmin):
-    list_display = ("user", "observed_node", "offline_after", "enabled", "created_at")
+    list_display = ("user", "observed_node", "enabled", "created_at")
     list_filter = ("enabled",)
     raw_id_fields = ("user", "observed_node")
 
@@ -14,6 +14,7 @@ class NodeWatchAdmin(admin.ModelAdmin):
 class NodePresenceAdmin(admin.ModelAdmin):
     list_display = (
         "observed_node",
+        "offline_after",
         "is_offline",
         "observed_online_at",
         "verification_started_at",

--- a/Meshflow/mesh_monitoring/constants.py
+++ b/Meshflow/mesh_monitoring/constants.py
@@ -2,6 +2,9 @@
 
 import os
 
+# Default silence threshold before verification may start (6 hours).
+DEFAULT_OFFLINE_AFTER_SECONDS = 21600
+
 # Align with STALE_TR_TIMEOUT_SECONDS / verification window in epic (~3 minutes).
 DEFAULT_VERIFICATION_WINDOW_SECONDS = 180
 

--- a/Meshflow/mesh_monitoring/eligibility.py
+++ b/Meshflow/mesh_monitoring/eligibility.py
@@ -1,4 +1,7 @@
-"""Who may create a NodeWatch (same rules as future REST API)."""
+"""Who may create a NodeWatch (REST + model validation).
+
+See docs/features/mesh-monitoring/permissions.md for the full permission matrix.
+"""
 
 from nodes.constants import INFRASTRUCTURE_ROLES
 

--- a/Meshflow/mesh_monitoring/migrations/0006_move_offline_after_to_node_presence.py
+++ b/Meshflow/mesh_monitoring/migrations/0006_move_offline_after_to_node_presence.py
@@ -1,0 +1,59 @@
+# Generated manually for UI #148 — canonical silence threshold on NodePresence.
+
+from django.db import migrations, models
+from django.db.models import Min
+
+
+def forwards_copy_offline_after_to_presence(apps, schema_editor):
+    NodeWatch = apps.get_model("mesh_monitoring", "NodeWatch")
+    NodePresence = apps.get_model("mesh_monitoring", "NodePresence")
+
+    for row in NodeWatch.objects.values("observed_node_id").distinct():
+        oid = row["observed_node_id"]
+        enabled_min = NodeWatch.objects.filter(observed_node_id=oid, enabled=True).aggregate(
+            m=Min("offline_after"),
+        )["m"]
+        if enabled_min is not None:
+            val = enabled_min
+        else:
+            val = NodeWatch.objects.filter(observed_node_id=oid).aggregate(m=Min("offline_after"))["m"]
+            if val is None:
+                val = 21600
+
+        pres, created = NodePresence.objects.get_or_create(
+            observed_node_id=oid,
+            defaults={
+                "offline_after": val,
+                "tr_sent_count": 0,
+                "is_offline": False,
+            },
+        )
+        if not created:
+            NodePresence.objects.filter(pk=oid).update(offline_after=val)
+
+
+def backwards_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("mesh_monitoring", "0005_nodepresence_last_verification_notify_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nodepresence",
+            name="offline_after",
+            field=models.PositiveIntegerField(
+                default=21600,
+                help_text="Seconds without packets (last_heard) before verification may start.",
+            ),
+        ),
+        migrations.RunPython(forwards_copy_offline_after_to_presence, backwards_noop),
+        migrations.RemoveField(
+            model_name="nodewatch",
+            name="offline_after",
+        ),
+    ]

--- a/Meshflow/mesh_monitoring/models.py
+++ b/Meshflow/mesh_monitoring/models.py
@@ -21,10 +21,6 @@ class NodeWatch(models.Model):
         on_delete=models.CASCADE,
         related_name="watches",
     )
-    offline_after = models.PositiveIntegerField(
-        default=7200,
-        help_text=_("Seconds without packets (last_heard) before verification may start."),
-    )
     enabled = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
@@ -59,6 +55,10 @@ class NodePresence(models.Model):
         on_delete=models.CASCADE,
         primary_key=True,
         related_name="mesh_presence",
+    )
+    offline_after = models.PositiveIntegerField(
+        default=21600,
+        help_text=_("Seconds without packets (last_heard) before verification may start."),
     )
     verification_started_at = models.DateTimeField(
         null=True,

--- a/Meshflow/mesh_monitoring/permission_helpers.py
+++ b/Meshflow/mesh_monitoring/permission_helpers.py
@@ -1,8 +1,11 @@
-"""Permission checks for mesh monitoring API actions."""
+"""Permission checks for mesh monitoring API actions.
+
+See docs/features/mesh-monitoring/permissions.md for the full matrix (watch vs offline_after).
+"""
 
 
 def user_can_edit_monitoring_offline_after(user, observed_node):
-    """Staff or the user who claimed the observed node may edit silence threshold."""
+    """Django staff or the claim owner may PATCH NodePresence.offline_after (silence threshold)."""
     if not user or not user.is_authenticated:
         return False
     if user.is_staff:

--- a/Meshflow/mesh_monitoring/permission_helpers.py
+++ b/Meshflow/mesh_monitoring/permission_helpers.py
@@ -1,0 +1,12 @@
+"""Permission checks for mesh monitoring API actions."""
+
+
+def user_can_edit_monitoring_offline_after(user, observed_node):
+    """Staff or the user who claimed the observed node may edit silence threshold."""
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_staff:
+        return True
+    if observed_node.claimed_by_id and observed_node.claimed_by_id == user.id:
+        return True
+    return False

--- a/Meshflow/mesh_monitoring/serializers.py
+++ b/Meshflow/mesh_monitoring/serializers.py
@@ -4,8 +4,9 @@ from django.utils.translation import gettext_lazy as _
 
 from rest_framework import serializers
 
+from mesh_monitoring.constants import DEFAULT_OFFLINE_AFTER_SECONDS
 from mesh_monitoring.eligibility import user_can_watch
-from mesh_monitoring.models import NodeWatch
+from mesh_monitoring.models import NodePresence, NodeWatch
 from nodes.models import ObservedNode
 
 
@@ -14,6 +15,7 @@ class ObservedNodeWatchSummarySerializer(serializers.ModelSerializer):
 
     monitoring_verification_started_at = serializers.SerializerMethodField()
     monitoring_offline_confirmed_at = serializers.SerializerMethodField()
+    offline_after = serializers.SerializerMethodField()
 
     class Meta:
         model = ObservedNode
@@ -22,6 +24,7 @@ class ObservedNodeWatchSummarySerializer(serializers.ModelSerializer):
             "node_id_str",
             "long_name",
             "last_heard",
+            "offline_after",
             "monitoring_verification_started_at",
             "monitoring_offline_confirmed_at",
         ]
@@ -38,9 +41,29 @@ class ObservedNodeWatchSummarySerializer(serializers.ModelSerializer):
             return None
         return rel.offline_confirmed_at
 
+    def get_offline_after(self, obj):
+        rel = getattr(obj, "mesh_presence", None)
+        if rel is None:
+            return DEFAULT_OFFLINE_AFTER_SECONDS
+        return rel.offline_after
+
+
+class NodePresenceOfflineAfterSerializer(serializers.ModelSerializer):
+    """PATCH body for NodePresence.offline_after (node-level silence threshold)."""
+
+    class Meta:
+        model = NodePresence
+        fields = ["offline_after"]
+
+    def validate_offline_after(self, value):
+        if value is not None and value < 1:
+            raise serializers.ValidationError(_("offline_after must be at least 1 second."))
+        return value
+
 
 class NodeWatchSerializer(serializers.ModelSerializer):
     observed_node = ObservedNodeWatchSummarySerializer(read_only=True)
+    offline_after = serializers.SerializerMethodField()
     observed_node_id = serializers.PrimaryKeyRelatedField(
         queryset=ObservedNode.objects.all(),
         source="observed_node",
@@ -58,7 +81,7 @@ class NodeWatchSerializer(serializers.ModelSerializer):
             "enabled",
             "created_at",
         ]
-        read_only_fields = ["id", "observed_node", "created_at"]
+        read_only_fields = ["id", "observed_node", "offline_after", "created_at"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -86,7 +109,8 @@ class NodeWatchSerializer(serializers.ModelSerializer):
                 )
         return attrs
 
-    def validate_offline_after(self, value):
-        if value is not None and value < 1:
-            raise serializers.ValidationError(_("offline_after must be at least 1 second."))
-        return value
+    def get_offline_after(self, obj):
+        rel = getattr(obj.observed_node, "mesh_presence", None)
+        if rel is None:
+            return DEFAULT_OFFLINE_AFTER_SECONDS
+        return rel.offline_after

--- a/Meshflow/mesh_monitoring/tasks.py
+++ b/Meshflow/mesh_monitoring/tasks.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import timedelta
 
-from django.db.models import F, Min
+from django.db.models import F
 from django.utils import timezone
 
 from asgiref.sync import async_to_sync
@@ -14,6 +14,7 @@ from nodes.models import ObservedNode
 from traceroute.models import AutoTraceRoute
 
 from .constants import (
+    DEFAULT_OFFLINE_AFTER_SECONDS,
     notify_verification_start_enabled,
     verification_notify_cooldown_seconds,
     verification_window_seconds,
@@ -113,9 +114,11 @@ def process_node_watch_presence() -> dict:
 
 
 def _process_one_observed_node(obs: ObservedNode, now, window: timedelta) -> None:
-    eff = NodeWatch.objects.filter(observed_node=obs, enabled=True).aggregate(m=Min("offline_after"))["m"]
-    if eff is None:
+    if not NodeWatch.objects.filter(observed_node=obs, enabled=True).exists():
         return
+
+    presence_row = NodePresence.objects.filter(pk=obs.pk).first()
+    eff = presence_row.offline_after if presence_row else DEFAULT_OFFLINE_AFTER_SECONDS
 
     effective_delta = timedelta(seconds=int(eff))
     last_heard = obs.last_heard
@@ -128,6 +131,7 @@ def _process_one_observed_node(obs: ObservedNode, now, window: timedelta) -> Non
             "is_offline": False,
         },
     )
+    eff = presence.offline_after
 
     if not silent:
         had_confirmed_offline = bool(presence.offline_confirmed_at) or presence.is_offline

--- a/Meshflow/mesh_monitoring/tests/conftest.py
+++ b/Meshflow/mesh_monitoring/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared helpers for mesh_monitoring tests."""
+
+from mesh_monitoring.models import NodePresence, NodeWatch
+
+
+def create_watch_with_offline_threshold(*, user, observed_node, offline_after=60, enabled=True):
+    """Create an enabled NodeWatch and set the node-level silence threshold on NodePresence."""
+    watch = NodeWatch.objects.create(user=user, observed_node=observed_node, enabled=enabled)
+    NodePresence.objects.update_or_create(observed_node=observed_node, defaults={"offline_after": offline_after})
+    return watch

--- a/Meshflow/mesh_monitoring/tests/test_eligibility_and_presence.py
+++ b/Meshflow/mesh_monitoring/tests/test_eligibility_and_presence.py
@@ -7,9 +7,10 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 from mesh_monitoring.eligibility import user_can_watch
-from mesh_monitoring.models import NodePresence, NodeWatch
+from mesh_monitoring.models import NodePresence
 from mesh_monitoring.services import clear_presence_on_packet_from_node
 from mesh_monitoring.suppression import suppressed_observed_node_ids
+from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 from nodes.constants import INFRASTRUCTURE_ROLES
 from nodes.models import RoleSource
 
@@ -100,4 +101,4 @@ def test_nodewatch_save_validates_eligibility(create_user, create_observed_node)
     user = create_user()
     obs = create_observed_node(role=RoleSource.CLIENT, claimed_by=None)
     with pytest.raises(ValidationError):
-        NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+        create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)

--- a/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
@@ -11,8 +11,9 @@ import pytest
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
 from mesh_monitoring.constants import notify_verification_start_enabled, verification_notify_cooldown_seconds
-from mesh_monitoring.models import NodePresence, NodeWatch
+from mesh_monitoring.models import NodePresence
 from mesh_monitoring.tasks import process_node_watch_presence, send_monitoring_traceroute_command
+from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 
 
 def test_notify_verification_start_enabled_default_true_when_unset(monkeypatch):
@@ -54,7 +55,7 @@ def test_verification_start_notify_happy_path(
     obs = create_observed_node(node_id=0xAABBCCDD, claimed_by=user)
     obs.last_heard = timezone.now() - timedelta(seconds=120)
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
 
     mn = create_managed_node(
         allow_auto_traceroute=True,
@@ -107,7 +108,7 @@ def test_verification_start_notify_skipped_when_flag_off(
     obs = create_observed_node(node_id=0xBBCCDDEE, claimed_by=user)
     obs.last_heard = timezone.now() - timedelta(seconds=120)
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
     mn = create_managed_node(
         allow_auto_traceroute=True,
         default_location_latitude=48.0,
@@ -153,9 +154,8 @@ def test_verification_start_notify_respects_cooldown(
     obs = create_observed_node(node_id=0xCCDDEEFF, claimed_by=user)
     obs.last_heard = timezone.now() - timedelta(seconds=120)
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
-    NodePresence.objects.create(
-        observed_node=obs,
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
+    NodePresence.objects.filter(observed_node=obs).update(
         last_verification_notify_at=timezone.now() - timedelta(minutes=1),
     )
     mn = create_managed_node(
@@ -196,9 +196,8 @@ def test_not_silent_clears_last_verification_notify_at(
     obs = create_observed_node(node_id=0xDDEEFF00, claimed_by=user)
     obs.last_heard = timezone.now()
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
-    NodePresence.objects.create(
-        observed_node=obs,
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
+    NodePresence.objects.filter(observed_node=obs).update(
         last_verification_notify_at=timezone.now() - timedelta(hours=1),
         verification_started_at=timezone.now() - timedelta(minutes=5),
     )

--- a/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
@@ -8,8 +8,8 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 from common.mesh_node_helpers import meshtastic_id_to_hex
-from mesh_monitoring.models import NodeWatch
 from mesh_monitoring.services import notify_watchers_node_offline, notify_watchers_verification_started
+from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 
 
 @pytest.mark.django_db
@@ -23,7 +23,7 @@ def test_offline_dm_includes_short_name_and_deep_link(create_user, create_observ
         short_name="MLNN",
         claimed_by=user,
     )
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
 
     with override_settings(FRONTEND_URL="https://mesh.example/"):
         with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
@@ -51,7 +51,7 @@ def test_offline_dm_omits_url_when_frontend_unset(create_user, create_observed_n
         short_name="ANOD",
         claimed_by=user,
     )
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
 
     with override_settings(FRONTEND_URL=""):
         with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
@@ -74,7 +74,7 @@ def test_verification_start_dm_includes_short_name_and_deep_link(create_user, cr
         short_name="VFYM",
         claimed_by=user,
     )
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=90, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=90)
 
     with override_settings(FRONTEND_URL="https://mesh.example"):
         with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):

--- a/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
+++ b/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
@@ -12,6 +12,7 @@ import packets.tests.conftest  # noqa: F401
 from mesh_monitoring.models import NodePresence, NodeWatch
 from mesh_monitoring.services import monitoring_traceroute_succeeded_since, on_monitoring_traceroute_completed
 from mesh_monitoring.tasks import process_node_watch_presence, send_monitoring_traceroute_command
+from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 from nodes.models import NodeLatestStatus
 from traceroute.models import AutoTraceRoute
 
@@ -32,7 +33,7 @@ def test_process_node_watch_presence_starts_verification_and_creates_monitor_tr(
     obs.save(update_fields=["last_heard"])
     NodeLatestStatus.objects.create(node=obs, latitude=48.0, longitude=2.0)
 
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
 
     mn = create_managed_node(
         allow_auto_traceroute=True,
@@ -146,7 +147,7 @@ def test_dispatch_zero_sources_sets_last_zero_sources_at(
     obs.last_heard = timezone.now() - timedelta(seconds=120)
     obs.save(update_fields=["last_heard"])
     NodeLatestStatus.objects.create(node=obs, latitude=48.0, longitude=2.0)
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
 
     mn = create_managed_node(
         allow_auto_traceroute=True,
@@ -173,9 +174,8 @@ def test_process_node_watch_presence_clears_observability_when_node_not_silent(
     obs = create_observed_node(node_id=0x44556677, claimed_by=user)
     obs.last_heard = timezone.now() - timedelta(seconds=120)
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
-    NodePresence.objects.create(
-        observed_node=obs,
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
+    NodePresence.objects.filter(observed_node=obs).update(
         verification_started_at=timezone.now() - timedelta(minutes=5),
         suspected_offline_at=timezone.now() - timedelta(minutes=5),
         tr_sent_count=2,
@@ -206,7 +206,7 @@ def test_process_node_watch_presence_sets_observed_online_at_when_created_heard(
     obs = create_observed_node(node_id=0x66778899, claimed_by=user)
     obs.last_heard = timezone.now()
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=3600, enabled=True)
+    NodeWatch.objects.create(user=user, observed_node=obs, enabled=True)
 
     process_node_watch_presence()
 
@@ -225,9 +225,8 @@ def test_process_node_watch_presence_recovery_from_offline_sets_observed_online_
     obs = create_observed_node(node_id=0x778899AA, claimed_by=user)
     obs.last_heard = timezone.now()
     obs.save(update_fields=["last_heard"])
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
-    NodePresence.objects.create(
-        observed_node=obs,
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
+    NodePresence.objects.filter(observed_node=obs).update(
         offline_confirmed_at=timezone.now() - timedelta(hours=1),
         is_offline=True,
     )
@@ -256,9 +255,9 @@ def test_process_node_watch_presence_offline_confirm_sets_is_offline(
     obs.last_heard = now - timedelta(minutes=10)
     obs.save(update_fields=["last_heard"])
     NodeLatestStatus.objects.create(node=obs, latitude=48.0, longitude=2.0)
-    NodeWatch.objects.create(user=user, observed_node=obs, offline_after=60, enabled=True)
+    create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
     vs = now - timedelta(minutes=2)
-    NodePresence.objects.create(observed_node=obs, verification_started_at=vs)
+    NodePresence.objects.filter(observed_node=obs).update(verification_started_at=vs)
 
     mn = create_managed_node(
         allow_auto_traceroute=True,

--- a/Meshflow/mesh_monitoring/tests/test_watch_api.py
+++ b/Meshflow/mesh_monitoring/tests/test_watch_api.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 import nodes.tests.conftest  # noqa: F401
-from mesh_monitoring.models import NodeWatch
 from nodes.constants import INFRASTRUCTURE_ROLES
 from nodes.models import RoleSource
 
@@ -26,7 +25,7 @@ def test_watch_create_requires_auth(api_client, create_observed_node):
     obs = create_observed_node()
     r = api_client.post(
         "/api/monitoring/watches/",
-        {"observed_node_id": str(obs.internal_id), "offline_after": 60, "enabled": True},
+        {"observed_node_id": str(obs.internal_id), "enabled": True},
         format="json",
     )
     assert r.status_code == status.HTTP_401_UNAUTHORIZED
@@ -40,15 +39,29 @@ def test_watch_crud_claimed_node(api_client, create_user, create_observed_node):
 
     r = api_client.post(
         "/api/monitoring/watches/",
-        {"observed_node_id": str(obs.internal_id), "offline_after": 90, "enabled": True},
+        {"observed_node_id": str(obs.internal_id), "enabled": True},
         format="json",
     )
     assert r.status_code == status.HTTP_201_CREATED
     wid = r.data["id"]
-    assert r.data["offline_after"] == 90
+    assert r.data["offline_after"] == 21600
     assert r.data["enabled"] is True
     assert r.data["observed_node"]["node_id_str"] == obs.node_id_str
     assert r.data["observed_node"]["monitoring_verification_started_at"] is None
+
+    r = api_client.patch(
+        f"/api/monitoring/nodes/{obs.internal_id}/offline-after/",
+        {"offline_after": 90},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["offline_after"] == 90
+    assert r.data["editable"] is True
+
+    r = api_client.get(f"/api/monitoring/watches/{wid}/")
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["offline_after"] == 90
+    assert r.data["observed_node"]["offline_after"] == 90
 
     r = api_client.get("/api/monitoring/watches/")
     assert r.status_code == status.HTTP_200_OK
@@ -61,6 +74,38 @@ def test_watch_crud_claimed_node(api_client, create_user, create_observed_node):
 
     r = api_client.delete(f"/api/monitoring/watches/{wid}/")
     assert r.status_code == status.HTTP_204_NO_CONTENT
+
+
+@pytest.mark.django_db
+def test_monitoring_offline_after_get_editable_flags(api_client, create_user, create_observed_node):
+    owner = create_user()
+    other = create_user()
+    obs = create_observed_node(claimed_by=owner)
+
+    api_client.force_authenticate(user=other)
+    r = api_client.get(f"/api/monitoring/nodes/{obs.internal_id}/offline-after/")
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["offline_after"] == 21600
+    assert r.data["editable"] is False
+
+    api_client.force_authenticate(user=owner)
+    r = api_client.get(f"/api/monitoring/nodes/{obs.internal_id}/offline-after/")
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["editable"] is True
+
+
+@pytest.mark.django_db
+def test_monitoring_offline_after_patch_forbidden_for_non_owner(api_client, create_user, create_observed_node):
+    owner = create_user()
+    other = create_user()
+    obs = create_observed_node(claimed_by=owner)
+    api_client.force_authenticate(user=other)
+    r = api_client.patch(
+        f"/api/monitoring/nodes/{obs.internal_id}/offline-after/",
+        {"offline_after": 120},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
@@ -110,10 +155,12 @@ def test_watch_duplicate(api_client, create_user, create_observed_node):
 
 @pytest.mark.django_db
 def test_watch_other_user_404(api_client, create_user, create_observed_node):
+    from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
+
     owner = create_user()
     other = create_user()
     obs = create_observed_node(claimed_by=owner)
-    w = NodeWatch.objects.create(user=owner, observed_node=obs, offline_after=60, enabled=True)
+    w = create_watch_with_offline_threshold(user=owner, observed_node=obs, offline_after=60)
 
     api_client.force_authenticate(user=other)
     r = api_client.get(f"/api/monitoring/watches/{w.pk}/")

--- a/Meshflow/mesh_monitoring/urls.py
+++ b/Meshflow/mesh_monitoring/urls.py
@@ -4,11 +4,16 @@ from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
 
-from mesh_monitoring.views import NodeWatchViewSet
+from mesh_monitoring.views import NodeMonitoringOfflineAfterView, NodeWatchViewSet
 
 router = DefaultRouter()
 router.register(r"watches", NodeWatchViewSet, basename="nodewatch")
 
 urlpatterns = [
+    path(
+        "nodes/<uuid:observed_node_id>/offline-after/",
+        NodeMonitoringOfflineAfterView.as_view(),
+        name="monitoring-node-offline-after",
+    ),
     path("", include(router.urls)),
 ]

--- a/Meshflow/mesh_monitoring/views.py
+++ b/Meshflow/mesh_monitoring/views.py
@@ -1,9 +1,56 @@
 """REST API for mesh monitoring."""
 
-from rest_framework import permissions, viewsets
+from django.shortcuts import get_object_or_404
 
-from mesh_monitoring.models import NodeWatch
-from mesh_monitoring.serializers import NodeWatchSerializer
+from rest_framework import permissions, status, views, viewsets
+from rest_framework.response import Response
+
+from mesh_monitoring.models import NodePresence, NodeWatch
+from mesh_monitoring.permission_helpers import user_can_edit_monitoring_offline_after
+from mesh_monitoring.serializers import NodePresenceOfflineAfterSerializer, NodeWatchSerializer
+from nodes.models import ObservedNode
+
+
+class NodeMonitoringOfflineAfterView(views.APIView):
+    """
+    Read or update the node-level silence threshold (NodePresence.offline_after).
+
+    GET/PATCH /api/monitoring/nodes/{observed_node_id}/offline-after/
+    observed_node_id is ObservedNode.internal_id (UUID).
+    """
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get(self, request, observed_node_id):
+        node = get_object_or_404(ObservedNode, pk=observed_node_id)
+        presence, _ = NodePresence.objects.get_or_create(
+            observed_node=node,
+            defaults={"is_offline": False},
+        )
+        return Response(
+            {
+                "offline_after": presence.offline_after,
+                "editable": user_can_edit_monitoring_offline_after(request.user, node),
+            },
+        )
+
+    def patch(self, request, observed_node_id):
+        node = get_object_or_404(ObservedNode, pk=observed_node_id)
+        if not user_can_edit_monitoring_offline_after(request.user, node):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        presence, _ = NodePresence.objects.get_or_create(
+            observed_node=node,
+            defaults={"is_offline": False},
+        )
+        ser = NodePresenceOfflineAfterSerializer(presence, data=request.data, partial=True)
+        ser.is_valid(raise_exception=True)
+        ser.save()
+        return Response(
+            {
+                "offline_after": ser.instance.offline_after,
+                "editable": True,
+            },
+        )
 
 
 class NodeWatchViewSet(viewsets.ModelViewSet):
@@ -27,4 +74,8 @@ class NodeWatchViewSet(viewsets.ModelViewSet):
         )
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        watch = serializer.save(user=self.request.user)
+        NodePresence.objects.get_or_create(
+            observed_node=watch.observed_node,
+            defaults={"is_offline": False},
+        )

--- a/docs/features/mesh-monitoring/README.md
+++ b/docs/features/mesh-monitoring/README.md
@@ -12,6 +12,7 @@ This document describes the **intended design** (models, Celery, APIs, and integ
 | Verified Discord DMs (prefs, test, `push_notifications.discord`) | Shipped (`users` + `push_notifications`) |
 | Django app **`mesh_monitoring`** (`NodeWatch`, `NodePresence`), Celery **`process_node_watch_presence`**, `AutoTraceRoute.trigger_type=monitor`, hooks in **`packets`** + **`traceroute.target_selection`** | **Shipped** (phase 03b) |
 | Watch **REST** CRUD | **`GET/POST /api/monitoring/watches/`**, **`GET/PATCH/PUT/DELETE …/watches/{id}/`** — authenticated; see **`openapi.yaml`** (`Mesh Monitoring` tag) |
+| Node-level **`offline_after`** | **`GET/PATCH /api/monitoring/nodes/{internal_id}/offline-after/`** — staff or claim owner may PATCH |
 | **UI** (My Nodes watch toggles) | **meshtastic-bot-ui** My Nodes page + `meshtastic-api` client (phase 04) |
 
 Env: **`MESH_MONITORING_VERIFICATION_SECONDS`** (default `180`) for the verification window after silence.
@@ -26,7 +27,7 @@ A node is **watched** when there is at least one **`NodeWatch`** row: a user has
 
 - **Per-user:** Each watch is `(user, observed_node)` with a **unique** constraint.
 - **Eligibility** (who may create a watch): the user **claims** the node (`observed_node.claimed_by == user`) **or** the node’s **role** is in **`nodes.constants.INFRASTRUCTURE_ROLES`** (routers/repeaters/etc., shared with other product rules).
-- **Silence threshold:** Each watch has **`offline_after`** (e.g. default 2 hours). If several users watch the same node, the effective threshold is the **minimum** `offline_after` among **enabled** watches — one shared silence window per observed node.
+- **Silence threshold:** **`offline_after`** is stored once per observed node on **`NodePresence`** (seconds without **`last_heard`** before verification may start; default **6 hours** / 21600 s). Staff or the **claim owner** may edit it via **`GET/PATCH /api/monitoring/nodes/{internal_id}/offline-after/`**. **`NodeWatch`** responses still expose **`offline_after`** (read-only) for convenience.
 
 ### How watching works at runtime
 

--- a/docs/features/mesh-monitoring/README.md
+++ b/docs/features/mesh-monitoring/README.md
@@ -50,6 +50,7 @@ Any packet that advances **`last_heard`** should clear **`offline_confirmed_at`*
 
 | Doc | Contents |
 |-----|----------|
+| [permissions.md](permissions.md) | Who may **watch** a node vs who may change **`offline_after`** (staff / claim owner) |
 | [models.md](models.md) | **`NodeWatch`** and **`NodePresence`** fields and how they change at runtime |
 | [flow.md](flow.md) | Chronological sequence, state machine, component responsibilities |
 | [discord.md](discord.md) | How Discord alerts fit into monitoring (pointer to `docs/features/discord/`) |

--- a/docs/features/mesh-monitoring/flow.md
+++ b/docs/features/mesh-monitoring/flow.md
@@ -31,7 +31,7 @@ sequenceDiagram
   participant Disc as push_notifications_discord
 
   Celery->>DB: load ObservedNode watches NodePresence
-  Note over Celery: last_heard older than min offline_after
+  Note over Celery: last_heard older than NodePresence.offline_after
   Celery->>DB: set NodePresence.verification_started_at suspected_offline_at reset episode counters
   Celery->>DB: create AutoTraceRoute monitor rows
   loop Up to three sources staggered
@@ -61,7 +61,7 @@ flowchart TD
   start[Periodic_task_tick]
   start --> hasWatch{Any_enabled_NodeWatch_for_node}
   hasWatch -->|no| skip[Skip_node]
-  hasWatch -->|yes| effThreshold[Effective_threshold equals min offline_after]
+  hasWatch -->|yes| effThreshold[Threshold_is_NodePresence_offline_after]
   effThreshold --> stale{last_heard_null_or_before_now_minus_threshold}
   stale -->|no| online[State_online_or_idle]
   stale -->|yes| checkPresence{Already_offline_confirmed}

--- a/docs/features/mesh-monitoring/models.md
+++ b/docs/features/mesh-monitoring/models.md
@@ -6,14 +6,13 @@ Django app: **`meshflow.Meshflow.mesh_monitoring`**. These models support **sile
 
 ## `NodeWatch`
 
-A user opt-in to monitor one **`ObservedNode`**. Several watches can point at the same node; the periodic task uses the **minimum** `offline_after` among enabled watches as the effective silence threshold.
+A user opt-in to monitor one **`ObservedNode`**. Several watches can point at the same node; silence timing is **not** per watch — see **`NodePresence.offline_after`**.
 
 | Field | Type | Meaning |
 |-------|------|---------|
 | **`user`** | FK → `users.User` | Watcher who receives notifications when eligible. |
 | **`observed_node`** | FK → `nodes.ObservedNode` | Node being monitored. Unique per `(user, observed_node)`. |
-| **`offline_after`** | positive int (seconds) | How long **`ObservedNode.last_heard`** may be stale before verification may start. Default **7200** (2 hours). |
-| **`enabled`** | bool | When `False`, this watch does not contribute to thresholds or notifications. |
+| **`enabled`** | bool | When `False`, this watch does not contribute to notifications (and the node is not “watched” for monitoring ticks). |
 | **`created_at`** | datetime | Auto-set when the row is created. |
 
 **Validation:** On save, **`clean()`** ensures the user may watch that node (**claimed** node or **infrastructure** role); see `mesh_monitoring.eligibility.user_can_watch`.
@@ -22,15 +21,16 @@ A user opt-in to monitor one **`ObservedNode`**. Several watches can point at th
 
 ## `NodePresence`
 
-One row per observed node that participates in mesh monitoring (created lazily when a watched node is processed). Primary key is **`observed_node_id`** (same UUID as **`ObservedNode.internal_id`**); reverse relation from observed node: **`observed_node.mesh_presence`**.
+One row per observed node that participates in mesh monitoring (created lazily when a watched node is processed, or when the silence threshold API is used). Primary key is **`observed_node_id`** (same UUID as **`ObservedNode.internal_id`**); reverse relation from observed node: **`observed_node.mesh_presence`**.
 
-State is split into: **episode / observability** (current verification round), **confirmed offline** (deadline expired), and **summary flags** for operators.
+State is split into: **silence threshold**, **episode / observability** (current verification round), **confirmed offline** (deadline expired), and **summary flags** for operators.
 
 ### Core state
 
 | Field | Type | Meaning |
 |-------|------|---------|
 | **`observed_node`** | OneToOne → `ObservedNode` (PK) | The node this row describes. |
+| **`offline_after`** | positive int (seconds) | How long **`ObservedNode.last_heard`** may be stale before verification may start. Default **21600** (6 hours). |
 | **`verification_started_at`** | datetime, null | When the **current** verification window started (monitoring TR round). Null when not verifying. |
 | **`offline_confirmed_at`** | datetime, null | When the node was **confirmed offline** after the verification window passed without reachability proof. Cleared when the node is heard again. |
 

--- a/docs/features/mesh-monitoring/permissions.md
+++ b/docs/features/mesh-monitoring/permissions.md
@@ -1,0 +1,58 @@
+# Mesh monitoring — permissions
+
+Who may **subscribe** to alerts (create a **`NodeWatch`**) vs who may change the **node-level silence threshold** (**`NodePresence.offline_after`**) are different. Rules align with the [Mesh Monitoring epic](https://github.com/pskillen/meshflow-api/issues/147) and phase **04** watch APIs.
+
+Implementation lives in:
+
+- **`mesh_monitoring.eligibility.user_can_watch`** — create/update/delete watches (validated on **`NodeWatch.save()`** and in **`NodeWatchSerializer`**).
+- **`mesh_monitoring.permission_helpers.user_can_edit_monitoring_offline_after`** — **`GET/PATCH …/offline-after/`** (PATCH returns **403** when not allowed).
+
+---
+
+## Who may create or keep a watch on an observed node?
+
+A user may create a **`NodeWatch`** only if **either**:
+
+1. **Claim owner:** the user is **`observed_node.claimed_by`** (they have claimed that observed node), or  
+2. **Infrastructure node:** the observed node’s **`role`** is one of **`nodes.constants.INFRASTRUCTURE_ROLES`** (e.g. routers / repeaters — shared infrastructure on the map that anyone eligible to use the app may watch).
+
+Everyone else gets validation errors on create (and **`NodeWatch.clean()`** rejects ineligible pairs).
+
+**Notes**
+
+- Watches are **per user × observed node** (unique constraint). Each user opts in individually.
+- **Discord** delivery still requires a **verified** Discord binding for that user; that is separate from watch eligibility (see [Discord notifications](../discord/notifications.md)).
+
+---
+
+## Who may read or change the silence threshold (`offline_after`)?
+
+**`offline_after`** is stored on **`NodePresence`** (one value per observed node). It controls how long **`last_heard`** may be stale before a **verification traceroute** round may start.
+
+| Action | Who |
+|--------|-----|
+| **GET** `…/monitoring/nodes/{internal_id}/offline-after/` | Any **authenticated** user. Response includes **`offline_after`** and **`editable`** (whether this user may PATCH). |
+| **PATCH** same URL | **Django staff** (`user.is_staff`, “system admin” / admin-site staff) **or** the **claim owner** (`observed_node.claimed_by == user`). **403** otherwise. |
+
+**Not** eligible to PATCH:
+
+- Users who only have a **watch** on an **infrastructure** node but are not staff (infrastructure nodes are often **unclaimed**; threshold is staff-only until product adds e.g. constellation-admin rules).
+- Other authenticated users with no claim and not staff.
+
+---
+
+## Watch API vs offline-after API
+
+| Endpoint | Auth | Extra rules |
+|----------|------|----------------|
+| **`/api/monitoring/watches/`** (CRUD) | Authenticated | Create: **`user_can_watch`**. List/detail/update/delete: only the **owning** user’s watches. |
+| **`/api/monitoring/nodes/{id}/offline-after/`** | Authenticated | PATCH: **`user_can_edit_monitoring_offline_after`**. |
+
+---
+
+## UI expectations
+
+- **Watch toggles** (add / enable / remove): only where the user is allowed to watch (same rules as API).
+- **Silence threshold editing**: treat as an **admin-style** control — expose only to users who would receive **`editable: true`** from GET (claim owner or staff); others may still **see** the current value when useful for context.
+
+For background on the wider epic (verification TRs, Discord), see the epic issue and [README.md](README.md).

--- a/docs/features/mesh-monitoring/permissions.md
+++ b/docs/features/mesh-monitoring/permissions.md
@@ -9,6 +9,21 @@ Implementation lives in:
 
 ---
 
+## Why these rules (design rationale)
+
+### Watching
+
+- **Infrastructure nodes** are explicitly shared infrastructure (routers, repeaters, etc.). There is no individual “owner privacy” in the same sense as a personal handset; watching them does not single out a person’s private device choice beyond what the mesh already exposes.
+- **All other (non‑infra) nodes** could raise **privacy** concerns if we let arbitrary users stack monitoring tooling on top of public mesh data. The underlying observations are already public in nature—operators choose to broadcast presence, messages, location, and so on—but we **avoid adding extra product surface** that could make it easier to track or pressure someone **without their participation**. Limiting watches to **people who have claimed the node** keeps “your own nodes are your own nodes”: the person who has identified themselves with that node controls monitoring opt‑in for that class of target.
+- **Your own nodes:** if you have **claimed** an observed node, you may watch it—aligned with ownership and consent to deeper tooling for radios you treat as yours.
+
+### Changing silence / threshold settings
+
+- **`offline_after`** applies to **every** enabled watch and the **whole** monitoring episode for that observed node (one **`NodePresence`** row per node). Changing it is not a personal preference for one subscriber; it changes behaviour for **all** watchers and for verification / offline semantics.
+- That calls for a **stronger gate** than “anyone who can watch”: only the **claim owner** (who speaks for that non‑infra node in the product) or **staff** (platform operators / “system admin” via Django’s **`is_staff`**) may **PATCH** the value. Others may still **GET** the number for context, with **`editable: false`** when they cannot change it.
+
+---
+
 ## Who may create or keep a watch on an observed node?
 
 A user may create a **`NodeWatch`** only if **either**:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -825,6 +825,10 @@ components:
           format: date-time
           nullable: true
           description: Present when mesh monitoring has confirmed offline after failed verification.
+        offline_after:
+          type: integer
+          description: >
+            Node-level silence threshold (seconds); stored on NodePresence. Duplicated here for convenience.
 
     NodeWatch:
       type: object
@@ -835,7 +839,10 @@ components:
           $ref: '#/components/schemas/ObservedNodeWatchSummary'
         offline_after:
           type: integer
-          description: Seconds without packets (last_heard) before verification may start.
+          readOnly: true
+          description: >
+            Node-level silence threshold (seconds without last_heard before verification may start);
+            same value as observed_node.offline_after. Edit via PATCH /monitoring/nodes/{id}/offline-after/.
         enabled:
           type: boolean
         created_at:
@@ -850,10 +857,6 @@ components:
           type: string
           format: uuid
           description: Target ObservedNode primary key (internal_id).
-        offline_after:
-          type: integer
-          minimum: 1
-          default: 7200
         enabled:
           type: boolean
           default: true
@@ -861,11 +864,26 @@ components:
     NodeWatchUpdate:
       type: object
       properties:
+        enabled:
+          type: boolean
+
+    NodeMonitoringOfflineAfter:
+      type: object
+      properties:
+        offline_after:
+          type: integer
+          description: Seconds without packets (last_heard) before verification may start.
+        editable:
+          type: boolean
+          description: Whether the current user may PATCH this value (staff or claim owner).
+
+    NodeMonitoringOfflineAfterPatch:
+      type: object
+      properties:
         offline_after:
           type: integer
           minimum: 1
-        enabled:
-          type: boolean
+      required: [offline_after]
 
     ObservedNodeEnvironmentSettingsPatch:
       type: object
@@ -4595,6 +4613,60 @@ paths:
                 $ref: '#/components/schemas/AutoTraceRoute'
         '404':
           description: Not found
+
+  /monitoring/nodes/{observed_node_id}/offline-after/:
+    parameters:
+      - name: observed_node_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+        description: ObservedNode primary key (internal_id)
+    get:
+      summary: Get node-level mesh monitoring silence threshold
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current threshold and whether the user may edit it
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeMonitoringOfflineAfter'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Observed node not found
+    patch:
+      summary: Update node-level silence threshold (NodePresence.offline_after)
+      description: >
+        Allowed for staff or the user who has claimed the observed node (claimed_by).
+      tags: [Mesh Monitoring]
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NodeMonitoringOfflineAfterPatch'
+      responses:
+        '200':
+          description: Updated threshold
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeMonitoringOfflineAfter'
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden (not claim owner or staff)
+        '404':
+          description: Observed node not found
 
   /monitoring/watches/:
     get:


### PR DESCRIPTION
## Summary

Moves mesh monitoring silence threshold **`offline_after`** from per-user **`NodeWatch`** to per-node **`NodePresence`** (default **21600s / 6h**), matching the product direction in [meshtastic-bot-ui#148](https://github.com/pskillen/meshtastic-bot-ui/issues/148).

Adds **`GET/PATCH /api/monitoring/nodes/{observed_node_id}/offline-after/`** (claim owner or staff). Watch CRUD is unchanged except **`offline_after`** is no longer writable on watch create/patch; the API still returns it read-only from presence.

**Documentation (same branch):**
- **`docs/features/mesh-monitoring/permissions.md`** — who can set offline threshold vs who can add watches, with design rationale; linked from the repo README where appropriate.
- Supporting docstrings on monitoring permission helpers where it helps reviewers.

## Companion

- UI PR: https://github.com/pskillen/meshtastic-bot-ui/pull/163

## Deploy notes

Deploy API before UI so the new routes and migration are live.