### PR TITLE
feat(monitoring): full ObservedNode on mesh watch API responses

### DIFF
--- a/Meshflow/mesh_monitoring/serializers.py
+++ b/Meshflow/mesh_monitoring/serializers.py
@@ -8,25 +8,30 @@ from mesh_monitoring.constants import DEFAULT_OFFLINE_AFTER_SECONDS
 from mesh_monitoring.eligibility import user_can_watch
 from mesh_monitoring.models import NodePresence, NodeWatch
 from nodes.models import ObservedNode
+from nodes.serializers import ObservedNodeSerializer
 
 
-class ObservedNodeWatchSummarySerializer(serializers.ModelSerializer):
-    """Minimal observed node + monitoring presence hints for watch payloads."""
+class ObservedNodeWatchSummarySerializer(ObservedNodeSerializer):
+    """
+    Observed node fields aligned with GET /nodes/observed-nodes/ plus mesh monitoring hints.
+
+    Used only on NodeWatch responses so dashboards can render charts and controls without N+1 fetches.
+    """
 
     monitoring_verification_started_at = serializers.SerializerMethodField()
     monitoring_offline_confirmed_at = serializers.SerializerMethodField()
     offline_after = serializers.SerializerMethodField()
 
-    class Meta:
-        model = ObservedNode
-        fields = [
-            "internal_id",
-            "node_id_str",
-            "long_name",
-            "last_heard",
-            "offline_after",
+    class Meta(ObservedNodeSerializer.Meta):
+        fields = list(ObservedNodeSerializer.Meta.fields) + [
             "monitoring_verification_started_at",
             "monitoring_offline_confirmed_at",
+            "offline_after",
+        ]
+        read_only_fields = list(ObservedNodeSerializer.Meta.read_only_fields) + [
+            "monitoring_verification_started_at",
+            "monitoring_offline_confirmed_at",
+            "offline_after",
         ]
 
     def get_monitoring_verification_started_at(self, obj):

--- a/Meshflow/mesh_monitoring/tests/test_watch_api.py
+++ b/Meshflow/mesh_monitoring/tests/test_watch_api.py
@@ -189,3 +189,5 @@ def test_watch_presence_hints(api_client, create_user, create_observed_node):
     )
     assert r.status_code == status.HTTP_201_CREATED
     assert r.data["observed_node"]["monitoring_verification_started_at"] is not None
+    assert r.data["observed_node"]["node_id"] == obs.node_id
+    assert "short_name" in r.data["observed_node"]

--- a/Meshflow/mesh_monitoring/views.py
+++ b/Meshflow/mesh_monitoring/views.py
@@ -69,7 +69,9 @@ class NodeWatchViewSet(viewsets.ModelViewSet):
         return (
             NodeWatch.objects.filter(user=self.request.user)
             .select_related("observed_node")
+            .select_related("observed_node__claimed_by")
             .select_related("observed_node__mesh_presence")
+            .select_related("observed_node__latest_status")
             .order_by("-created_at", "-id")
         )
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -799,36 +799,28 @@ components:
             Null when the user has no claim. Use accepted_at to distinguish pending vs accepted claims.
 
     ObservedNodeWatchSummary:
-      type: object
       description: >
-        Observed node fields included on NodeWatch responses for My Nodes / monitoring UI.
-      properties:
-        internal_id:
-          type: string
-          format: uuid
-        node_id_str:
-          type: string
-        long_name:
-          type: string
-          nullable: true
-        last_heard:
-          type: string
-          format: date-time
-          nullable: true
-        monitoring_verification_started_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Present when mesh monitoring is verifying reachability for this node.
-        monitoring_offline_confirmed_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Present when mesh monitoring has confirmed offline after failed verification.
-        offline_after:
-          type: integer
-          description: >
-            Node-level silence threshold (seconds); stored on NodePresence. Duplicated here for convenience.
+        Same fields as ObservedNode (aligned with GET /nodes/observed-nodes/) embedded on NodeWatch
+        responses, plus mesh monitoring hints so clients can render dashboards without N+1 node fetches.
+      allOf:
+        - $ref: '#/components/schemas/ObservedNode'
+        - type: object
+          properties:
+            monitoring_verification_started_at:
+              type: string
+              format: date-time
+              nullable: true
+              description: Present when mesh monitoring is verifying reachability for this node.
+            monitoring_offline_confirmed_at:
+              type: string
+              format: date-time
+              nullable: true
+              description: Present when mesh monitoring has confirmed offline after failed verification.
+            offline_after:
+              type: integer
+              description: >
+                Node-level silence threshold (seconds); stored on NodePresence. Duplicated here for
+                convenience; same value as top-level NodeWatch.offline_after.
 
     NodeWatch:
       type: object


### PR DESCRIPTION
## Summary

Extends `ObservedNodeWatchSummarySerializer` to inherit `ObservedNodeSerializer` so `GET/POST/PATCH /api/monitoring/watches/` embed the same observed-node fields as list/detail (position, metrics, owner, claim, etc.) plus existing mesh monitoring hints. Adds `select_related` for `observed_node__claimed_by` and `observed_node__latest_status` to avoid N+1 queries.

OpenAPI: `ObservedNodeWatchSummary` is now `allOf` `ObservedNode` + monitoring fields.

## Testing performed

- `python -m pytest mesh_monitoring/tests/test_watch_api.py -v`

## Related

- Companion UI: meshtastic-bot-ui branch `ui-145/pskillen/watched-nodes-dashboard`
- Tracking: pskillen/meshtastic-bot-ui#145