### PR TITLE
feat(traceroute): position on triggerable-nodes + permissions doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,7 @@ where the code deviates from openapi.yaml, the OpenAPI spec is often correct. Ch
 
 When asked to create a pull request description, follow the template at
 .github/pull_request_template.md, and output a markdown file named `tmp/PR.md`
+
+## Plan mode
+
+When creating a plan, Include that we should branch from the latest origin/main, do the work, commit, push, and open a PR. Use the github-personal MCP. the gh command is not available.

--- a/Meshflow/traceroute/permission_helpers.py
+++ b/Meshflow/traceroute/permission_helpers.py
@@ -3,7 +3,7 @@
 from django.db.models import OuterRef, Q, Subquery
 
 from constellations.models import ConstellationUserMembership
-from nodes.models import ManagedNode, ObservedNode
+from nodes.models import ManagedNode, NodeLatestStatus, ObservedNode
 
 from .source_eligibility import eligible_auto_traceroute_sources_queryset
 
@@ -53,7 +53,13 @@ def get_triggerable_nodes_queryset(user):
         qs = eligible.filter(Q(owner=user) | Q(constellation_id__in=constellation_ids)).distinct()
     obs_short = ObservedNode.objects.filter(node_id=OuterRef("node_id")).values("short_name")[:1]
     obs_long = ObservedNode.objects.filter(node_id=OuterRef("node_id")).values("long_name")[:1]
+    # Latest known position of the node's ObservedNode counterpart. Used by the UI
+    # to render triggerable sources on a map alongside the traceroute target.
+    latest_lat = NodeLatestStatus.objects.filter(node__node_id=OuterRef("node_id")).values("latitude")[:1]
+    latest_lng = NodeLatestStatus.objects.filter(node__node_id=OuterRef("node_id")).values("longitude")[:1]
     return qs.annotate(
         observed_short_name=Subquery(obs_short),
         observed_long_name=Subquery(obs_long),
+        observed_latitude=Subquery(latest_lat),
+        observed_longitude=Subquery(latest_lng),
     ).order_by("node_id")

--- a/Meshflow/traceroute/serializers.py
+++ b/Meshflow/traceroute/serializers.py
@@ -242,10 +242,19 @@ class TriggerableNodeSerializer(serializers.ModelSerializer):
     short_name = serializers.SerializerMethodField()
     long_name = serializers.SerializerMethodField()
     constellation = TracerouteListConstellationSerializer(read_only=True)
+    position = serializers.SerializerMethodField()
 
     class Meta:
         model = ManagedNode
-        fields = ["node_id", "node_id_str", "short_name", "long_name", "allow_auto_traceroute", "constellation"]
+        fields = [
+            "node_id",
+            "node_id_str",
+            "short_name",
+            "long_name",
+            "allow_auto_traceroute",
+            "constellation",
+            "position",
+        ]
         read_only_fields = fields
 
     def get_node_id_str(self, obj):
@@ -256,6 +265,17 @@ class TriggerableNodeSerializer(serializers.ModelSerializer):
 
     def get_long_name(self, obj):
         return getattr(obj, "observed_long_name", None) or obj.name
+
+    def get_position(self, obj):
+        # Prefer the latest observed position (annotated from NodeLatestStatus);
+        # fall back to the ManagedNode's configured default location so the UI
+        # can still place nodes that have never been heard.
+        lat = getattr(obj, "observed_latitude", None)
+        lng = getattr(obj, "observed_longitude", None)
+        if lat is None and lng is None:
+            lat = obj.default_location_latitude
+            lng = obj.default_location_longitude
+        return {"latitude": lat, "longitude": lng}
 
 
 class TriggerTracerouteSerializer(serializers.Serializer):

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -293,6 +293,35 @@ class TestTracerouteTriggerableNodes:
         assert "long_name" in node
         assert "allow_auto_traceroute" in node
         assert "constellation" in node
+        assert "position" in node
+        assert set(node["position"].keys()) == {"latitude", "longitude"}
+
+    def test_triggerable_nodes_position_prefers_latest_observed_location(
+        self, api_client, editor_user, editor_managed_node
+    ):
+        """position is populated from NodeLatestStatus when the node has been heard."""
+        from nodes.models import NodeLatestStatus, ObservedNode
+
+        observed, _ = ObservedNode.objects.get_or_create(node_id=editor_managed_node.node_id)
+        NodeLatestStatus.objects.update_or_create(node=observed, defaults={"latitude": 55.86, "longitude": -4.25})
+        api_client.force_authenticate(user=editor_user)
+        resp = api_client.get("/api/traceroutes/triggerable-nodes/")
+        assert resp.status_code == 200
+        node = next(n for n in resp.json() if n["node_id"] == editor_managed_node.node_id)
+        assert node["position"] == {"latitude": 55.86, "longitude": -4.25}
+
+    def test_triggerable_nodes_position_falls_back_to_default_location(
+        self, api_client, editor_user, editor_managed_node
+    ):
+        """When no latest-observed position exists, fall back to ManagedNode default_location_*."""
+        editor_managed_node.default_location_latitude = 51.5
+        editor_managed_node.default_location_longitude = -0.12
+        editor_managed_node.save(update_fields=["default_location_latitude", "default_location_longitude"])
+        api_client.force_authenticate(user=editor_user)
+        resp = api_client.get("/api/traceroutes/triggerable-nodes/")
+        assert resp.status_code == 200
+        node = next(n for n in resp.json() if n["node_id"] == editor_managed_node.node_id)
+        assert node["position"] == {"latitude": 51.5, "longitude": -0.12}
 
     def test_triggerable_nodes_excludes_without_recent_ingestion(self, api_client, staff_user, create_managed_node):
         """Nodes with allow_auto_traceroute but no recent PacketObservation as observer are omitted."""

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -62,6 +62,7 @@ Auto-scheduler and permission checks share one notion of a **live** source node 
 
 ## Related Documentation
 
+- [Permissions](permissions.md) – Canonical rules for who may view and trigger traceroutes
 - [Flow](flow.md) – End-to-end lifecycle from trigger to completion
 - [Heatmap](heatmap.md) – Neo4j schema, heatmap-edges API, visualization
 - [Mesh monitoring](../mesh-monitoring/README.md) – watches, verification rounds, `pick_traceroute_target` exclusion for nodes under monitoring

--- a/docs/features/traceroute/permissions.md
+++ b/docs/features/traceroute/permissions.md
@@ -1,0 +1,132 @@
+# Traceroute Permissions
+
+Canonical reference for who can see traceroutes and who can trigger them. If the
+OpenAPI spec or code drifts from this document, the rules here are the intended
+contract; update the code (or this document) until they agree.
+
+## Principles
+
+1. **Visibility is open to any authenticated user.** Any logged-in user can
+   browse the traceroute list, fetch detail records, and view the heatmap. This
+   mirrors how observed packets are treated: once a traceroute has happened on
+   the mesh, it is considered public mesh telemetry.
+2. **Triggering is privileged and tied to a source node.** A user may trigger a
+   traceroute only from a `ManagedNode` they have a meaningful relationship
+   with (they own it, they administer the constellation it belongs to, or they
+   are a system administrator).
+3. **A source node must be capable of sourcing a traceroute.** It must have
+   `allow_auto_traceroute=True` and must have been recently seen reporting
+   packets (i.e. the bot behind it is online). Nodes that are offline or have
+   opted out are excluded from the triggerable set.
+4. **Rate limits are enforced at the API, not at the UI.** The Meshtastic radio
+   firmware only tolerates one traceroute every ~30 seconds. The API enforces
+   the same minimum interval per source node and returns a 429 when exceeded.
+5. **The API is always authoritative.** UI clients may hide affordances when the
+   user cannot trigger, but a client-side check is never a substitute for the
+   server's answer. Any trigger request is re-validated end-to-end.
+
+## Roles and who may trigger
+
+| Role                            | May trigger from                                                                            |
+| ------------------------------- | ------------------------------------------------------------------------------------------- |
+| System administrator (`is_staff`) | Any `ManagedNode` that is eligible (allow_auto_traceroute and recently heard)             |
+| `ManagedNode` owner             | Nodes they own (`ManagedNode.owner == user`), subject to eligibility                        |
+| Constellation admin / editor    | Nodes in constellations where the user has `admin` or `editor` role, subject to eligibility |
+| Constellation viewer            | Cannot trigger                                                                              |
+| Authenticated but none of above | Cannot trigger                                                                              |
+| Anonymous                       | Cannot view or trigger                                                                      |
+
+"Eligibility" for a source node means:
+
+- `allow_auto_traceroute=True`, and
+- The node has reported packets recently enough to be considered live — see
+  `eligible_auto_traceroute_sources_queryset` in
+  [`Meshflow/traceroute/source_eligibility.py`](../../../Meshflow/traceroute/source_eligibility.py)
+  and its canonical definition in `nodes.managed_node_liveness`.
+
+## Endpoints
+
+All endpoints require authentication unless otherwise stated.
+
+| Endpoint                              | Method | Permission                                                                                                                             |
+| ------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/traceroutes/`                   | GET    | Any authenticated user. Supports filters: `managed_node`, `source_node`, `target_node`, `status`, `trigger_type`, `triggered_after/before`. |
+| `/api/traceroutes/<pk>/`              | GET    | Any authenticated user.                                                                                                                |
+| `/api/traceroutes/trigger/`           | POST   | Authenticated user who passes `CanTriggerTraceroute` (see below).                                                                       |
+| `/api/traceroutes/can_trigger/`       | GET    | Any authenticated user. Returns `{"can_trigger": bool}`.                                                                               |
+| `/api/traceroutes/triggerable-nodes/` | GET    | Any authenticated user. Returns the user's triggerable `ManagedNode` set (may be empty).                                               |
+| `/api/traceroutes/heatmap-edges/`     | GET    | Any authenticated user.                                                                                                                |
+
+### Payload: `POST /api/traceroutes/trigger/`
+
+```json
+{
+  "managed_node_id": 123456789,
+  "target_node_id": 987654321
+}
+```
+
+- `managed_node_id` (required): `ManagedNode.node_id` of the source.
+- `target_node_id` (optional): `ObservedNode.node_id` of the target. When
+  omitted, the server picks a target via
+  `pick_traceroute_target(source_node)`.
+
+### Checks performed on POST (in order)
+
+1. **Authentication** – `IsAuthenticated`.
+2. **`CanTriggerTraceroute` (DRF permission)** – the user must have at least
+   one `ManagedNode` with `allow_auto_traceroute=True` that they own or are
+   admin/editor on. Recent-ingestion is deliberately not checked here, so
+   clients get a clearer error in step 4 rather than a generic 403.
+3. **Source node exists** – otherwise `404`.
+4. **`allow_auto_traceroute`** on the chosen node – otherwise `400`.
+5. **Eligibility** – the source must have recent ingestion via
+   `is_managed_node_eligible_traceroute_source`. Otherwise `400` with a message
+   pointing the user at the offline monitor.
+6. **Rate limit** – enforced with `MANUAL_TRIGGER_MIN_INTERVAL_SEC`. Returns
+   `429` with a `Try again in Ns` hint.
+7. **Per-node permission** – `user_can_trigger_from_node(user, source_node)`
+   re-validates the user/constellation relationship. Otherwise `403`.
+8. **Target** – if `target_node_id` is given, it must resolve to an
+   `ObservedNode`; otherwise `pick_traceroute_target` chooses one, and if it
+   cannot, the API returns `400` asking for `target_node_id`.
+
+## Triggerable nodes endpoint
+
+`GET /api/traceroutes/triggerable-nodes/` is the canonical data source for UI
+clients. The response is the intersection of:
+
+- **Eligible sources** (`allow_auto_traceroute=True` and recently heard), and
+- **Permission** (staff, owner, or constellation admin/editor).
+
+When this list is empty, the UI should hide all trigger affordances. The list
+has annotated `observed_short_name` / `observed_long_name` so the UI can label
+the source without a second round trip.
+
+## Client expectations
+
+- Any client may hide trigger buttons when
+  `GET /api/traceroutes/triggerable-nodes/` returns an empty array (or when
+  `GET /api/traceroutes/can_trigger/` returns `false`).
+- No client should assume a successful trigger based only on the UI state: the
+  API owns the final answer (ownership, rate limit, eligibility, target
+  resolution) and any of these checks can fail.
+- For pages that "trigger to a fixed target" (e.g. Node Details), only the
+  source picker needs to be shown; the `target_node_id` is set to the node
+  being viewed. Permissions and rate limits are unchanged.
+
+## Related code
+
+- [`Meshflow/traceroute/views.py`](../../../Meshflow/traceroute/views.py) –
+  `traceroute_list`, `traceroute_trigger`, `traceroute_can_trigger`,
+  `traceroute_triggerable_nodes`.
+- [`Meshflow/traceroute/permissions.py`](../../../Meshflow/traceroute/permissions.py) –
+  `CanTriggerTraceroute` DRF permission.
+- [`Meshflow/traceroute/permission_helpers.py`](../../../Meshflow/traceroute/permission_helpers.py) –
+  `user_can_trigger_from_node`, `get_nodes_permitted_for_trigger_queryset`,
+  `get_triggerable_nodes_queryset`.
+- [`Meshflow/traceroute/source_eligibility.py`](../../../Meshflow/traceroute/source_eligibility.py) –
+  eligibility helper (re-exports the canonical
+  `nodes.managed_node_liveness` functions).
+- [`Meshflow/traceroute/trigger_intervals.py`](../../../Meshflow/traceroute/trigger_intervals.py) –
+  `MANUAL_TRIGGER_MIN_INTERVAL_SEC`.

--- a/docs/features/traceroute/permissions.md
+++ b/docs/features/traceroute/permissions.md
@@ -99,9 +99,13 @@ clients. The response is the intersection of:
 - **Eligible sources** (`allow_auto_traceroute=True` and recently heard), and
 - **Permission** (staff, owner, or constellation admin/editor).
 
-When this list is empty, the UI should hide all trigger affordances. The list
-has annotated `observed_short_name` / `observed_long_name` so the UI can label
-the source without a second round trip.
+When this list is empty, the UI should hide all trigger affordances. The
+payload includes `short_name` / `long_name` (from the node's `ObservedNode`
+counterpart) and a `position` object so the UI can label and place each source
+on a map without a second round trip. `position` uses the latest observed
+`NodeLatestStatus` if available, otherwise falls back to the `ManagedNode`'s
+configured `default_location_*`; either coordinate may be `null` if no
+location has ever been recorded.
 
 ## Client expectations
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4507,7 +4507,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  required: [node_id, node_id_str, short_name, long_name, allow_auto_traceroute, constellation]
+                  required: [node_id, node_id_str, short_name, long_name, allow_auto_traceroute, constellation, position]
                   properties:
                     node_id:
                       type: integer
@@ -4528,6 +4528,17 @@ paths:
                           type: string
                         map_color:
                           type: string
+                    position:
+                      type: object
+                      description: Latest known position of the node's ObservedNode counterpart, falling back to the ManagedNode's configured default location. Both fields may be null if no location is known.
+                      required: [latitude, longitude]
+                      properties:
+                        latitude:
+                          type: number
+                          nullable: true
+                        longitude:
+                          type: number
+                          nullable: true
 
   /traceroutes/trigger/:
     post:


### PR DESCRIPTION
# Summary

Two small changes to support the Node Details traceroute UI in `meshtastic-bot-ui#166`:

1. **Add `position` to `GET /api/traceroutes/triggerable-nodes/`** so the UI can render triggerable source nodes on a map (the fixed-target Trigger TR modal on Node Details shows the target plus all available sources). Without this, the UI map silently skipped every source because `position` was undefined.
2. **Document canonical traceroute permissions** at `docs/features/traceroute/permissions.md` and link it from `docs/features/traceroute/README.md`.

## Changes

### API — triggerable-nodes payload

- `get_triggerable_nodes_queryset` now annotates each `ManagedNode` with `observed_latitude` / `observed_longitude` via a `NodeLatestStatus` subquery keyed on `node_id`.
- `TriggerableNodeSerializer` exposes a new `position: { latitude, longitude }` object. It prefers the latest observed position and falls back to the `ManagedNode`'s `default_location_latitude` / `default_location_longitude` so nodes that have never been heard still have a best-effort location. Either coordinate may be `null` if nothing is known.
- `openapi.yaml` updated; `position` is required in the response item (the coordinates inside it are nullable).

### Docs — canonical permissions

- New `docs/features/traceroute/permissions.md` describing principles, role matrix, endpoints, POST payload, checks performed, the triggerable-nodes contract (including the new `position` field), and client expectations.
- `docs/features/traceroute/README.md` links to it.

## Testing performed

- New/updated unit tests in `Meshflow/traceroute/tests/test_views.py`:
  - `test_triggerable_nodes_response_shape` now asserts `position` is present with `{latitude, longitude}` keys.
  - `test_triggerable_nodes_position_prefers_latest_observed_location` — creates a `NodeLatestStatus` for the node and checks the serializer returns it.
  - `test_triggerable_nodes_position_falls_back_to_default_location` — sets `ManagedNode.default_location_*` and checks the fallback path.
- `python -m pytest Meshflow/traceroute/tests/` — 63 passed locally.
- `black`, `isort`, `flake8` clean on the edited files (repo's `max-line-length=120`).

## Related

- Depended on by UI PR: pskillen/meshtastic-bot-ui#166 (closes pskillen/meshtastic-bot-ui#134)
