### PR TITLE
feat(nodes): expose managed-node status fields via include=status

### DIFF
--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -230,6 +230,11 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
     latest_air_quality_metrics = serializers.SerializerMethodField(read_only=True)
     latest_health_metrics = serializers.SerializerMethodField(read_only=True)
     latest_host_metrics = serializers.SerializerMethodField(read_only=True)
+    last_packet_ingested_at = serializers.DateTimeField(read_only=True, required=False, allow_null=True)
+    packets_last_hour = serializers.IntegerField(read_only=True, required=False)
+    packets_last_24h = serializers.IntegerField(read_only=True, required=False)
+    radio_last_heard = serializers.DateTimeField(read_only=True, required=False, allow_null=True)
+    is_eligible_traceroute_source = serializers.BooleanField(read_only=True, required=False)
 
     class Meta:
         model = ManagedNode
@@ -252,6 +257,11 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             "latest_air_quality_metrics",
             "latest_health_metrics",
             "latest_host_metrics",
+            "last_packet_ingested_at",
+            "packets_last_hour",
+            "packets_last_24h",
+            "radio_last_heard",
+            "is_eligible_traceroute_source",
         ]
         read_only_fields = [
             "internal_id",
@@ -262,6 +272,20 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             "owner",
             "constellation",
         ]
+
+    STATUS_FIELDS = (
+        "last_packet_ingested_at",
+        "packets_last_hour",
+        "packets_last_24h",
+        "radio_last_heard",
+        "is_eligible_traceroute_source",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.context.get("include_status", False):
+            for field_name in self.STATUS_FIELDS:
+                self.fields.pop(field_name, None)
 
     def get_node_id_str(self, obj):
         if hasattr(obj, "node_id_str") and obj.node_id_str:

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -1,10 +1,12 @@
 from django.urls import reverse
+from django.utils import timezone
 
 import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
+from nodes.models import NodeLatestStatus
 
 
 @pytest.mark.django_db
@@ -38,6 +40,57 @@ def test_managed_node_detail_view(create_managed_node, create_user):
     response = client.get(reverse("managed-nodes-detail", kwargs={"node_id": node.node_id}))
     assert response.status_code == status.HTTP_200_OK
     assert response.data["node_id"] == node.node_id
+
+
+@pytest.mark.django_db
+def test_managed_nodes_status_fields_only_returned_with_include_status(
+    create_managed_node,
+    create_observed_node,
+    create_packet_observation,
+    create_user,
+):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+
+    now = timezone.now()
+    managed = create_managed_node(owner=user, node_id=123450001, allow_auto_traceroute=True)
+    observed = create_observed_node(
+        node_id=managed.node_id, node_id_str=meshtastic_id_to_hex(managed.node_id), last_heard=now
+    )
+    NodeLatestStatus.objects.create(node=observed)
+    observation = create_packet_observation(observer=managed)
+    observation.upload_time = now
+    observation.save(update_fields=["upload_time"])
+
+    list_url = reverse("managed-nodes-list")
+    response_without_status = client.get(list_url)
+    assert response_without_status.status_code == status.HTTP_200_OK
+    first_without_status = response_without_status.data["results"][0]
+    assert "last_packet_ingested_at" not in first_without_status
+    assert "packets_last_hour" not in first_without_status
+    assert "packets_last_24h" not in first_without_status
+    assert "radio_last_heard" not in first_without_status
+    assert "is_eligible_traceroute_source" not in first_without_status
+
+    response_with_status = client.get(list_url, {"include": "status"})
+    assert response_with_status.status_code == status.HTTP_200_OK
+    first_with_status = response_with_status.data["results"][0]
+    assert first_with_status["last_packet_ingested_at"] is not None
+    assert first_with_status["packets_last_hour"] == 1
+    assert first_with_status["packets_last_24h"] == 1
+    assert first_with_status["radio_last_heard"] is not None
+    assert first_with_status["is_eligible_traceroute_source"] is True
+
+    detail_url = reverse("managed-nodes-detail", kwargs={"node_id": managed.node_id})
+    detail_response = client.get(detail_url, {"include": "status"})
+    assert detail_response.status_code == status.HTTP_200_OK
+    assert detail_response.data["packets_last_hour"] == 1
+
+    mine_url = reverse("managed-nodes-mine")
+    mine_response = client.get(mine_url, {"include": "status"})
+    assert mine_response.status_code == status.HTTP_200_OK
+    assert mine_response.data["results"][0]["packets_last_24h"] == 1
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -1,6 +1,19 @@
 from datetime import datetime, timedelta
 
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import (
+    BooleanField,
+    Case,
+    Count,
+    DateTimeField,
+    Exists,
+    IntegerField,
+    OuterRef,
+    Q,
+    Subquery,
+    Value,
+    When,
+)
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
@@ -13,6 +26,7 @@ from rest_framework.views import APIView
 from common.mesh_node_helpers import meshtastic_hex_to_int
 from constellations.models import ConstellationUserMembership
 from nodes.constants import INFRASTRUCTURE_ROLES
+from nodes.managed_node_liveness import schedule_traceroute_source_recency_seconds
 from nodes.models import (
     DeviceMetrics,
     EnvironmentExposure,
@@ -48,6 +62,7 @@ from nodes.serializers import (
 )
 from nodes.services.device_metrics import get_device_metrics_bulk
 from nodes.services.environment_metrics import get_environment_metrics_bulk
+from packets.models import PacketObservation
 
 from .utils import generate_claim_key
 
@@ -747,37 +762,95 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
     serializer_class = ManagedNodeSerializer
     lookup_field = "node_id"
 
-    def get_queryset(self):
-        """Filter nodes based on user ownership and annotate with observed node and NodeLatestStatus."""
+    def _status_requested(self):
+        include_values = _multi_query_strings(self.request, "include")
+        return "status" in {value.lower() for value in include_values}
+
+    def _annotate_common_fields(self, queryset):
         observed_node_qs = ObservedNode.objects.filter(node_id=OuterRef("node_id"))
         latest_status_qs = NodeLatestStatus.objects.filter(node__node_id=OuterRef("node_id"))
-
-        return (
-            ManagedNode.objects.all()
-            .order_by("node_id")
-            .annotate(
-                long_name=Subquery(observed_node_qs.values("long_name")[:1]),
-                short_name=Subquery(observed_node_qs.values("short_name")[:1]),
-                last_heard=Subquery(observed_node_qs.values("last_heard")[:1]),
-                last_latitude=Subquery(latest_status_qs.values("latitude")[:1]),
-                last_longitude=Subquery(latest_status_qs.values("longitude")[:1]),
-                last_altitude=Subquery(latest_status_qs.values("altitude")[:1]),
-                last_position_time=Subquery(latest_status_qs.values("position_reported_time")[:1]),
-                last_heading=Subquery(latest_status_qs.values("heading")[:1]),
-                last_location_source=Subquery(latest_status_qs.values("location_source")[:1]),
-                last_precision_bits=Subquery(latest_status_qs.values("precision_bits")[:1]),
-                last_ground_speed=Subquery(latest_status_qs.values("ground_speed")[:1]),
-                last_ground_track=Subquery(latest_status_qs.values("ground_track")[:1]),
-                last_sats_in_view=Subquery(latest_status_qs.values("sats_in_view")[:1]),
-                last_pdop=Subquery(latest_status_qs.values("pdop")[:1]),
-                last_battery_level=Subquery(latest_status_qs.values("battery_level")[:1]),
-                last_voltage=Subquery(latest_status_qs.values("voltage")[:1]),
-                last_metrics_time=Subquery(latest_status_qs.values("metrics_reported_time")[:1]),
-                last_channel_utilization=Subquery(latest_status_qs.values("channel_utilization")[:1]),
-                last_air_util_tx=Subquery(latest_status_qs.values("air_util_tx")[:1]),
-                last_uptime_seconds=Subquery(latest_status_qs.values("uptime_seconds")[:1]),
-            )
+        return queryset.annotate(
+            long_name=Subquery(observed_node_qs.values("long_name")[:1]),
+            short_name=Subquery(observed_node_qs.values("short_name")[:1]),
+            last_heard=Subquery(observed_node_qs.values("last_heard")[:1]),
+            last_latitude=Subquery(latest_status_qs.values("latitude")[:1]),
+            last_longitude=Subquery(latest_status_qs.values("longitude")[:1]),
+            last_altitude=Subquery(latest_status_qs.values("altitude")[:1]),
+            last_position_time=Subquery(latest_status_qs.values("position_reported_time")[:1]),
+            last_heading=Subquery(latest_status_qs.values("heading")[:1]),
+            last_location_source=Subquery(latest_status_qs.values("location_source")[:1]),
+            last_precision_bits=Subquery(latest_status_qs.values("precision_bits")[:1]),
+            last_ground_speed=Subquery(latest_status_qs.values("ground_speed")[:1]),
+            last_ground_track=Subquery(latest_status_qs.values("ground_track")[:1]),
+            last_sats_in_view=Subquery(latest_status_qs.values("sats_in_view")[:1]),
+            last_pdop=Subquery(latest_status_qs.values("pdop")[:1]),
+            last_battery_level=Subquery(latest_status_qs.values("battery_level")[:1]),
+            last_voltage=Subquery(latest_status_qs.values("voltage")[:1]),
+            last_metrics_time=Subquery(latest_status_qs.values("metrics_reported_time")[:1]),
+            last_channel_utilization=Subquery(latest_status_qs.values("channel_utilization")[:1]),
+            last_air_util_tx=Subquery(latest_status_qs.values("air_util_tx")[:1]),
+            last_uptime_seconds=Subquery(latest_status_qs.values("uptime_seconds")[:1]),
         )
+
+    def _annotate_status_fields(self, queryset):
+        now = timezone.now()
+        hour_cutoff = now - timedelta(hours=1)
+        day_cutoff = now - timedelta(hours=24)
+        recent_cutoff = now - timedelta(seconds=schedule_traceroute_source_recency_seconds())
+
+        packet_observation_qs = PacketObservation.objects.filter(observer_id=OuterRef("pk"))
+        observed_node_qs = ObservedNode.objects.filter(node_id=OuterRef("node_id"))
+
+        last_packet_subquery = packet_observation_qs.order_by("-upload_time").values("upload_time")[:1]
+        packets_last_hour_subquery = (
+            packet_observation_qs.filter(upload_time__gte=hour_cutoff)
+            .values("observer")
+            .annotate(c=Count("id"))
+            .values("c")[:1]
+        )
+        packets_last_24h_subquery = (
+            packet_observation_qs.filter(upload_time__gte=day_cutoff)
+            .values("observer")
+            .annotate(c=Count("id"))
+            .values("c")[:1]
+        )
+        eligible_observation_exists = Exists(packet_observation_qs.filter(upload_time__gte=recent_cutoff))
+
+        return queryset.annotate(
+            last_packet_ingested_at=Subquery(last_packet_subquery, output_field=DateTimeField()),
+            packets_last_hour=Coalesce(
+                Subquery(packets_last_hour_subquery, output_field=IntegerField()),
+                Value(0),
+            ),
+            packets_last_24h=Coalesce(
+                Subquery(packets_last_24h_subquery, output_field=IntegerField()),
+                Value(0),
+            ),
+            radio_last_heard=Subquery(observed_node_qs.values("last_heard")[:1], output_field=DateTimeField()),
+            is_eligible_traceroute_source=Case(
+                When(allow_auto_traceroute=True, then=eligible_observation_exists),
+                default=Value(False),
+                output_field=BooleanField(),
+            ),
+        )
+
+    def _managed_nodes_queryset(self, owner=None):
+        queryset = ManagedNode.objects.all().order_by("node_id")
+        if owner is not None:
+            queryset = queryset.filter(owner=owner)
+        queryset = self._annotate_common_fields(queryset)
+        if self._status_requested():
+            queryset = self._annotate_status_fields(queryset)
+        return queryset
+
+    def get_queryset(self):
+        """Filter nodes based on user ownership and annotate with observed node and NodeLatestStatus."""
+        return self._managed_nodes_queryset()
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["include_status"] = self._status_requested()
+        return context
 
     def get_serializer_class(self):
         """Return different serializers based on the action."""
@@ -820,25 +893,7 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
         """
         Get all managed nodes owned by the current user.
         """
-        observed_node_qs = ObservedNode.objects.filter(node_id=OuterRef("node_id"))
-        latest_status_qs = NodeLatestStatus.objects.filter(node__node_id=OuterRef("node_id"))
-
-        nodes = (
-            ManagedNode.objects.filter(owner=request.user)
-            .order_by("node_id")
-            .annotate(
-                long_name=Subquery(observed_node_qs.values("long_name")[:1]),
-                short_name=Subquery(observed_node_qs.values("short_name")[:1]),
-                last_heard=Subquery(observed_node_qs.values("last_heard")[:1]),
-                last_latitude=Subquery(latest_status_qs.values("latitude")[:1]),
-                last_longitude=Subquery(latest_status_qs.values("longitude")[:1]),
-                last_altitude=Subquery(latest_status_qs.values("altitude")[:1]),
-                last_position_time=Subquery(latest_status_qs.values("position_reported_time")[:1]),
-                last_battery_level=Subquery(latest_status_qs.values("battery_level")[:1]),
-                last_voltage=Subquery(latest_status_qs.values("voltage")[:1]),
-                last_metrics_time=Subquery(latest_status_qs.values("metrics_reported_time")[:1]),
-            )
-        )
+        nodes = self._managed_nodes_queryset(owner=request.user)
 
         page = self.paginate_queryset(nodes)
         if page is not None:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1323,6 +1323,30 @@ components:
           type: boolean
           description: If true, this node may be used for auto-scheduled traceroutes and manual triggers
           default: false
+        last_packet_ingested_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: Included when include=status. Last packet ingestion timestamp where this node was observer.
+          readOnly: true
+        packets_last_hour:
+          type: integer
+          description: Included when include=status. Number of packet observations in the last hour.
+          readOnly: true
+        packets_last_24h:
+          type: integer
+          description: Included when include=status. Number of packet observations in the last 24 hours.
+          readOnly: true
+        radio_last_heard:
+          type: string
+          format: date-time
+          nullable: true
+          description: Included when include=status. ObservedNode last_heard matched by node_id.
+          readOnly: true
+        is_eligible_traceroute_source:
+          type: boolean
+          description: Included when include=status. True when allow_auto_traceroute and recent packet ingestion.
+          readOnly: true
         position:
           type: object
           description: The latest known position of the node
@@ -3775,6 +3799,13 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PaginationPage'
         - $ref: '#/components/parameters/PaginationPageSize'
+        - name: include
+          in: query
+          required: false
+          description: Optional extras. Use include=status to add managed-node health fields.
+          schema:
+            type: string
+            enum: [status]
       responses:
         '200':
           description: List of managed nodes
@@ -3818,6 +3849,13 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PaginationPage'
         - $ref: '#/components/parameters/PaginationPageSize'
+        - name: include
+          in: query
+          required: false
+          description: Optional extras. Use include=status to add managed-node health fields.
+          schema:
+            type: string
+            enum: [status]
       responses:
         '200':
           description: List of managed nodes owned by the current user
@@ -3849,6 +3887,13 @@ paths:
           required: true
           schema:
             type: integer
+        - name: include
+          in: query
+          required: false
+          description: Optional extras. Use include=status to add managed-node health fields.
+          schema:
+            type: string
+            enum: [status]
       responses:
         '200':
           description: Node details (OwnedManagedNode shape for owner/staff; else ManagedNodeRead)


### PR DESCRIPTION
# Summary

- Extend managed-node list/detail/mine responses to support `?include=status` for feeder health metadata.
- Add annotated status fields (`last_packet_ingested_at`, packet-window counts, `radio_last_heard`, `is_eligible_traceroute_source`) without N+1 queries.
- Document the API contract in `openapi.yaml` and add view tests covering inclusion behaviour and computed status values.

## Testing performed

- `source venv/bin/activate && python -m pytest Meshflow/nodes/tests/test_node_views.py -q`
- `source venv/bin/activate && cd Meshflow && black nodes/views.py nodes/serializers.py nodes/tests/test_node_views.py`
- `source venv/bin/activate && cd Meshflow && isort nodes/views.py nodes/serializers.py nodes/tests/test_node_views.py`
- `source venv/bin/activate && cd Meshflow && flake8 nodes/views.py nodes/serializers.py nodes/tests/test_node_views.py`

Closes #175.