### PR TITLE
feat(traceroute): add by_target aggregate to /traceroutes/stats/

### DIFF
--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -586,3 +586,108 @@ class TestTracerouteStats:
         assert resp_filtered.status_code == 200
         rows_f = {r["managed_node_id"]: r for r in resp_filtered.json()["by_source"]}
         assert rows_f[str(mn.internal_id)]["total"] == 1
+
+    def test_stats_by_target_empty_when_no_traceroutes(
+        self,
+        api_client,
+        create_user,
+    ):
+        user = create_user()
+        api_client.force_authenticate(user=user)
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "by_target" in data
+        assert data["by_target"] == []
+
+    def test_stats_includes_by_target_for_two_targets(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn = create_managed_node(node_id=444_444_444)
+        on_a = create_observed_node(node_id=100_000_001, short_name="AAAA", long_name="Target A")
+        on_b = create_observed_node(node_id=100_000_002, short_name="BBBB", long_name="Target B")
+        api_client.force_authenticate(user=user)
+
+        # Target A: 2 completed, 1 failed -> success_rate 2/3
+        create_auto_traceroute(
+            source_node=mn, target_node=on_a, triggered_by=user, status=AutoTraceRoute.STATUS_COMPLETED
+        )
+        create_auto_traceroute(
+            source_node=mn, target_node=on_a, triggered_by=user, status=AutoTraceRoute.STATUS_COMPLETED
+        )
+        create_auto_traceroute(source_node=mn, target_node=on_a, triggered_by=user, status=AutoTraceRoute.STATUS_FAILED)
+        # Target B: 1 pending, 1 sent -> no finished runs, success_rate is null
+        create_auto_traceroute(
+            source_node=mn, target_node=on_b, triggered_by=user, status=AutoTraceRoute.STATUS_PENDING
+        )
+        create_auto_traceroute(source_node=mn, target_node=on_b, triggered_by=user, status=AutoTraceRoute.STATUS_SENT)
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "by_target" in data
+        by_node_id = {row["node_id"]: row for row in data["by_target"]}
+
+        row_a = by_node_id[on_a.node_id]
+        assert row_a["total"] == 3
+        assert row_a["completed"] == 2
+        assert row_a["failed"] == 1
+        assert row_a["success_rate"] == pytest.approx(2 / 3)
+        assert row_a["short_name"] == on_a.short_name
+        assert row_a["long_name"] == on_a.long_name
+        assert "node_id_str" in row_a
+
+        row_b = by_node_id[on_b.node_id]
+        assert row_b["total"] == 2
+        assert row_b["completed"] == 0
+        assert row_b["failed"] == 0
+        assert row_b["success_rate"] is None
+
+    def test_by_target_respects_triggered_at_after(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn = create_managed_node(node_id=555_555_555)
+        on = create_observed_node(node_id=200_000_001)
+        api_client.force_authenticate(user=user)
+
+        old_time = timezone.now() - timedelta(days=30)
+        tr_old = create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+        AutoTraceRoute.objects.filter(pk=tr_old.pk).update(triggered_at=old_time)
+
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_FAILED,
+        )
+
+        resp_all = api_client.get("/api/traceroutes/stats/")
+        rows_all = {r["node_id"]: r for r in resp_all.json()["by_target"]}
+        assert rows_all[on.node_id]["total"] == 2
+        assert rows_all[on.node_id]["completed"] == 1
+        assert rows_all[on.node_id]["failed"] == 1
+
+        since = (timezone.now() - timedelta(days=7)).isoformat()
+        resp_filtered = api_client.get("/api/traceroutes/stats/", {"triggered_at_after": since})
+        rows_f = {r["node_id"]: r for r in resp_filtered.json()["by_target"]}
+        assert rows_f[on.node_id]["total"] == 1
+        assert rows_f[on.node_id]["completed"] == 0
+        assert rows_f[on.node_id]["failed"] == 1

--- a/Meshflow/traceroute/views.py
+++ b/Meshflow/traceroute/views.py
@@ -408,6 +408,42 @@ def traceroute_stats(request):
         )
     by_source.sort(key=lambda x: (-x["total"], x["node_id_str"]))
 
+    # Per target observed node (same triggered_at window as qs)
+    by_target_rows = list(
+        qs.values("target_node_id").annotate(
+            total=Count("id"),
+            completed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_COMPLETED)),
+            failed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_FAILED)),
+        )
+    )
+    target_internal_ids = [r["target_node_id"] for r in by_target_rows]
+    observed_by_internal_id = {
+        o.internal_id: o for o in ObservedNode.objects.filter(internal_id__in=target_internal_ids)
+    }
+
+    by_target = []
+    for row in by_target_rows:
+        on = observed_by_internal_id.get(row["target_node_id"])
+        if on is None:
+            continue
+        completed_n = row["completed"]
+        failed_n = row["failed"]
+        finished = completed_n + failed_n
+        success_rate = None if finished == 0 else completed_n / finished
+        by_target.append(
+            {
+                "node_id": on.node_id,
+                "node_id_str": meshtastic_id_to_hex(on.node_id),
+                "short_name": on.short_name,
+                "long_name": on.long_name,
+                "total": row["total"],
+                "completed": completed_n,
+                "failed": failed_n,
+                "success_rate": success_rate,
+            }
+        )
+    by_target.sort(key=lambda x: (-x["total"], x["node_id_str"]))
+
     # Success over time: last 14 days, from StatsSnapshot or on-demand
     fourteen_days_ago = timezone.now() - timedelta(days=14)
     success_over_time = _get_success_over_time(fourteen_days_ago)
@@ -418,6 +454,7 @@ def traceroute_stats(request):
             "success_failure": success_failure,
             "top_routers": top_routers,
             "by_source": by_source,
+            "by_target": by_target,
             "success_over_time": success_over_time,
         }
     )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4263,8 +4263,8 @@ paths:
       description: >
         Returns traceroute stats for the given timeframe: sources (by trigger_type),
         success/failure counts, top routers (intermediate nodes), per-source managed node
-        totals (with success rate among finished runs only), and success over time (14d).
-        All authenticated users.
+        totals (with success rate among finished runs only), per-target observed node totals,
+        and success over time (14d). All authenticated users.
       tags: [Traceroutes]
       security:
         - BearerAuth: []
@@ -4283,7 +4283,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [sources, success_failure, top_routers, by_source, success_over_time]
+                required: [sources, success_failure, top_routers, by_source, by_target, success_over_time]
                 properties:
                   sources:
                     type: array
@@ -4347,6 +4347,49 @@ paths:
                           type: string
                         short_name:
                           type: string
+                        total:
+                          type: integer
+                          description: All runs in the period (any status).
+                        completed:
+                          type: integer
+                        failed:
+                          type: integer
+                        success_rate:
+                          type: number
+                          format: float
+                          nullable: true
+                          description: >
+                            Fraction of finished runs that completed successfully.
+                            Denominator is completed + failed only.
+                  by_target:
+                    type: array
+                    description: >
+                      One row per target ObservedNode in the filtered period, ordered by total
+                      runs descending. success_rate is completed / (completed + failed) when
+                      that sum is positive; null if there are no finished runs (pending/sent
+                      count toward total only).
+                    items:
+                      type: object
+                      required:
+                        - node_id
+                        - node_id_str
+                        - short_name
+                        - long_name
+                        - total
+                        - completed
+                        - failed
+                        - success_rate
+                      properties:
+                        node_id:
+                          type: integer
+                        node_id_str:
+                          type: string
+                        short_name:
+                          type: string
+                          nullable: true
+                        long_name:
+                          type: string
+                          nullable: true
                         total:
                           type: integer
                           description: All runs in the period (any status).


### PR DESCRIPTION
# Summary

Mirrors the existing `by_source` block on `/api/traceroutes/stats/`, keyed on the target `ObservedNode` instead of the source `ManagedNode`. Each row carries `total`, `completed`, `failed`, and `success_rate` (null when there are no finished runs), plus the target's `node_id`, `node_id_str`, `short_name`, and `long_name`.

Unblocks UI work in [pskillen/meshtastic-bot-ui#164](https://github.com/pskillen/meshtastic-bot-ui/issues/164) (top / least successful target stats cards).

No breaking changes; existing fields are unchanged.

Closes #173

## Testing performed

- Added `TestTracerouteStats` cases:
  - `test_stats_by_target_empty_when_no_traceroutes`
  - `test_stats_includes_by_target_for_two_targets` (mixed completed/failed/pending/sent)
  - `test_by_target_respects_triggered_at_after`
- Re-ran the full `traceroute/tests/test_views.py` suite (36 passed).
- Updated `openapi.yaml` `/traceroutes/stats/` schema and `required` list.