### PR TITLE
feat(rf-propagation): render pipeline (Site Planner, Celery, cache, retention)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,8 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r Meshflow/requirements.txt
-          pip install pytest pytest-django pytest-cov pytest-asyncio black isort flake8 flake8-quotes
+          pip install -r Meshflow/requirements.dev.txt
 
       - name: Run linting
         run: |

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,27 @@
             "env": {
                 "DJANGO_SETTINGS_MODULE": "Meshflow.settings.monolith"
             }
+        },
+        {
+            "name": "Celery RF worker (rf_renders queue)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "celery",
+            "args": [
+                "-A", "Meshflow",
+                "worker",
+                "-Q", "rf_renders",
+                "-l", "info",
+                "--concurrency=1",
+                "--pool=solo"
+            ],
+            "cwd": "${workspaceFolder}/Meshflow",
+            "python": "${workspaceFolder}/venv/bin/python",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "env": {
+                "DJANGO_SETTINGS_MODULE": "Meshflow.settings.monolith"
+            }
         }
     ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,8 @@ python manage.py migrate && python manage.py run_deploy_tasks
 Always update openapi.yaml when modifying API contract. openapi.yaml is the contract shared between API and clients;
 where the code deviates from openapi.yaml, the OpenAPI spec is often correct. Check for what to do if this happens.
 
-- **Redis**: logical database usage (Channels, Celery, cache, planned RF engine) is documented in **[docs/REDIS.md](docs/REDIS.md)**. Update that file when introducing a new Redis consumer or changing DB indices.
+- **Redis**: logical database usage (Channels, Celery, cache, RF engine) is documented in **[docs/REDIS.md](docs/REDIS.md)**. Update that file when introducing a new Redis consumer or changing DB indices.
+- **RF propagation**: the render pipeline (Site Planner engine, dedicated Celery worker, hash-based cache) is documented in **[docs/features/rf_propagation/README.md](docs/features/rf_propagation/README.md)**. Key env vars: `RF_PROPAGATION_ENGINE_URL`, `RF_PROPAGATION_IMAGE_TAG`, `RF_PROPAGATION_RENDER_VERSION`. Smoke-test the engine independently with `docker compose exec api curl http://rf-propagation:8080/docs` (root compose) or `http://site-planner:8080/docs` (Portainer).
 
 ## Source control
 

--- a/Meshflow/Meshflow/celery.py
+++ b/Meshflow/Meshflow/celery.py
@@ -8,4 +8,4 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "Meshflow.settings")
 
 app = Celery("Meshflow")
 app.config_from_object("django.conf:settings", namespace="CELERY")
-app.autodiscover_tasks(["traceroute", "stats", "mesh_monitoring"])
+app.autodiscover_tasks(["traceroute", "stats", "mesh_monitoring", "rf_propagation"])

--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -143,13 +143,27 @@ _celery_broker_url = f"redis://:{_redis_password}@{_redis_host}:{_redis_port}/1"
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", _celery_broker_url)
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
+# Route heavy RF propagation renders to a dedicated queue consumed by celery-rf-worker;
+# keep the default "celery" queue so the existing worker picks up everything else.
+CELERY_TASK_DEFAULT_QUEUE = "celery"
+CELERY_TASK_ROUTES = {
+    "nodes.tasks.render_rf_propagation": {"queue": "rf_renders"},
+}
 
-# RF propagation cached PNGs (on-disk; Celery worker writes in plan 2)
+# RF propagation cached PNGs (on-disk; written by the Celery worker).
 RF_PROPAGATION_ASSET_DIR = Path(
     os.environ.get("RF_PROPAGATION_ASSET_DIR", "/var/meshflow/generated-assets/rf-propagation")
 )
-# Reserved for plan 2 (Site Planner HTTP client)
+# Meshtastic Site Planner engine base URL (FastAPI service, see deployment/docker-compose.yaml).
 RF_PROPAGATION_ENGINE_URL = os.environ.get("RF_PROPAGATION_ENGINE_URL", "")
+# Bump this to invalidate every cached render (pipeline or post-processing change).
+RF_PROPAGATION_RENDER_VERSION = os.environ.get("RF_PROPAGATION_RENDER_VERSION", "1")
+# Default bbox radius around the tx (metres) when the profile does not specify one.
+RF_PROPAGATION_DEFAULT_RADIUS_M = int(os.environ.get("RF_PROPAGATION_DEFAULT_RADIUS_M", "20000"))
+# Upper bound (seconds) for polling engine job status inside the Celery task.
+RF_PROPAGATION_POLL_MAX_SECONDS = int(os.environ.get("RF_PROPAGATION_POLL_MAX_SECONDS", "300"))
+# Per-node retention: how many ``ready`` renders to keep on disk before GC.
+RF_PROPAGATION_READY_RETENTION = int(os.environ.get("RF_PROPAGATION_READY_RETENTION", "3"))
 
 # Django cache (Redis DB 2; channels use DB 0, Celery broker DB 1)
 _cache_url = f"redis://:{_redis_password}@{_redis_host}:{_redis_port}/2"

--- a/Meshflow/Meshflow/settings/test.py
+++ b/Meshflow/Meshflow/settings/test.py
@@ -32,3 +32,7 @@ LOGGING = {}
 # Disable CORS for tests
 CORS_ALLOWED_ORIGINS = []
 CORS_ALLOW_CREDENTIALS = False
+
+# Run Celery tasks synchronously in tests so `.delay()` invokes the task in-process.
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True

--- a/Meshflow/nodes/tests/test_rf_propagation.py
+++ b/Meshflow/nodes/tests/test_rf_propagation.py
@@ -369,6 +369,133 @@ def test_rf_propagation_recompute_cache_hit_reuses_asset(settings, create_observ
 
 
 @pytest.mark.django_db
+def test_rf_propagation_cancel_marks_in_flight_as_failed(create_observed_node, create_user, stub_render_task):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_816,
+        node_id_str=meshtastic_id_to_hex(812_812_816),
+        claimed_by=owner,
+    )
+    NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
+    client = APIClient()
+    client.force_authenticate(user=owner)
+
+    recompute_url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
+    cancel_url = reverse("observed-node-rf-propagation-cancel", kwargs={"node_id": node.node_id})
+
+    client.post(recompute_url, {}, format="json")
+    assert (
+        NodeRfPropagationRender.objects.filter(
+            observed_node=node,
+            status=NodeRfPropagationRender.Status.PENDING,
+        ).count()
+        == 1
+    )
+
+    response = client.post(cancel_url, {}, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["cancelled"] == 1
+
+    row = NodeRfPropagationRender.objects.get(observed_node=node)
+    assert row.status == NodeRfPropagationRender.Status.FAILED
+    assert row.error_message == "Cancelled by user"
+    assert row.completed_at is not None
+
+
+@pytest.mark.django_db
+def test_rf_propagation_cancel_is_noop_when_nothing_in_flight(create_observed_node, create_user):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_817,
+        node_id_str=meshtastic_id_to_hex(812_812_817),
+        claimed_by=owner,
+    )
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    cancel_url = reverse("observed-node-rf-propagation-cancel", kwargs={"node_id": node.node_id})
+
+    response = client.post(cancel_url, {}, format="json")
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["cancelled"] == 0
+
+
+@pytest.mark.django_db
+def test_rf_propagation_cancel_allows_new_recompute(create_observed_node, create_user, stub_render_task):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_818,
+        node_id_str=meshtastic_id_to_hex(812_812_818),
+        claimed_by=owner,
+    )
+    NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    recompute_url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
+    cancel_url = reverse("observed-node-rf-propagation-cancel", kwargs={"node_id": node.node_id})
+
+    first = client.post(recompute_url, {}, format="json")
+    assert first.status_code == status.HTTP_201_CREATED
+    client.post(cancel_url, {}, format="json")
+    second = client.post(recompute_url, {}, format="json")
+
+    assert second.status_code == status.HTTP_201_CREATED
+    # First row cancelled, second row freshly dispatched → 2 rows + 2 .delay() calls.
+    assert NodeRfPropagationRender.objects.filter(observed_node=node).count() == 2
+    assert stub_render_task.call_count == 2
+
+
+@pytest.mark.django_db
+def test_rf_propagation_delete_removes_non_ready_rows(create_observed_node, create_user):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_820,
+        node_id_str=meshtastic_id_to_hex(812_812_820),
+        claimed_by=owner,
+    )
+    NodeRfPropagationRender.objects.create(observed_node=node, status=NodeRfPropagationRender.Status.PENDING)
+    NodeRfPropagationRender.objects.create(
+        observed_node=node,
+        status=NodeRfPropagationRender.Status.FAILED,
+        error_message="boom",
+    )
+    ready = NodeRfPropagationRender.objects.create(
+        observed_node=node,
+        status=NodeRfPropagationRender.Status.READY,
+        asset_filename="h.png",
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("observed-node-rf-propagation-dismiss", kwargs={"node_id": node.node_id})
+    response = client.post(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["deleted"] == 2
+    # Only the ready row survives.
+    remaining = list(NodeRfPropagationRender.objects.filter(observed_node=node))
+    assert remaining == [ready]
+
+
+@pytest.mark.django_db
+def test_rf_propagation_delete_requires_edit_permission(create_observed_node, create_user):
+    owner = create_user()
+    stranger = create_user(username="stranger", email="stranger@example.com")
+    node = create_observed_node(
+        node_id=812_812_821,
+        node_id_str=meshtastic_id_to_hex(812_812_821),
+        claimed_by=owner,
+    )
+    NodeRfPropagationRender.objects.create(observed_node=node, status=NodeRfPropagationRender.Status.PENDING)
+    client = APIClient()
+    client.force_authenticate(user=stranger)
+    url = reverse("observed-node-rf-propagation-dismiss", kwargs={"node_id": node.node_id})
+    response = client.post(url)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert NodeRfPropagationRender.objects.filter(observed_node=node).count() == 1
+
+
+@pytest.mark.django_db
 def test_observed_node_detail_rf_flags(create_observed_node, create_user):
     owner = create_user()
     node = create_observed_node(

--- a/Meshflow/nodes/tests/test_rf_propagation.py
+++ b/Meshflow/nodes/tests/test_rf_propagation.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError
 from django.urls import reverse
@@ -9,6 +11,29 @@ from rest_framework.test import APIClient, APIRequestFactory
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import AntennaPattern, NodeRfProfile, NodeRfPropagationRender
 from nodes.serializers import NodeRfProfileSerializer
+
+
+@pytest.fixture
+def stub_render_task():
+    """Replace ``render_rf_propagation.delay`` with a no-op so endpoint tests
+    don't trigger the real engine via Celery ``ALWAYS_EAGER``."""
+    with patch("rf_propagation.tasks.render_rf_propagation.delay") as mock_delay:
+        yield mock_delay
+
+
+def _rf_profile_fields(**overrides):
+    data = {
+        "rf_latitude": 55.861,
+        "rf_longitude": -4.251,
+        "rf_altitude_m": 80.0,
+        "antenna_height_m": 6.0,
+        "antenna_gain_dbi": 3.0,
+        "tx_power_dbm": 27.0,
+        "rf_frequency_mhz": 869.525,
+        "antenna_pattern": AntennaPattern.OMNI,
+    }
+    data.update(overrides)
+    return data
 
 
 @pytest.mark.django_db
@@ -200,13 +225,14 @@ def test_rf_profile_patch_owner_staff_stranger_unauth(create_observed_node, crea
 
 
 @pytest.mark.django_db
-def test_rf_propagation_get_none_then_pending(create_observed_node, create_user):
+def test_rf_propagation_get_none_then_pending(create_observed_node, create_user, stub_render_task):
     owner = create_user()
     node = create_observed_node(
         node_id=810_810_810,
         node_id_str=meshtastic_id_to_hex(810_810_810),
         claimed_by=owner,
     )
+    NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
     client = APIClient()
     client.force_authenticate(user=owner)
     url = reverse("observed-node-rf-propagation", kwargs={"node_id": node.node_id})
@@ -218,6 +244,7 @@ def test_rf_propagation_get_none_then_pending(create_observed_node, create_user)
     r1 = client.post(rec_url, {}, format="json")
     assert r1.status_code == status.HTTP_201_CREATED
     assert r1.data["status"] == "pending"
+    assert stub_render_task.call_count == 1
 
     r2 = client.get(url)
     assert r2.status_code == status.HTTP_200_OK
@@ -241,19 +268,104 @@ def test_rf_propagation_recompute_forbidden_stranger(create_observed_node, creat
 
 
 @pytest.mark.django_db
-def test_rf_propagation_recompute_creates_row(create_observed_node, create_user):
+def test_rf_propagation_recompute_creates_row(create_observed_node, create_user, stub_render_task):
     owner = create_user()
     node = create_observed_node(
         node_id=812_812_812,
         node_id_str=meshtastic_id_to_hex(812_812_812),
         claimed_by=owner,
     )
+    NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
     client = APIClient()
     client.force_authenticate(user=owner)
     url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
     response = client.post(url, {}, format="json")
     assert response.status_code == status.HTTP_201_CREATED
     assert NodeRfPropagationRender.objects.filter(observed_node=node).count() == 1
+    stub_render_task.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_rf_propagation_recompute_400_when_no_profile(create_observed_node, create_user, stub_render_task):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_813,
+        node_id_str=meshtastic_id_to_hex(812_812_813),
+        claimed_by=owner,
+    )
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
+    response = client.post(url, {}, format="json")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    stub_render_task.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_rf_propagation_recompute_dedup_returns_in_flight(create_observed_node, create_user, stub_render_task):
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_814,
+        node_id_str=meshtastic_id_to_hex(812_812_814),
+        claimed_by=owner,
+    )
+    NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
+
+    first = client.post(url, {}, format="json")
+    assert first.status_code == status.HTTP_201_CREATED
+    second = client.post(url, {}, format="json")
+    assert second.status_code == status.HTTP_200_OK
+    assert second.data["created_at"] == first.data["created_at"]
+    assert second.data["input_hash"] == first.data["input_hash"]
+    assert NodeRfPropagationRender.objects.filter(observed_node=node).count() == 1
+    assert stub_render_task.call_count == 1
+
+
+@pytest.mark.django_db
+def test_rf_propagation_recompute_cache_hit_reuses_asset(settings, create_observed_node, create_user, stub_render_task):
+    import tempfile
+    from pathlib import Path
+
+    from rf_propagation.hashing import compute_input_hash
+    from rf_propagation.payload import build_request
+
+    owner = create_user()
+    node = create_observed_node(
+        node_id=812_812_815,
+        node_id_str=meshtastic_id_to_hex(812_812_815),
+        claimed_by=owner,
+    )
+    profile = NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
+
+    with tempfile.TemporaryDirectory() as tmp:
+        settings.RF_PROPAGATION_ASSET_DIR = tmp
+        payload = build_request(profile)
+        input_hash = compute_input_hash(profile, extras={"radius_m": int(payload["radius"])})
+        Path(tmp, f"{input_hash}.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        NodeRfPropagationRender.objects.create(
+            observed_node=node,
+            status=NodeRfPropagationRender.Status.READY,
+            input_hash=input_hash,
+            asset_filename=f"{input_hash}.png",
+            bounds_west=-5.0,
+            bounds_south=55.0,
+            bounds_east=-3.5,
+            bounds_north=56.5,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=owner)
+        url = reverse("observed-node-rf-propagation-recompute", kwargs={"node_id": node.node_id})
+        response = client.post(url, {}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["status"] == "ready"
+    assert response.data["input_hash"] == input_hash
+    assert response.data["asset_url"] is not None
+    stub_render_task.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -662,15 +662,90 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"], url_path="rf-propagation/recompute")
     def rf_propagation_recompute(self, request, node_id=None):
-        """Queue a new propagation render (worker wiring deferred to plan 2)."""
+        """Queue a new propagation render.
+
+        Dedup strategy:
+
+        1. If a ``ready`` render with a matching content hash already exists
+           (and its PNG is still on disk), reuse it — no new row.
+        2. Else if a ``pending``/``running`` render exists for this node,
+           return that row without enqueueing another task.
+        3. Otherwise create a new ``pending`` row and dispatch the Celery
+           task.
+        """
         node = self.get_object()
         if not user_can_edit_observed_node_rf_profile(request.user, node):
             raise PermissionDenied()
+
+        try:
+            profile = node.rf_profile
+        except NodeRfProfile.DoesNotExist:
+            return Response(
+                {"detail": "Set an RF profile before requesting a propagation render."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Compute hash + radius up front so cache lookup and eventual task agree.
+        from rf_propagation.hashing import compute_input_hash
+        from rf_propagation.payload import InvalidProfileError, build_request
+        from rf_propagation.tasks import render_rf_propagation
+
+        try:
+            payload = build_request(profile)
+        except InvalidProfileError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        input_hash = compute_input_hash(profile, extras={"radius_m": int(payload["radius"])})
+
+        asset_dir = Path(settings.RF_PROPAGATION_ASSET_DIR)
+        cache_hit = (
+            NodeRfPropagationRender.objects.filter(
+                status=NodeRfPropagationRender.Status.READY,
+                input_hash=input_hash,
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if cache_hit is not None and cache_hit.asset_filename:
+            if (asset_dir / cache_hit.asset_filename).is_file():
+                if cache_hit.observed_node_id == node.pk:
+                    ser = NodeRfPropagationRenderSerializer(cache_hit, context=self.get_serializer_context())
+                    return Response(ser.data, status=status.HTTP_200_OK)
+                row = NodeRfPropagationRender.objects.create(
+                    observed_node=node,
+                    status=NodeRfPropagationRender.Status.READY,
+                    input_hash=input_hash,
+                    asset_filename=cache_hit.asset_filename,
+                    bounds_west=cache_hit.bounds_west,
+                    bounds_south=cache_hit.bounds_south,
+                    bounds_east=cache_hit.bounds_east,
+                    bounds_north=cache_hit.bounds_north,
+                    completed_at=timezone.now(),
+                )
+                ser = NodeRfPropagationRenderSerializer(row, context=self.get_serializer_context())
+                return Response(ser.data, status=status.HTTP_201_CREATED)
+
+        in_flight = (
+            NodeRfPropagationRender.objects.filter(
+                observed_node=node,
+                status__in=[
+                    NodeRfPropagationRender.Status.PENDING,
+                    NodeRfPropagationRender.Status.RUNNING,
+                ],
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        if in_flight is not None:
+            ser = NodeRfPropagationRenderSerializer(in_flight, context=self.get_serializer_context())
+            return Response(ser.data, status=status.HTTP_200_OK)
+
         row = NodeRfPropagationRender.objects.create(
             observed_node=node,
             status=NodeRfPropagationRender.Status.PENDING,
+            input_hash=input_hash,
         )
-        # TODO(plan-2): enqueue render task
+        render_rf_propagation.delay(row.pk)
         ser = NodeRfPropagationRenderSerializer(row, context=self.get_serializer_context())
         return Response(ser.data, status=status.HTTP_201_CREATED)
 

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -660,6 +660,54 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         ser = NodeRfPropagationRenderSerializer(render, context=self.get_serializer_context())
         return Response(ser.data)
 
+    @action(detail=True, methods=["post"], url_path="rf-propagation/dismiss")
+    def rf_propagation_dismiss(self, request, node_id=None):
+        """Delete every non-``ready`` render row for this node.
+
+        Powers the UI "Cancel" (while ``pending``/``running``) and "Dismiss"
+        (while ``failed``) actions — the same discard semantics, one DELETE
+        endpoint. ``ready`` rows are preserved so the currently-served map
+        keeps working until the operator queues a fresh render.
+
+        The worker is resilient to the row vanishing mid-flight: it catches
+        ``DoesNotExist`` on pickup/status-check and returns without writing.
+        """
+        node = self.get_object()
+        if not user_can_edit_observed_node_rf_profile(request.user, node):
+            raise PermissionDenied()
+
+        deleted, _ = (
+            NodeRfPropagationRender.objects.filter(observed_node=node)
+            .exclude(status=NodeRfPropagationRender.Status.READY)
+            .delete()
+        )
+        return Response({"deleted": deleted}, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=["post"], url_path="rf-propagation/cancel")
+    def rf_propagation_cancel(self, request, node_id=None):
+        """Mark any in-flight (``pending``/``running``) renders for this node as failed.
+
+        Lets the user abandon a stuck render so the next ``recompute`` starts
+        fresh. The worker picks up the status flip on its next DB read and
+        bails without writing an asset (see ``render_rf_propagation``).
+        """
+        node = self.get_object()
+        if not user_can_edit_observed_node_rf_profile(request.user, node):
+            raise PermissionDenied()
+
+        cancelled = NodeRfPropagationRender.objects.filter(
+            observed_node=node,
+            status__in=[
+                NodeRfPropagationRender.Status.PENDING,
+                NodeRfPropagationRender.Status.RUNNING,
+            ],
+        ).update(
+            status=NodeRfPropagationRender.Status.FAILED,
+            error_message="Cancelled by user",
+            completed_at=timezone.now(),
+        )
+        return Response({"cancelled": cancelled}, status=status.HTTP_200_OK)
+
     @action(detail=True, methods=["post"], url_path="rf-propagation/recompute")
     def rf_propagation_recompute(self, request, node_id=None):
         """Queue a new propagation render.

--- a/Meshflow/requirements.dev.txt
+++ b/Meshflow/requirements.dev.txt
@@ -7,6 +7,7 @@ pytest-mock~=3.12
 pytest-factoryboy~=2.5
 factory-boy~=3.3
 coverage~=7.4
+respx~=0.23
 
 # Development tools
 black~=26.1

--- a/Meshflow/requirements.dev.txt
+++ b/Meshflow/requirements.dev.txt
@@ -12,6 +12,7 @@ respx~=0.23
 # Development tools
 black~=26.1
 flake8~=7.3
+flake8-quotes~=3.4
 isort~=8.0
 
 # live reload

--- a/Meshflow/requirements.txt
+++ b/Meshflow/requirements.txt
@@ -22,3 +22,8 @@ django-celery-beat~=2.7
 neo4j>=6.1.0
 h3~=4.1
 
+# RF propagation pipeline (Meshtastic Site Planner engine client + GeoTIFF→PNG)
+httpx~=0.28
+Pillow~=12.0
+tifffile~=2026.4
+

--- a/Meshflow/rf_propagation/__init__.py
+++ b/Meshflow/rf_propagation/__init__.py
@@ -1,0 +1,16 @@
+"""RF propagation render pipeline.
+
+This package wires the `meshflow-rf-propagation` (Meshtastic Site Planner)
+engine into the API via a dedicated Celery worker and a content-addressed
+render cache.
+
+Public submodules:
+
+- :mod:`rf_propagation.hashing` – SHA256 over a normalized RF profile.
+- :mod:`rf_propagation.bounds` – centre+radius to WGS84 bbox maths.
+- :mod:`rf_propagation.payload` – :class:`nodes.models.NodeRfProfile` to
+  Site Planner ``CoveragePredictionRequest``.
+- :mod:`rf_propagation.image` – GeoTIFF bytes to PNG bytes.
+- :mod:`rf_propagation.client` – thin httpx-based Site Planner client.
+- :mod:`rf_propagation.tasks` – the Celery render task itself.
+"""

--- a/Meshflow/rf_propagation/bounds.py
+++ b/Meshflow/rf_propagation/bounds.py
@@ -1,0 +1,64 @@
+"""Centre+radius to WGS84 bbox.
+
+Site Planner / SPLAT! outputs GeoTIFFs already in EPSG:4326, so we do not
+reproject — we only need the axis-aligned lat/lng bounding box that the
+Leaflet ``imageOverlay`` expects as ``[[south, west], [north, east]]``.
+
+The maths uses the standard small-distance approximation:
+
+.. math::
+
+   \\Delta\\mathrm{lat} = \\frac{r}{111{,}320\\,\\mathrm{m/deg}}
+
+   \\Delta\\mathrm{lng} = \\frac{r}{111{,}320 \\cdot \\cos(\\mathrm{lat})}
+
+This is accurate to well within a PNG pixel at the ≤20 km radii we use,
+which is the whole point of keeping this cheap and dependency-free.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+METRES_PER_DEGREE_LATITUDE = 111_320.0
+
+
+@dataclass(frozen=True)
+class Bbox:
+    """Axis-aligned WGS84 bounding box (degrees)."""
+
+    west: float
+    south: float
+    east: float
+    north: float
+
+    def as_tuple(self) -> tuple[float, float, float, float]:
+        return (self.west, self.south, self.east, self.north)
+
+
+def bbox_from_center(lat: float, lng: float, radius_m: float) -> Bbox:
+    """Return the WGS84 bbox centred on (``lat``, ``lng``) of radius ``radius_m``.
+
+    Clamps ``cos(lat)`` to avoid a zero divisor exactly at the poles; a caller
+    rendering at the pole has bigger problems than a slightly off east/west
+    edge, so we just guard the maths.
+    """
+
+    if radius_m <= 0:
+        raise ValueError("radius_m must be positive")
+    if not -90.0 <= lat <= 90.0:
+        raise ValueError(f"lat out of range: {lat}")
+    if not -180.0 <= lng <= 180.0:
+        raise ValueError(f"lng out of range: {lng}")
+
+    d_lat = radius_m / METRES_PER_DEGREE_LATITUDE
+    cos_lat = max(math.cos(math.radians(lat)), 1e-6)
+    d_lng = radius_m / (METRES_PER_DEGREE_LATITUDE * cos_lat)
+
+    return Bbox(
+        west=lng - d_lng,
+        south=lat - d_lat,
+        east=lng + d_lng,
+        north=lat + d_lat,
+    )

--- a/Meshflow/rf_propagation/client.py
+++ b/Meshflow/rf_propagation/client.py
@@ -1,0 +1,132 @@
+"""Thin HTTP client for Meshtastic Site Planner.
+
+We keep retries and polling cadence in the Celery task — this module only
+shapes the three HTTP calls and exposes a couple of typed exceptions the
+task can branch on (transient vs fatal).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class EngineError(RuntimeError):
+    """Base class for Site Planner engine errors."""
+
+
+class EngineTransientError(EngineError):
+    """HTTP 5xx / connection reset / timeout — the Celery task should retry."""
+
+
+class EngineFatalError(EngineError):
+    """The engine rejected the request (4xx, reported ``failed``, bad body)."""
+
+
+@dataclass(frozen=True)
+class SubmitResponse:
+    task_id: str
+
+
+# Site Planner's OpenAPI schema calls this ``/predict``; the upstream
+# pydantic docstring sometimes refers to ``/coverage``. We centralize the
+# path here so fixing that becomes a one-line change.
+PREDICT_PATH = "/predict"
+STATUS_PATH_TMPL = "/status/{task_id}"
+RESULT_PATH_TMPL = "/result/{task_id}"
+
+DEFAULT_CONNECT_TIMEOUT = 5.0
+DEFAULT_READ_TIMEOUT_SHORT = 30.0
+DEFAULT_READ_TIMEOUT_RESULT = 120.0
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    if response.is_success:
+        return
+    if 500 <= response.status_code < 600:
+        raise EngineTransientError(f"engine {response.status_code}: {response.text[:200]}")
+    raise EngineFatalError(f"engine {response.status_code}: {response.text[:200]}")
+
+
+class SitePlannerClient:
+    """Synchronous httpx wrapper over the Site Planner coverage API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: httpx.Client | None = None,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        read_timeout_short: float = DEFAULT_READ_TIMEOUT_SHORT,
+        read_timeout_result: float = DEFAULT_READ_TIMEOUT_RESULT,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required (see RF_PROPAGATION_ENGINE_URL)")
+        self._base_url = base_url.rstrip("/")
+        self._owned_client = client is None
+        self._client = client or httpx.Client(base_url=self._base_url)
+        self._read_timeout_short = read_timeout_short
+        self._read_timeout_result = read_timeout_result
+        self._connect_timeout = connect_timeout
+
+    def close(self) -> None:
+        if self._owned_client:
+            self._client.close()
+
+    def __enter__(self) -> "SitePlannerClient":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
+
+    # --- HTTP surface ---------------------------------------------------
+
+    def submit(self, payload: dict[str, Any]) -> SubmitResponse:
+        timeout = httpx.Timeout(self._read_timeout_short, connect=self._connect_timeout)
+        try:
+            response = self._client.post(PREDICT_PATH, json=payload, timeout=timeout)
+        except httpx.TransportError as exc:
+            raise EngineTransientError(f"transport error submitting: {exc}") from exc
+        _raise_for_status(response)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise EngineFatalError(f"engine returned non-JSON submit body: {exc}") from exc
+        task_id = data.get("task_id") or data.get("id")
+        if not task_id:
+            raise EngineFatalError(f"engine submit response missing task_id: {data!r}")
+        return SubmitResponse(task_id=str(task_id))
+
+    def status(self, task_id: str) -> str:
+        timeout = httpx.Timeout(self._read_timeout_short, connect=self._connect_timeout)
+        path = STATUS_PATH_TMPL.format(task_id=task_id)
+        try:
+            response = self._client.get(path, timeout=timeout)
+        except httpx.TransportError as exc:
+            raise EngineTransientError(f"transport error polling status: {exc}") from exc
+        _raise_for_status(response)
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise EngineFatalError(f"engine returned non-JSON status body: {exc}") from exc
+        status_value = data.get("status")
+        if not status_value:
+            raise EngineFatalError(f"engine status response missing status: {data!r}")
+        return str(status_value).lower()
+
+    def result(self, task_id: str) -> bytes:
+        timeout = httpx.Timeout(self._read_timeout_result, connect=self._connect_timeout)
+        path = RESULT_PATH_TMPL.format(task_id=task_id)
+        try:
+            response = self._client.get(path, timeout=timeout)
+        except httpx.TransportError as exc:
+            raise EngineTransientError(f"transport error fetching result: {exc}") from exc
+        _raise_for_status(response)
+        if not response.content:
+            raise EngineFatalError("engine returned empty result body")
+        return response.content

--- a/Meshflow/rf_propagation/hashing.py
+++ b/Meshflow/rf_propagation/hashing.py
@@ -1,0 +1,80 @@
+"""Content-addressed hashing for RF propagation renders.
+
+The goal is to detect when two render requests share identical RF inputs
+(so we can reuse a cached PNG) while tolerating tiny floating-point noise
+on float fields. The render pipeline version is part of the hash, so a
+bump invalidates every cached render without schema changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+
+if TYPE_CHECKING:
+    from nodes.models import NodeRfProfile
+
+_LATLNG_PRECISION = 6
+_METRES_PRECISION = 2
+_DB_PRECISION = 1
+_FREQ_PRECISION = 3
+
+
+def _round_or_none(value: Any, ndigits: int) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), ndigits)
+
+
+def _normalized_profile_dict(profile: "NodeRfProfile") -> dict[str, Any]:
+    """Return the deterministic field bag we hash over.
+
+    Keeping rounding here (rather than in the DB) means historical rows
+    can be rehashed consistently. Field order is irrelevant because we
+    dump JSON with ``sort_keys=True`` downstream.
+    """
+
+    return {
+        "rf_latitude": _round_or_none(profile.rf_latitude, _LATLNG_PRECISION),
+        "rf_longitude": _round_or_none(profile.rf_longitude, _LATLNG_PRECISION),
+        "rf_altitude_m": _round_or_none(profile.rf_altitude_m, _METRES_PRECISION),
+        "antenna_height_m": _round_or_none(profile.antenna_height_m, _METRES_PRECISION),
+        "antenna_gain_dbi": _round_or_none(profile.antenna_gain_dbi, _DB_PRECISION),
+        "tx_power_dbm": _round_or_none(profile.tx_power_dbm, _DB_PRECISION),
+        "rf_frequency_mhz": _round_or_none(profile.rf_frequency_mhz, _FREQ_PRECISION),
+        "antenna_pattern": profile.antenna_pattern,
+        "antenna_azimuth_deg": _round_or_none(profile.antenna_azimuth_deg, _DB_PRECISION),
+        "antenna_beamwidth_deg": _round_or_none(profile.antenna_beamwidth_deg, _DB_PRECISION),
+    }
+
+
+def compute_input_hash(
+    profile: "NodeRfProfile",
+    *,
+    render_version: str | int | None = None,
+    extras: dict[str, Any] | None = None,
+) -> str:
+    """Return a stable SHA256 hex digest over the rounded profile.
+
+    :param profile: The :class:`NodeRfProfile` being rendered.
+    :param render_version: Overrides :data:`settings.RF_PROPAGATION_RENDER_VERSION`.
+        Exposed for tests.
+    :param extras: Optional extra key/value pairs to fold into the hash
+        (e.g. radius or colormap overrides). Keys must be JSON-serialisable.
+    """
+
+    data = _normalized_profile_dict(profile)
+    data["render_version"] = str(
+        render_version if render_version is not None else settings.RF_PROPAGATION_RENDER_VERSION
+    )
+    if extras:
+        for key, value in extras.items():
+            if key in data:
+                raise ValueError(f"extras key collides with profile field: {key}")
+            data[key] = value
+
+    blob = json.dumps(data, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/Meshflow/rf_propagation/image.py
+++ b/Meshflow/rf_propagation/image.py
@@ -1,0 +1,67 @@
+"""GeoTIFF bytes to PNG bytes.
+
+We deliberately avoid ``rasterio``/GDAL — the engine already emits the
+GeoTIFF in EPSG:4326 with the payload we asked for, so the only thing we
+need to do on the API side is re-encode to a PNG the browser can draw
+inside a Leaflet ``imageOverlay``. Pillow handles this for baseline TIFFs;
+for oddball SPLAT!/tifffile variants we fall back to ``tifffile``.
+"""
+
+from __future__ import annotations
+
+import logging
+from io import BytesIO
+
+logger = logging.getLogger(__name__)
+
+
+class TiffDecodeError(RuntimeError):
+    """Raised when neither Pillow nor tifffile can decode the engine output."""
+
+
+def geotiff_bytes_to_png(tiff_bytes: bytes) -> bytes:
+    """Convert a GeoTIFF byte blob into a PNG byte blob (RGBA)."""
+
+    if not tiff_bytes:
+        raise TiffDecodeError("engine returned empty GeoTIFF bytes")
+
+    try:
+        return _pillow_convert(tiff_bytes)
+    except Exception as exc:  # noqa: BLE001 — fallback path is the whole point
+        logger.warning("rf_propagation.image: Pillow failed (%s); trying tifffile", exc)
+
+    try:
+        return _tifffile_convert(tiff_bytes)
+    except Exception as exc:  # noqa: BLE001
+        raise TiffDecodeError(f"could not decode GeoTIFF: {exc}") from exc
+
+
+def _pillow_convert(tiff_bytes: bytes) -> bytes:
+    from PIL import Image  # local import so test runners without Pillow can skip
+
+    with Image.open(BytesIO(tiff_bytes)) as img:
+        img.load()
+        if img.mode != "RGBA":
+            img = img.convert("RGBA")
+        buf = BytesIO()
+        img.save(buf, format="PNG", optimize=True)
+        return buf.getvalue()
+
+
+def _tifffile_convert(tiff_bytes: bytes) -> bytes:
+    import numpy as np
+    import tifffile
+    from PIL import Image
+
+    arr = tifffile.imread(BytesIO(tiff_bytes))
+    if arr.ndim == 2:
+        img = Image.fromarray(arr).convert("RGBA")
+    elif arr.ndim == 3 and arr.shape[2] in (3, 4):
+        mode = "RGBA" if arr.shape[2] == 4 else "RGB"
+        img = Image.fromarray(np.asarray(arr, dtype=arr.dtype), mode=mode).convert("RGBA")
+    else:
+        raise TiffDecodeError(f"unexpected TIFF shape: {arr.shape}")
+
+    buf = BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()

--- a/Meshflow/rf_propagation/payload.py
+++ b/Meshflow/rf_propagation/payload.py
@@ -55,12 +55,16 @@ def build_request(profile: "NodeRfProfile", *, radius_m: int | None = None) -> d
     freq = _require(profile.rf_frequency_mhz, "rf_frequency_mhz")
     tx_power = _require(profile.tx_power_dbm, "tx_power_dbm")
 
-    tx_height = (
+    tx_height_raw = (
         profile.antenna_height_m
         if profile.antenna_height_m is not None
         else (profile.rf_altitude_m if profile.rf_altitude_m is not None else 1.0)
     )
-    tx_gain = profile.antenna_gain_dbi if profile.antenna_gain_dbi is not None else 0.0
+    # Site Planner enforces tx_height >= 1 m and tx_gain >= 0 dBi; clamp defensively
+    # so realistic-but-low Meshtastic profiles still produce a render.
+    tx_height = max(1.0, float(tx_height_raw))
+    tx_gain_raw = profile.antenna_gain_dbi if profile.antenna_gain_dbi is not None else 0.0
+    tx_gain = max(0.0, float(tx_gain_raw))
 
     if profile.antenna_pattern == "directional":
         logger.warning(
@@ -70,12 +74,12 @@ def build_request(profile: "NodeRfProfile", *, radius_m: int | None = None) -> d
         )
 
     payload: dict[str, Any] = {
-        "tx_lat": float(lat),
-        "tx_lng": float(lng),
-        "tx_height": float(tx_height),
-        "tx_gain": float(tx_gain),
+        "lat": float(lat),
+        "lon": float(lng),
+        "tx_height": tx_height,
+        "tx_gain": tx_gain,
         "tx_power": float(tx_power),
-        "frequency": float(freq),
+        "frequency_mhz": float(freq),
         "rx_height": DEFAULT_RX_HEIGHT_M,
         "rx_gain": DEFAULT_RX_GAIN_DBI,
         "signal_threshold": DEFAULT_SIGNAL_THRESHOLD_DBM,

--- a/Meshflow/rf_propagation/payload.py
+++ b/Meshflow/rf_propagation/payload.py
@@ -1,0 +1,89 @@
+"""Build Site Planner ``CoveragePredictionRequest`` payloads from an RF profile.
+
+Site Planner's current request schema does not model directional antennas,
+so we always submit an omni prediction and surface a note on the render
+(and a WARN log) when the operator has picked ``directional``. This matches
+the v1 feature intent (rough coverage maps, not calibrated RF engineering).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from django.conf import settings
+
+if TYPE_CHECKING:
+    from nodes.models import NodeRfProfile
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RX_HEIGHT_M = 1.0
+DEFAULT_RX_GAIN_DBI = 1.0
+DEFAULT_SIGNAL_THRESHOLD_DBM = -110.0
+DEFAULT_RADIO_CLIMATE = "maritime_temperate_land"
+DEFAULT_COLORMAP = "viridis"
+DEFAULT_MIN_DBM = -130.0
+DEFAULT_MAX_DBM = -50.0
+DEFAULT_HIGH_RESOLUTION = False
+
+_MISSING = object()
+
+
+class InvalidProfileError(ValueError):
+    """Raised when a profile is missing fields required to call the engine."""
+
+
+def _require(value: Any, name: str) -> Any:
+    if value is None:
+        raise InvalidProfileError(f"RF profile is missing required field: {name}")
+    return value
+
+
+def build_request(profile: "NodeRfProfile", *, radius_m: int | None = None) -> dict[str, Any]:
+    """Return a dict suitable for ``POST /predict`` on Site Planner.
+
+    Raises :class:`InvalidProfileError` when the profile lacks any of the
+    required latitude/longitude/frequency/tx-power fields.
+    """
+
+    if radius_m is None:
+        radius_m = settings.RF_PROPAGATION_DEFAULT_RADIUS_M
+
+    lat = _require(profile.rf_latitude, "rf_latitude")
+    lng = _require(profile.rf_longitude, "rf_longitude")
+    freq = _require(profile.rf_frequency_mhz, "rf_frequency_mhz")
+    tx_power = _require(profile.tx_power_dbm, "tx_power_dbm")
+
+    tx_height = (
+        profile.antenna_height_m
+        if profile.antenna_height_m is not None
+        else (profile.rf_altitude_m if profile.rf_altitude_m is not None else 1.0)
+    )
+    tx_gain = profile.antenna_gain_dbi if profile.antenna_gain_dbi is not None else 0.0
+
+    if profile.antenna_pattern == "directional":
+        logger.warning(
+            "rf_propagation.payload: directional antenna requested for node_id=%s; "
+            "Site Planner only supports omni — rendering omni",
+            getattr(profile.observed_node, "node_id", "?"),
+        )
+
+    payload: dict[str, Any] = {
+        "tx_lat": float(lat),
+        "tx_lng": float(lng),
+        "tx_height": float(tx_height),
+        "tx_gain": float(tx_gain),
+        "tx_power": float(tx_power),
+        "frequency": float(freq),
+        "rx_height": DEFAULT_RX_HEIGHT_M,
+        "rx_gain": DEFAULT_RX_GAIN_DBI,
+        "signal_threshold": DEFAULT_SIGNAL_THRESHOLD_DBM,
+        "radio_climate": DEFAULT_RADIO_CLIMATE,
+        "colormap": DEFAULT_COLORMAP,
+        "radius": int(radius_m),
+        "min_dbm": DEFAULT_MIN_DBM,
+        "max_dbm": DEFAULT_MAX_DBM,
+        "high_resolution": DEFAULT_HIGH_RESOLUTION,
+    }
+    return payload

--- a/Meshflow/rf_propagation/tasks.py
+++ b/Meshflow/rf_propagation/tasks.py
@@ -1,0 +1,276 @@
+"""Celery task that drives a single RF propagation render.
+
+Flow (see plan 2 ``docs/features/rf_propagation/README.md``):
+
+1. Load the render row + RF profile.
+2. Build the payload + compute the input hash.
+3. Cache hit: if a sibling render with the same hash is ``ready`` and its
+   PNG still exists on disk, mirror its fields onto this row and return.
+4. Engine roundtrip: ``submit`` → poll ``status`` with backoff → ``result``.
+5. GeoTIFF → PNG → atomic write to ``RF_PROPAGATION_ASSET_DIR``.
+6. Bounds from ``(lat, lng, radius_m)``.
+7. Mark the row ``ready``; run light retention GC.
+
+Transient HTTP / engine errors bubble up as :class:`EngineTransientError`
+so Celery's ``autoretry_for`` can retry with jitter. Fatal errors and a
+final retry-exhaust both land the row in ``failed`` with a useful message.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import timedelta
+from pathlib import Path
+
+from django.conf import settings
+from django.utils import timezone
+
+import httpx
+from celery import shared_task
+from celery.exceptions import MaxRetriesExceededError, SoftTimeLimitExceeded
+
+from .bounds import bbox_from_center
+from .client import EngineFatalError, EngineTransientError, SitePlannerClient
+from .hashing import compute_input_hash
+from .image import TiffDecodeError, geotiff_bytes_to_png
+from .payload import InvalidProfileError, build_request
+
+logger = logging.getLogger(__name__)
+
+# Exponential-ish backoff; capped cumulatively by RF_PROPAGATION_POLL_MAX_SECONDS.
+_POLL_SCHEDULE_SECONDS: tuple[float, ...] = (1.0, 2.0, 5.0, 10.0, 10.0, 15.0, 15.0, 20.0, 30.0)
+
+
+def _poll_until_done(client: SitePlannerClient, task_id: str, max_seconds: int) -> None:
+    """Block until the engine reports ``done``/``ready`` or raise.
+
+    Raises :class:`EngineFatalError` if the engine reports ``failed`` or if
+    the cumulative wait exceeds ``max_seconds``.
+    """
+
+    elapsed = 0.0
+    step = 0
+    while True:
+        state = client.status(task_id).lower()
+        if state in {"done", "ready", "complete", "completed", "success"}:
+            return
+        if state in {"failed", "error"}:
+            raise EngineFatalError(f"engine task {task_id} reported status={state}")
+        if elapsed >= max_seconds:
+            raise EngineFatalError(
+                f"engine task {task_id} did not complete within {max_seconds}s (last status={state})"
+            )
+        delay = _POLL_SCHEDULE_SECONDS[min(step, len(_POLL_SCHEDULE_SECONDS) - 1)]
+        time.sleep(delay)
+        elapsed += delay
+        step += 1
+
+
+def _asset_dir() -> Path:
+    path = Path(settings.RF_PROPAGATION_ASSET_DIR)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(data)
+    os.replace(tmp, path)
+
+
+def _find_cache_hit(model_cls, render_id: int, input_hash: str) -> object | None:
+    """Return a sibling ``ready`` render with the same hash whose PNG still exists."""
+
+    base_dir = _asset_dir()
+    candidate = (
+        model_cls.objects.filter(status=model_cls.Status.READY, input_hash=input_hash)
+        .exclude(pk=render_id)
+        .order_by("-created_at")
+        .first()
+    )
+    if candidate is None:
+        return None
+    if not candidate.asset_filename:
+        return None
+    if not (base_dir / candidate.asset_filename).is_file():
+        return None
+    return candidate
+
+
+def _run_retention(model_cls, observed_node, *, keep: int) -> None:
+    """Keep at most ``keep`` ready renders per node; delete orphan PNGs."""
+
+    base_dir = _asset_dir()
+    ready_renders = list(
+        model_cls.objects.filter(observed_node=observed_node, status=model_cls.Status.READY).order_by("-created_at")
+    )
+    victims = ready_renders[keep:]
+    surviving = ready_renders[:keep]
+    surviving_filenames = {r.asset_filename for r in surviving if r.asset_filename}
+
+    for victim in victims:
+        filename = victim.asset_filename
+        victim.delete()
+        if filename and filename not in surviving_filenames:
+            _safe_unlink(base_dir / filename)
+
+    cutoff = timezone.now() - timedelta(days=7)
+    model_cls.objects.filter(
+        observed_node=observed_node,
+        status=model_cls.Status.FAILED,
+        created_at__lt=cutoff,
+    ).delete()
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as exc:  # pragma: no cover — best-effort GC
+        logger.warning("rf_propagation.tasks: could not remove %s: %s", path, exc)
+
+
+@shared_task(
+    bind=True,
+    name="nodes.tasks.render_rf_propagation",
+    autoretry_for=(httpx.TransportError, EngineTransientError),
+    retry_backoff=True,
+    retry_backoff_max=120,
+    retry_jitter=True,
+    max_retries=3,
+    soft_time_limit=600,
+    time_limit=660,
+)
+def render_rf_propagation(self, render_id: int) -> dict:
+    """Generate the PNG overlay for a single :class:`NodeRfPropagationRender` row."""
+
+    # Local import avoids the Celery autodiscover import-time circular.
+    from nodes.models import NodeRfProfile, NodeRfPropagationRender
+
+    try:
+        render = NodeRfPropagationRender.objects.select_related("observed_node").get(pk=render_id)
+    except NodeRfPropagationRender.DoesNotExist:
+        logger.warning("render_rf_propagation: render_id=%s vanished", render_id)
+        return {"status": "missing"}
+
+    observed_node = render.observed_node
+    logger.info("render_rf_propagation.render_start render_id=%s node_id=%s", render_id, observed_node.node_id)
+
+    try:
+        profile = observed_node.rf_profile
+    except NodeRfProfile.DoesNotExist:
+        return _mark_failed(render, "observed node has no RF profile")
+
+    try:
+        payload = build_request(profile)
+    except InvalidProfileError as exc:
+        return _mark_failed(render, str(exc))
+
+    input_hash = compute_input_hash(profile, extras={"radius_m": int(payload["radius"])})
+
+    cache_hit = _find_cache_hit(NodeRfPropagationRender, render_id, input_hash)
+    if cache_hit is not None:
+        logger.info(
+            "render_rf_propagation.cache_hit render_id=%s source_id=%s hash=%s",
+            render_id,
+            cache_hit.pk,
+            input_hash,
+        )
+        return _mirror_ready(render, cache_hit, input_hash)
+
+    # Engine roundtrip ----------------------------------------------------
+    render.status = NodeRfPropagationRender.Status.RUNNING
+    render.save(update_fields=["status"])
+
+    engine_url = settings.RF_PROPAGATION_ENGINE_URL
+    if not engine_url:
+        return _mark_failed(render, "RF_PROPAGATION_ENGINE_URL is not configured")
+
+    try:
+        with SitePlannerClient(engine_url) as client:
+            submission = client.submit(payload)
+            logger.info(
+                "render_rf_propagation.engine_submitted render_id=%s task_id=%s",
+                render_id,
+                submission.task_id,
+            )
+            _poll_until_done(client, submission.task_id, settings.RF_PROPAGATION_POLL_MAX_SECONDS)
+            logger.info("render_rf_propagation.engine_ready render_id=%s", render_id)
+            tiff_bytes = client.result(submission.task_id)
+    except EngineTransientError:
+        raise
+    except EngineFatalError as exc:
+        return _mark_failed(render, str(exc))
+    except SoftTimeLimitExceeded:
+        return _mark_failed(render, "render exceeded soft_time_limit")
+    except MaxRetriesExceededError as exc:
+        return _mark_failed(render, f"max retries exceeded: {exc}")
+
+    try:
+        png_bytes = geotiff_bytes_to_png(tiff_bytes)
+    except TiffDecodeError as exc:
+        return _mark_failed(render, f"could not decode engine GeoTIFF: {exc}")
+
+    bbox = bbox_from_center(
+        float(profile.rf_latitude),
+        float(profile.rf_longitude),
+        float(payload["radius"]),
+    )
+
+    asset_filename = f"{input_hash}.png"
+    asset_path = _asset_dir() / asset_filename
+    _atomic_write(asset_path, png_bytes)
+    logger.info(
+        "render_rf_propagation.png_written render_id=%s path=%s bytes=%s",
+        render_id,
+        asset_path,
+        len(png_bytes),
+    )
+
+    render.status = NodeRfPropagationRender.Status.READY
+    render.input_hash = input_hash
+    render.asset_filename = asset_filename
+    render.bounds_west = bbox.west
+    render.bounds_south = bbox.south
+    render.bounds_east = bbox.east
+    render.bounds_north = bbox.north
+    render.error_message = ""
+    render.completed_at = timezone.now()
+    render.save()
+
+    _run_retention(
+        NodeRfPropagationRender,
+        observed_node,
+        keep=settings.RF_PROPAGATION_READY_RETENTION,
+    )
+
+    logger.info("render_rf_propagation.render_complete render_id=%s", render_id)
+    return {"status": "ready", "render_id": render_id, "asset_filename": asset_filename}
+
+
+def _mirror_ready(render, cache_hit, input_hash: str) -> dict:
+    """Copy a cache-hit's asset metadata onto ``render`` and mark it ready."""
+
+    render.status = render.Status.READY
+    render.input_hash = input_hash
+    render.asset_filename = cache_hit.asset_filename
+    render.bounds_west = cache_hit.bounds_west
+    render.bounds_south = cache_hit.bounds_south
+    render.bounds_east = cache_hit.bounds_east
+    render.bounds_north = cache_hit.bounds_north
+    render.error_message = ""
+    render.completed_at = timezone.now()
+    render.save()
+    return {"status": "ready", "render_id": render.pk, "asset_filename": render.asset_filename, "cache": True}
+
+
+def _mark_failed(render, message: str) -> dict:
+    render.status = render.Status.FAILED
+    render.error_message = message[:4000]
+    render.completed_at = timezone.now()
+    render.save(update_fields=["status", "error_message", "completed_at"])
+    logger.warning("render_rf_propagation.render_failed render_id=%s reason=%s", render.pk, message)
+    return {"status": "failed", "render_id": render.pk, "error": message}

--- a/Meshflow/rf_propagation/tasks.py
+++ b/Meshflow/rf_propagation/tasks.py
@@ -156,6 +156,21 @@ def render_rf_propagation(self, render_id: int) -> dict:
         logger.warning("render_rf_propagation: render_id=%s vanished", render_id)
         return {"status": "missing"}
 
+    # If the row was already cancelled / completed (e.g. user hit cancel before
+    # the worker picked it up, or the task was re-dispatched after completion),
+    # don't do any of the expensive engine work.
+    terminal_statuses = {
+        NodeRfPropagationRender.Status.READY,
+        NodeRfPropagationRender.Status.FAILED,
+    }
+    if render.status in terminal_statuses:
+        logger.info(
+            "render_rf_propagation.skip_terminal render_id=%s status=%s",
+            render_id,
+            render.status,
+        )
+        return {"status": str(render.status), "render_id": render_id, "skipped": True}
+
     observed_node = render.observed_node
     logger.info("render_rf_propagation.render_start render_id=%s node_id=%s", render_id, observed_node.node_id)
 
@@ -180,6 +195,22 @@ def render_rf_propagation(self, render_id: int) -> dict:
             input_hash,
         )
         return _mirror_ready(render, cache_hit, input_hash)
+
+    # One final cancellation check before committing to the engine roundtrip.
+    # The row may have been cancelled (status flipped) or dismissed (deleted)
+    # by the operator; both mean "don't do the work".
+    try:
+        render.refresh_from_db(fields=["status"])
+    except NodeRfPropagationRender.DoesNotExist:
+        logger.info("render_rf_propagation.dismissed_before_engine render_id=%s", render_id)
+        return {"status": "missing", "render_id": render_id, "skipped": True}
+    if render.status in terminal_statuses:
+        logger.info(
+            "render_rf_propagation.cancelled_before_engine render_id=%s status=%s",
+            render_id,
+            render.status,
+        )
+        return {"status": str(render.status), "render_id": render_id, "skipped": True}
 
     # Engine roundtrip ----------------------------------------------------
     render.status = NodeRfPropagationRender.Status.RUNNING
@@ -229,6 +260,23 @@ def render_rf_propagation(self, render_id: int) -> dict:
         asset_path,
         len(png_bytes),
     )
+
+    # If the operator cancelled or dismissed while the engine was running, the
+    # row is now ``failed`` or gone — don't resurrect it. The PNG is content-
+    # addressed by hash, so it's safe to leave on disk; retention on a future
+    # render will reap it if it's orphaned.
+    try:
+        render.refresh_from_db(fields=["status"])
+    except NodeRfPropagationRender.DoesNotExist:
+        logger.info("render_rf_propagation.dismissed_after_engine render_id=%s", render_id)
+        return {"status": "missing", "render_id": render_id, "skipped": True}
+    if render.status in terminal_statuses:
+        logger.info(
+            "render_rf_propagation.cancelled_after_engine render_id=%s status=%s",
+            render_id,
+            render.status,
+        )
+        return {"status": str(render.status), "render_id": render_id, "skipped": True}
 
     render.status = NodeRfPropagationRender.Status.READY
     render.input_hash = input_hash

--- a/Meshflow/rf_propagation/tests/conftest.py
+++ b/Meshflow/rf_propagation/tests/conftest.py
@@ -1,0 +1,4 @@
+"""Re-export ``nodes`` fixtures so RF propagation tests can use them."""
+
+from nodes.tests.conftest import create_observed_node  # noqa: F401
+from nodes.tests.conftest import create_user  # noqa: F401

--- a/Meshflow/rf_propagation/tests/test_bounds.py
+++ b/Meshflow/rf_propagation/tests/test_bounds.py
@@ -1,0 +1,53 @@
+"""Unit tests for :mod:`rf_propagation.bounds`."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from rf_propagation.bounds import METRES_PER_DEGREE_LATITUDE, bbox_from_center
+
+
+def test_bbox_equator_is_symmetric_in_lat_and_lng():
+    radius_m = 20_000
+    bbox = bbox_from_center(0.0, 0.0, radius_m)
+
+    expected_deg = radius_m / METRES_PER_DEGREE_LATITUDE
+    assert bbox.south == pytest.approx(-expected_deg)
+    assert bbox.north == pytest.approx(expected_deg)
+    # cos(0) == 1, so east/west deltas equal north/south at the equator.
+    assert bbox.west == pytest.approx(-expected_deg)
+    assert bbox.east == pytest.approx(expected_deg)
+
+
+def test_bbox_is_wider_in_longitude_at_high_latitude():
+    radius_m = 20_000
+    lat = 60.0
+    bbox = bbox_from_center(lat, 0.0, radius_m)
+
+    d_lat = radius_m / METRES_PER_DEGREE_LATITUDE
+    d_lng = radius_m / (METRES_PER_DEGREE_LATITUDE * math.cos(math.radians(lat)))
+
+    assert bbox.north - bbox.south == pytest.approx(2 * d_lat)
+    assert bbox.east - bbox.west == pytest.approx(2 * d_lng)
+    # Longitude delta at 60°N is ~2x latitude delta because cos(60°)==0.5.
+    assert (bbox.east - bbox.west) > (bbox.north - bbox.south)
+
+
+def test_bbox_rejects_invalid_input():
+    with pytest.raises(ValueError):
+        bbox_from_center(0.0, 0.0, 0)
+    with pytest.raises(ValueError):
+        bbox_from_center(0.0, 0.0, -1)
+    with pytest.raises(ValueError):
+        bbox_from_center(95.0, 0.0, 1000)
+    with pytest.raises(ValueError):
+        bbox_from_center(0.0, 200.0, 1000)
+
+
+def test_bbox_near_pole_uses_clamped_cosine():
+    bbox = bbox_from_center(89.9999, 0.0, 1000)
+    # Must not raise ZeroDivisionError; east/west are huge but finite.
+    assert math.isfinite(bbox.east)
+    assert math.isfinite(bbox.west)

--- a/Meshflow/rf_propagation/tests/test_client.py
+++ b/Meshflow/rf_propagation/tests/test_client.py
@@ -1,0 +1,97 @@
+"""Unit tests for :mod:`rf_propagation.client`.
+
+We mock the HTTP layer with :mod:`respx` so we can exercise the error-mapping
+logic without touching the real engine.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from rf_propagation.client import (
+    EngineFatalError,
+    EngineTransientError,
+    SitePlannerClient,
+)
+
+BASE_URL = "http://site-planner.test:8080"
+
+
+@respx.mock
+def test_submit_returns_task_id():
+    route = respx.post(f"{BASE_URL}/predict").mock(
+        return_value=httpx.Response(200, json={"task_id": "abc-123"}),
+    )
+    with SitePlannerClient(BASE_URL) as client:
+        result = client.submit({"tx_lat": 0.0})
+    assert route.called
+    assert result.task_id == "abc-123"
+
+
+@respx.mock
+def test_submit_accepts_id_alias():
+    respx.post(f"{BASE_URL}/predict").mock(return_value=httpx.Response(200, json={"id": "xyz"}))
+    with SitePlannerClient(BASE_URL) as client:
+        assert client.submit({}).task_id == "xyz"
+
+
+@respx.mock
+def test_submit_5xx_is_transient():
+    respx.post(f"{BASE_URL}/predict").mock(return_value=httpx.Response(503, text="overloaded"))
+    with SitePlannerClient(BASE_URL) as client:
+        with pytest.raises(EngineTransientError):
+            client.submit({})
+
+
+@respx.mock
+def test_submit_4xx_is_fatal():
+    respx.post(f"{BASE_URL}/predict").mock(return_value=httpx.Response(400, text="bad payload"))
+    with SitePlannerClient(BASE_URL) as client:
+        with pytest.raises(EngineFatalError):
+            client.submit({})
+
+
+@respx.mock
+def test_status_parses_lowercase():
+    respx.get(f"{BASE_URL}/status/42").mock(return_value=httpx.Response(200, json={"status": "DONE"}))
+    with SitePlannerClient(BASE_URL) as client:
+        assert client.status("42") == "done"
+
+
+@respx.mock
+def test_result_returns_raw_bytes():
+    tiff_bytes = b"II*\x00...synthetic geotiff..."
+    respx.get(f"{BASE_URL}/result/42").mock(return_value=httpx.Response(200, content=tiff_bytes))
+    with SitePlannerClient(BASE_URL) as client:
+        assert client.result("42") == tiff_bytes
+
+
+@respx.mock
+def test_result_empty_body_is_fatal():
+    respx.get(f"{BASE_URL}/result/42").mock(return_value=httpx.Response(200, content=b""))
+    with SitePlannerClient(BASE_URL) as client:
+        with pytest.raises(EngineFatalError):
+            client.result("42")
+
+
+@respx.mock
+def test_transport_error_mapped_to_transient():
+    respx.post(f"{BASE_URL}/predict").mock(side_effect=httpx.ConnectError("boom"))
+    with SitePlannerClient(BASE_URL) as client:
+        with pytest.raises(EngineTransientError):
+            client.submit({})
+
+
+def test_requires_base_url():
+    with pytest.raises(ValueError):
+        SitePlannerClient("")
+
+
+@respx.mock
+def test_submit_non_json_is_fatal():
+    respx.post(f"{BASE_URL}/predict").mock(return_value=httpx.Response(200, content=b"<html></html>"))
+    with SitePlannerClient(BASE_URL) as client:
+        with pytest.raises(EngineFatalError):
+            client.submit({})

--- a/Meshflow/rf_propagation/tests/test_hashing.py
+++ b/Meshflow/rf_propagation/tests/test_hashing.py
@@ -1,0 +1,79 @@
+"""Unit tests for the RF render input hash."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from rf_propagation.hashing import compute_input_hash
+
+
+def _profile(**overrides):
+    base = dict(
+        rf_latitude=55.8610,
+        rf_longitude=-4.2510,
+        rf_altitude_m=80.0,
+        antenna_height_m=6.0,
+        antenna_gain_dbi=3.0,
+        tx_power_dbm=27.0,
+        rf_frequency_mhz=869.525,
+        antenna_pattern="omni",
+        antenna_azimuth_deg=None,
+        antenna_beamwidth_deg=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_hash_is_deterministic():
+    profile = _profile()
+    assert compute_input_hash(profile, render_version="1") == compute_input_hash(profile, render_version="1")
+
+
+def test_hash_changes_for_each_field():
+    profile = _profile()
+    base = compute_input_hash(profile, render_version="1")
+    cases = {
+        "rf_latitude": 60.0,
+        "rf_longitude": -2.0,
+        "rf_altitude_m": 200.0,
+        "antenna_height_m": 12.0,
+        "antenna_gain_dbi": 9.0,
+        "tx_power_dbm": 17.0,
+        "rf_frequency_mhz": 915.0,
+        "antenna_pattern": "directional",
+        "antenna_azimuth_deg": 90.0,
+        "antenna_beamwidth_deg": 60.0,
+    }
+    for field, new_value in cases.items():
+        mutated = _profile(**{field: new_value})
+        assert compute_input_hash(mutated, render_version="1") != base, field
+
+
+def test_hash_ignores_subpixel_latlng_noise():
+    base = compute_input_hash(_profile(), render_version="1")
+    jitter = compute_input_hash(
+        _profile(rf_latitude=55.8610 + 1e-8, rf_longitude=-4.2510 - 1e-8),
+        render_version="1",
+    )
+    assert base == jitter
+
+
+def test_hash_changes_when_render_version_bumps():
+    profile = _profile()
+    a = compute_input_hash(profile, render_version="1")
+    b = compute_input_hash(profile, render_version="2")
+    assert a != b
+
+
+def test_hash_accepts_extras():
+    profile = _profile()
+    a = compute_input_hash(profile, render_version="1", extras={"radius_m": 20000})
+    b = compute_input_hash(profile, render_version="1", extras={"radius_m": 10000})
+    assert a != b
+
+
+def test_hash_extras_cannot_collide_with_profile_field():
+    import pytest
+
+    with pytest.raises(ValueError):
+        compute_input_hash(_profile(), render_version="1", extras={"rf_latitude": 0.0})

--- a/Meshflow/rf_propagation/tests/test_image.py
+++ b/Meshflow/rf_propagation/tests/test_image.py
@@ -1,0 +1,42 @@
+"""Unit tests for :mod:`rf_propagation.image`."""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from rf_propagation.image import TiffDecodeError, geotiff_bytes_to_png
+
+
+def _synthetic_tiff_bytes(mode: str = "RGBA", size: tuple[int, int] = (8, 8)) -> bytes:
+    img = Image.new(mode, size, color=(255, 128, 64, 200) if mode == "RGBA" else (255, 128, 64))
+    buf = BytesIO()
+    img.save(buf, format="TIFF")
+    return buf.getvalue()
+
+
+def test_roundtrip_rgba_tiff_to_png_produces_valid_png():
+    png_bytes = geotiff_bytes_to_png(_synthetic_tiff_bytes())
+    assert png_bytes.startswith(b"\x89PNG\r\n\x1a\n")
+    with Image.open(BytesIO(png_bytes)) as img:
+        assert img.format == "PNG"
+        assert img.mode == "RGBA"
+        assert img.size == (8, 8)
+
+
+def test_converts_rgb_tiff_to_rgba_png():
+    png_bytes = geotiff_bytes_to_png(_synthetic_tiff_bytes(mode="RGB"))
+    with Image.open(BytesIO(png_bytes)) as img:
+        assert img.mode == "RGBA"
+
+
+def test_rejects_empty_payload():
+    with pytest.raises(TiffDecodeError):
+        geotiff_bytes_to_png(b"")
+
+
+def test_rejects_unreadable_bytes():
+    with pytest.raises(TiffDecodeError):
+        geotiff_bytes_to_png(b"not-a-real-tiff")

--- a/Meshflow/rf_propagation/tests/test_payload.py
+++ b/Meshflow/rf_propagation/tests/test_payload.py
@@ -35,15 +35,24 @@ def _profile(**overrides):
 
 def test_build_request_populates_required_fields():
     payload = build_request(_profile())
-    assert payload["tx_lat"] == pytest.approx(55.861)
-    assert payload["tx_lng"] == pytest.approx(-4.251)
+    assert payload["lat"] == pytest.approx(55.861)
+    assert payload["lon"] == pytest.approx(-4.251)
     assert payload["tx_height"] == pytest.approx(6.0)
     assert payload["tx_gain"] == pytest.approx(3.0)
     assert payload["tx_power"] == pytest.approx(27.0)
-    assert payload["frequency"] == pytest.approx(869.525)
+    assert payload["frequency_mhz"] == pytest.approx(869.525)
     assert payload["radius"] > 0
     assert payload["colormap"] == DEFAULT_COLORMAP
     assert payload["radio_climate"] == DEFAULT_RADIO_CLIMATE
+    # Site Planner's required fields must be present verbatim.
+    for required in ("lat", "lon", "tx_power"):
+        assert required in payload
+
+
+def test_build_request_clamps_tx_height_and_gain_below_engine_minimums():
+    payload = build_request(_profile(antenna_height_m=0.3, antenna_gain_dbi=-2.0))
+    assert payload["tx_height"] == pytest.approx(1.0)
+    assert payload["tx_gain"] == pytest.approx(0.0)
 
 
 def test_build_request_uses_settings_default_radius(settings):

--- a/Meshflow/rf_propagation/tests/test_payload.py
+++ b/Meshflow/rf_propagation/tests/test_payload.py
@@ -1,0 +1,79 @@
+"""Unit tests for :mod:`rf_propagation.payload`."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from rf_propagation.payload import (
+    DEFAULT_COLORMAP,
+    DEFAULT_RADIO_CLIMATE,
+    InvalidProfileError,
+    build_request,
+)
+
+
+def _profile(**overrides):
+    base = dict(
+        rf_latitude=55.861,
+        rf_longitude=-4.251,
+        rf_altitude_m=80.0,
+        antenna_height_m=6.0,
+        antenna_gain_dbi=3.0,
+        tx_power_dbm=27.0,
+        rf_frequency_mhz=869.525,
+        antenna_pattern="omni",
+        antenna_azimuth_deg=None,
+        antenna_beamwidth_deg=None,
+        observed_node=SimpleNamespace(node_id=12345),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_build_request_populates_required_fields():
+    payload = build_request(_profile())
+    assert payload["tx_lat"] == pytest.approx(55.861)
+    assert payload["tx_lng"] == pytest.approx(-4.251)
+    assert payload["tx_height"] == pytest.approx(6.0)
+    assert payload["tx_gain"] == pytest.approx(3.0)
+    assert payload["tx_power"] == pytest.approx(27.0)
+    assert payload["frequency"] == pytest.approx(869.525)
+    assert payload["radius"] > 0
+    assert payload["colormap"] == DEFAULT_COLORMAP
+    assert payload["radio_climate"] == DEFAULT_RADIO_CLIMATE
+
+
+def test_build_request_uses_settings_default_radius(settings):
+    settings.RF_PROPAGATION_DEFAULT_RADIUS_M = 12345
+    payload = build_request(_profile())
+    assert payload["radius"] == 12345
+
+
+def test_build_request_respects_radius_override():
+    payload = build_request(_profile(), radius_m=5000)
+    assert payload["radius"] == 5000
+
+
+def test_build_request_rejects_profile_missing_required_field():
+    profile = _profile(rf_latitude=None)
+    with pytest.raises(InvalidProfileError):
+        build_request(profile)
+
+
+def test_build_request_warns_on_directional_but_still_builds(caplog):
+    profile = _profile(antenna_pattern="directional", antenna_azimuth_deg=90.0, antenna_beamwidth_deg=60.0)
+    with caplog.at_level(logging.WARNING, logger="rf_propagation.payload"):
+        payload = build_request(profile)
+    assert any("directional" in rec.getMessage() for rec in caplog.records)
+    # We still ask Site Planner for an omni prediction since the engine has no
+    # directional model — the profile fields are captured in the hash instead.
+    assert payload["tx_gain"] == pytest.approx(3.0)
+
+
+def test_build_request_falls_back_to_altitude_for_height():
+    profile = _profile(antenna_height_m=None, rf_altitude_m=50.0)
+    payload = build_request(profile)
+    assert payload["tx_height"] == pytest.approx(50.0)

--- a/Meshflow/rf_propagation/tests/test_tasks.py
+++ b/Meshflow/rf_propagation/tests/test_tasks.py
@@ -1,0 +1,272 @@
+"""Integration tests for the Celery render task, running eagerly."""
+
+from __future__ import annotations
+
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from nodes.models import AntennaPattern, NodeRfProfile, NodeRfPropagationRender
+from rf_propagation.client import EngineFatalError, EngineTransientError
+
+
+def _tiff_bytes(size: tuple[int, int] = (8, 8)) -> bytes:
+    img = Image.new("RGBA", size, color=(255, 128, 64, 200))
+    buf = BytesIO()
+    img.save(buf, format="TIFF")
+    return buf.getvalue()
+
+
+def _make_profile(node):
+    return NodeRfProfile.objects.create(
+        observed_node=node,
+        rf_latitude=55.861,
+        rf_longitude=-4.251,
+        rf_altitude_m=80.0,
+        antenna_height_m=6.0,
+        antenna_gain_dbi=3.0,
+        tx_power_dbm=27.0,
+        rf_frequency_mhz=869.525,
+        antenna_pattern=AntennaPattern.OMNI,
+    )
+
+
+class _FakeSubmit:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+
+
+class _FakeClient:
+    """Stand-in for ``SitePlannerClient`` used as a context manager."""
+
+    def __init__(
+        self,
+        *,
+        task_id: str = "engine-task-1",
+        status: str = "done",
+        result: bytes | None = None,
+        submit_error: Exception | None = None,
+        result_error: Exception | None = None,
+    ) -> None:
+        self._task_id = task_id
+        self._status = status
+        self._result = result if result is not None else _tiff_bytes()
+        self._submit_error = submit_error
+        self._result_error = result_error
+        self.submit_calls = 0
+        self.status_calls = 0
+        self.result_calls = 0
+
+    def __enter__(self) -> "_FakeClient":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def submit(self, _payload):
+        self.submit_calls += 1
+        if self._submit_error is not None:
+            raise self._submit_error
+        return _FakeSubmit(self._task_id)
+
+    def status(self, _task_id: str) -> str:
+        self.status_calls += 1
+        return self._status
+
+    def result(self, _task_id: str) -> bytes:
+        self.result_calls += 1
+        if self._result_error is not None:
+            raise self._result_error
+        return self._result
+
+
+@pytest.fixture
+def asset_dir(settings):
+    with tempfile.TemporaryDirectory() as tmp:
+        settings.RF_PROPAGATION_ASSET_DIR = Path(tmp)
+        settings.RF_PROPAGATION_ENGINE_URL = "http://engine.test:8080"
+        settings.RF_PROPAGATION_POLL_MAX_SECONDS = 5
+        yield Path(tmp)
+
+
+@pytest.mark.django_db
+def test_task_happy_path_writes_png_and_marks_ready(asset_dir, create_observed_node):
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_820,
+        node_id_str=meshtastic_id_to_hex(820_820_820),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient()
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.READY
+    assert render.asset_filename
+    assert (asset_dir / render.asset_filename).is_file()
+    assert render.bounds_west is not None and render.bounds_east > render.bounds_west
+    assert render.bounds_north > render.bounds_south
+    assert fake.submit_calls == 1
+    assert fake.result_calls == 1
+
+
+@pytest.mark.django_db
+def test_task_engine_fatal_marks_failed(asset_dir, create_observed_node):
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_821,
+        node_id_str=meshtastic_id_to_hex(820_820_821),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient(submit_error=EngineFatalError("bad payload"))
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.FAILED
+    assert "bad payload" in render.error_message
+
+
+@pytest.mark.django_db
+def test_task_transient_error_retries(asset_dir, create_observed_node, settings):
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_822,
+        node_id_str=meshtastic_id_to_hex(820_820_822),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient(submit_error=EngineTransientError("engine 503"))
+    # Run the task eagerly — Celery's eager mode raises on retry.
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        with pytest.raises((EngineTransientError, Exception)):
+            task_mod.render_rf_propagation.apply(args=[render.pk], throw=True).get()
+
+
+@pytest.mark.django_db
+def test_task_cache_hit_reuses_existing_asset(asset_dir, create_observed_node):
+    from rf_propagation import tasks as task_mod
+    from rf_propagation.hashing import compute_input_hash
+    from rf_propagation.payload import build_request
+
+    node = create_observed_node(
+        node_id=820_820_823,
+        node_id_str=meshtastic_id_to_hex(820_820_823),
+    )
+    profile = _make_profile(node)
+
+    payload = build_request(profile)
+    input_hash = compute_input_hash(profile, extras={"radius_m": int(payload["radius"])})
+    asset_filename = f"{input_hash}.png"
+    (asset_dir / asset_filename).write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    NodeRfPropagationRender.objects.create(
+        observed_node=node,
+        status=NodeRfPropagationRender.Status.READY,
+        input_hash=input_hash,
+        asset_filename=asset_filename,
+        bounds_west=-5.0,
+        bounds_south=55.0,
+        bounds_east=-3.5,
+        bounds_north=56.5,
+    )
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient()
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.READY
+    assert render.asset_filename == asset_filename
+    assert fake.submit_calls == 0, "cache hit must not call the engine"
+
+
+@pytest.mark.django_db
+def test_task_retention_keeps_only_n_ready_per_node(asset_dir, create_observed_node, settings):
+    from rf_propagation import tasks as task_mod
+
+    settings.RF_PROPAGATION_READY_RETENTION = 2
+
+    node = create_observed_node(
+        node_id=820_820_824,
+        node_id_str=meshtastic_id_to_hex(820_820_824),
+    )
+    _make_profile(node)
+
+    for idx in range(3):
+        filename = f"cached-{idx}.png"
+        (asset_dir / filename).write_bytes(b"stub")
+        NodeRfPropagationRender.objects.create(
+            observed_node=node,
+            status=NodeRfPropagationRender.Status.READY,
+            input_hash=f"stub-{idx}",
+            asset_filename=filename,
+            bounds_west=-5.0,
+            bounds_south=55.0,
+            bounds_east=-3.5,
+            bounds_north=56.5,
+        )
+
+    new_render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient()
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[new_render.pk]).get()
+
+    ready_count = NodeRfPropagationRender.objects.filter(
+        observed_node=node,
+        status=NodeRfPropagationRender.Status.READY,
+    ).count()
+    assert ready_count == settings.RF_PROPAGATION_READY_RETENTION
+
+
+@pytest.mark.django_db
+def test_task_missing_profile_fails_gracefully(asset_dir, create_observed_node):
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_825,
+        node_id_str=meshtastic_id_to_hex(820_820_825),
+    )
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.FAILED
+    assert "RF profile" in render.error_message
+
+
+@pytest.mark.django_db
+def test_task_missing_engine_url_fails(asset_dir, create_observed_node, settings):
+    from rf_propagation import tasks as task_mod
+
+    settings.RF_PROPAGATION_ENGINE_URL = ""
+
+    node = create_observed_node(
+        node_id=820_820_826,
+        node_id_str=meshtastic_id_to_hex(820_820_826),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.FAILED
+    assert "RF_PROPAGATION_ENGINE_URL" in render.error_message

--- a/Meshflow/rf_propagation/tests/test_tasks.py
+++ b/Meshflow/rf_propagation/tests/test_tasks.py
@@ -253,6 +253,94 @@ def test_task_missing_profile_fails_gracefully(asset_dir, create_observed_node):
 
 
 @pytest.mark.django_db
+def test_task_skips_when_row_already_cancelled(asset_dir, create_observed_node):
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_827,
+        node_id_str=meshtastic_id_to_hex(820_820_827),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(
+        observed_node=node,
+        status=NodeRfPropagationRender.Status.FAILED,
+        error_message="Cancelled by user",
+    )
+
+    with patch.object(task_mod, "SitePlannerClient") as fake_cls:
+        result = task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    assert result.get("skipped") is True
+    fake_cls.assert_not_called()
+    render.refresh_from_db()
+    # Cancellation message preserved; worker did not overwrite.
+    assert render.status == NodeRfPropagationRender.Status.FAILED
+    assert render.error_message == "Cancelled by user"
+
+
+@pytest.mark.django_db
+def test_task_respects_cancellation_during_engine_run(asset_dir, create_observed_node, settings):
+    """A cancel issued while the engine is running must not be overwritten."""
+    from rf_propagation import tasks as task_mod
+
+    settings.RF_PROPAGATION_ENGINE_URL = "http://fake-engine:8080"
+
+    node = create_observed_node(
+        node_id=820_820_828,
+        node_id_str=meshtastic_id_to_hex(820_820_828),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    def _cancel_mid_flight(*args, **kwargs):
+        NodeRfPropagationRender.objects.filter(pk=render.pk).update(
+            status=NodeRfPropagationRender.Status.FAILED,
+            error_message="Cancelled by user",
+        )
+        return _tiff_bytes()
+
+    fake = _FakeClient(result=_tiff_bytes())
+    fake.result = _cancel_mid_flight
+
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        result = task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    assert result.get("skipped") is True
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.FAILED
+    assert render.error_message == "Cancelled by user"
+
+
+@pytest.mark.django_db
+def test_task_handles_row_deleted_mid_flight(asset_dir, create_observed_node, settings):
+    """Dismiss (DELETE) mid-flight must not crash the worker or revive the row."""
+    from rf_propagation import tasks as task_mod
+
+    settings.RF_PROPAGATION_ENGINE_URL = "http://fake-engine:8080"
+
+    node = create_observed_node(
+        node_id=820_820_829,
+        node_id_str=meshtastic_id_to_hex(820_820_829),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    def _dismiss_mid_flight(*args, **kwargs):
+        NodeRfPropagationRender.objects.filter(pk=render.pk).delete()
+        return _tiff_bytes()
+
+    fake = _FakeClient(result=_tiff_bytes())
+    fake.result = _dismiss_mid_flight
+
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        result = task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    assert result.get("status") == "missing"
+    assert result.get("skipped") is True
+    assert not NodeRfPropagationRender.objects.filter(pk=render.pk).exists()
+
+
+@pytest.mark.django_db
 def test_task_missing_engine_url_fails(asset_dir, create_observed_node, settings):
     from rf_propagation import tasks as task_mod
 

--- a/deployment/portainer/.env.portainer.example
+++ b/deployment/portainer/.env.portainer.example
@@ -1,0 +1,90 @@
+# =============================================================================
+# Meshflow — Portainer / docker compose environment
+# =============================================================================
+# Copy to e.g. .env.portainer.preprod or .env.portainer.prod and fill in values.
+#
+# Same host, two stacks: use a distinct Portainer stack name per environment so
+# container and volume names do not collide. Set non-overlapping *_EXT_PORT values
+# and different POSTGRES_* / public URLs. If shared Postgres uses a named Docker
+# network per env, set PG_NET_NAME (and MONITORING_NET_NAME) accordingly.
+# =============================================================================
+
+# --- Image tags ---
+DJANGO_TAG=latest-dev
+UI_TAG=latest-dev
+RF_PROPAGATION_TAG=latest-dev
+
+# --- Published host ports (must be unique per stack on one machine) ---
+UI_EXT_PORT=5175
+API_EXT_PORT=8001
+REDOC_EXT_PORT=8010
+REDIS_EXT_PORT=6380
+NEO4J_HTTP_PORT=7475
+NEO4J_BOLT_PORT=7688
+RF_PROPAGATION_HTTP_PORT=8020
+
+# --- RF propagation ---
+# Internal URL the api / celery-rf-worker use to reach the site-planner engine.
+# Leave default unless you rename the service.
+# RF_PROPAGATION_ENGINE_URL=http://site-planner:8080
+# Bump this to invalidate all cached renders (e.g. after a recipe change).
+# RF_PROPAGATION_RENDER_VERSION=1
+# Default bbox radius in metres around the tx when the profile does not specify one.
+# RF_PROPAGATION_DEFAULT_RADIUS_M=20000
+# Cap on how long the render task polls the engine before giving up.
+# RF_PROPAGATION_POLL_MAX_SECONDS=300
+# How many "ready" renders to keep per node before GC reclaims the oldest PNG.
+# RF_PROPAGATION_READY_RETENTION=3
+
+# --- Public URLs (no trailing slash) ---
+API_PUBLIC_URL=https://mesh-preprod.example.com
+WEB_PUBLIC_URL=https://mesh-preprod.example.com
+CALLBACK_URL_BASE=https://mesh-preprod.example.com
+
+# Django: comma-separated host headers the API accepts (domains, IPs, container names).
+# Include your public hostname, reverse-proxy host, and any internal names health checks use.
+ALLOWED_HOSTS=mesh-preprod.example.com,172.17.0.1
+
+# Comma-separated browser origins allowed for CORS (your SPA origin; add http://localhost:5173 for local dev against this API).
+CORS_ALLOWED_ORIGINS=https://mesh-preprod.example.com, http://localhost:5173
+
+# Usually the same as API_PUBLIC_URL; comma-separate if you need more than one origin.
+CSRF_TRUSTED_ORIGINS=https://mesh-preprod.example.com
+
+# --- Django runtime ---
+DEBUG=true
+DJANGO_SECRET_KEY=change-me-to-a-long-random-string
+
+# --- PostgreSQL (often on shared external network; not defined in this compose file) ---
+POSTGRES_DB=meshflow_preprod
+POSTGRES_USER=meshflow_preprod
+POSTGRES_PASSWORD=change-me
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# --- Redis ---
+REDIS_IMAGE=redis:8-alpine
+REDIS_PASSWORD=change-me
+
+# --- Neo4j ---
+NEO4J_IMAGE=2026-community
+NEO4J_PASSWORD=change-me
+
+# --- OAuth (fill from each provider) ---
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+DISCORD_CLIENT_ID=
+DISCORD_CLIENT_SECRET=
+
+# --- Integrations ---
+MAPBOX_TOKEN=
+DISCORD_BOT_TOKEN=
+
+# --- Monitoring ---
+PROMETHEUS_PASSWORD=change-me
+
+# --- External Docker networks (must exist: docker network create …) ---
+PG_NET_NAME=pg_net
+MONITORING_NET_NAME=monitoring

--- a/deployment/portainer/docker-compose.portainer.yaml
+++ b/deployment/portainer/docker-compose.portainer.yaml
@@ -215,7 +215,7 @@ services:
     image: ghcr.io/pskillen/meshflow-rf-propagation:${RF_PROPAGATION_TAG:-latest-dev}
     restart: unless-stopped
     ports:
-      - "${RF_PROPAGATION_HTTP_PORT:-8020}:8080"
+      - "${RF_PROPAGATION_HTTP_PORT}:8080"
     environment:
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/3
       SDF_DIR: /data/sdf

--- a/deployment/portainer/docker-compose.portainer.yaml
+++ b/deployment/portainer/docker-compose.portainer.yaml
@@ -1,0 +1,240 @@
+# Portainer / docker compose stack for Meshflow (API, UI, workers, data stores).
+# Deploy multiple environments on one host: give each stack a unique name in Portainer
+# and a separate env file with distinct ports, DB names, and public URLs. Compose
+# prefixes project volumes automatically; override PG_NET_NAME / MONITORING_NET_NAME if
+# your shared external networks use different names per environment.
+
+---
+
+services:
+
+  react-ui:
+    image: ghcr.io/pskillen/meshtastic-bot-ui:${UI_TAG}
+    restart: unless-stopped
+    environment:
+      MESHBOT_API_URL: ${API_PUBLIC_URL}
+      MESHBOT_API_BASE_PATH: /api
+      MESHBOT_API_TIMEOUT: 10000
+      NODE_ENV: production
+      MAPBOX_TOKEN: ${MAPBOX_TOKEN}
+    ports:
+      - "${UI_EXT_PORT}:80"
+
+  migrations:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}
+    command: ["sh", "-c", "python manage.py migrate && python manage.py run_deploy_tasks"]
+    restart: no
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+    networks:
+      - pg_net
+
+  redoc:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}-docs
+    restart: no
+    ports:
+      - "${REDOC_EXT_PORT}:8080"
+
+  redis:
+    image: ${REDIS_IMAGE}
+    restart: unless-stopped
+    ports:
+      - "${REDIS_EXT_PORT}:6379"
+    command: redis-server --requirepass ${REDIS_PASSWORD}
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    volumes:
+      - redis_data:/data
+    networks:
+      - redis
+
+  neo4j:
+    image: neo4j:${NEO4J_IMAGE}
+    restart: unless-stopped
+    ports:
+      - "${NEO4J_HTTP_PORT}:7474"
+      - "${NEO4J_BOLT_PORT}:7687"
+    environment:
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD}
+    volumes:
+      - neo4j_data:/data
+    networks:
+      - neo4j
+
+  api:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}
+    restart: unless-stopped
+    environment:
+      # Runtime env
+      DEBUG: ${DEBUG}
+
+      # Django settings
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      CSRF_TRUSTED_ORIGINS: ${CSRF_TRUSTED_ORIGINS}
+      SECRET_KEY: ${DJANGO_SECRET_KEY}
+
+      # Database
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+
+      # Monitoring
+      PROMETHEUS_PASSWORD: ${PROMETHEUS_PASSWORD}
+
+      # Redis
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+
+      # NEO4J
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+
+      # RF propagation (Site Planner engine + on-disk PNG cache)
+      RF_PROPAGATION_ENGINE_URL: http://site-planner:8080
+      RF_PROPAGATION_ASSET_DIR: /var/meshflow/generated-assets/rf-propagation
+
+      # Social auth
+      CALLBACK_URL_BASE: ${CALLBACK_URL_BASE}
+      FRONTEND_URL: ${WEB_PUBLIC_URL}
+      AUTH_SITE_ID: 0
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+
+      # Discord notifications
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
+    ports:
+      - "${API_EXT_PORT}:8000"
+    volumes:
+      - rf_assets:/var/meshflow/generated-assets/rf-propagation
+    networks:
+      - pg_net
+      - monitoring
+      - redis
+      - neo4j
+      - site-planner
+
+  celery-worker:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}
+    restart: unless-stopped
+    command: celery -A Meshflow worker -l info
+    environment:
+      DEBUG: ${DEBUG:-false}
+      FRONTEND_URL: ${WEB_PUBLIC_URL}
+      # Database
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      # Redis
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      # NEO4J
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      # Discord notifications
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+    networks:
+      - pg_net
+      - redis
+      - neo4j
+
+  celery-rf-worker:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}
+    restart: unless-stopped
+    command: celery -A Meshflow worker -Q rf_renders -l info --concurrency=1
+    environment:
+      DEBUG: ${DEBUG:-false}
+      FRONTEND_URL: ${WEB_PUBLIC_URL}
+      # Database
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      # Redis
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      # NEO4J
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      # RF propagation
+      RF_PROPAGATION_ENGINE_URL: http://site-planner:8080
+      RF_PROPAGATION_ASSET_DIR: /var/meshflow/generated-assets/rf-propagation
+    volumes:
+      - rf_assets:/var/meshflow/generated-assets/rf-propagation
+    networks:
+      - pg_net
+      - redis
+      - neo4j
+      - site-planner
+
+  celery-beat:
+    image: ghcr.io/pskillen/meshflow-api:${DJANGO_TAG}
+    restart: unless-stopped
+    command: celery -A Meshflow beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
+    environment:
+      DEBUG: ${DEBUG:-false}
+      # Database
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      # Redis
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      # NEO4J
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+    networks:
+      - pg_net
+      - redis
+      - neo4j
+
+  site-planner:
+    image: ghcr.io/pskillen/meshflow-rf-propagation:${RF_PROPAGATION_TAG:-latest-dev}
+    restart: unless-stopped
+    ports:
+      - "${RF_PROPAGATION_HTTP_PORT:-8020}:8080"
+    environment:
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379/3
+      SDF_DIR: /data/sdf
+    networks:
+      - redis
+      - site-planner
+    depends_on:
+      - redis
+
+networks:
+  pg_net:
+    external: true
+  monitoring:
+    external: true
+  redis:
+  neo4j:
+  site-planner:
+
+volumes:
+  redis_data:
+  neo4j_data:
+  rf_assets:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,7 @@ services:
       NEO4J_PASSWORD: ${NEO4J_PASSWORD:-neo4j}
       ALLOWED_HOSTS: meshflow-manager
       RF_PROPAGATION_ASSET_DIR: /var/meshflow/generated-assets/rf-propagation
+      RF_PROPAGATION_ENGINE_URL: http://rf-propagation:8080
     ports:
       - "8000:8000"
     volumes:
@@ -128,6 +129,52 @@ services:
       redis:
         condition: service_started
       neo4j:
+        condition: service_started
+    networks:
+      - meshflow_net
+
+  celery-rf-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: meshflow-celery-rf-worker
+    restart: unless-stopped
+    command: celery -A Meshflow worker -Q rf_renders -l info --concurrency=1
+    environment:
+      DEBUG: true
+      POSTGRES_DB: meshflow
+      POSTGRES_USER: meshflow
+      POSTGRES_PASSWORD: meshflow
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      CELERY_BROKER_URL: redis://redis:6379/1
+      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-neo4j}
+      RF_PROPAGATION_ASSET_DIR: /var/meshflow/generated-assets/rf-propagation
+      RF_PROPAGATION_ENGINE_URL: http://rf-propagation:8080
+    volumes:
+      - rf_assets:/var/meshflow/generated-assets/rf-propagation
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      rf-propagation:
+        condition: service_started
+    networks:
+      - meshflow_net
+
+  rf-propagation:
+    image: ghcr.io/pskillen/meshflow-rf-propagation:${RF_PROPAGATION_IMAGE_TAG:-latest-dev}
+    container_name: meshflow-rf-propagation
+    restart: unless-stopped
+    environment:
+      REDIS_URL: redis://redis:6379/3
+    depends_on:
+      redis:
         condition: service_started
     networks:
       - meshflow_net

--- a/docs/REDIS.md
+++ b/docs/REDIS.md
@@ -31,9 +31,9 @@ Configuration lives in [`Meshflow/Meshflow/settings/base.py`](../Meshflow/Meshfl
     - **`discord_connect_oauth:{nonce}`** — one-time Discord OAuth link nonces ([`Meshflow/users/discord_connect_oauth.py`](../Meshflow/users/discord_connect_oauth.py)); TTL **900 s** (`STATE_MAX_AGE`).
   - Prefer **feature prefixes** (`tr:`, `discord_connect_oauth:`) so keys are identifiable in `KEYS`/monitoring.
 
-- **DB 3 — Meshtastic Site Planner engine (planned)**  
-  - **Purpose:** Reserved for the **`meshflow-rf-propagation`** / Meshtastic Site Planner sibling container when added to Compose. The engine uses Redis for its **own** async prediction task state (task IDs, status); Meshflow API code does **not** read this DB directly — only HTTP calls to the engine.  
-  - **Important:** DB **2** must **not** be reused for Site Planner: it is already Django cache (see above). Configure the engine with e.g. `REDIS_URL=redis://redis:6379/3`.
+- **DB 3 — Meshtastic Site Planner engine**
+  - **Purpose:** Consumed by the **`rf-propagation`** (a.k.a. `site-planner` in Portainer) sibling container running the Meshtastic Site Planner image. The engine uses Redis for its **own** async prediction task state (task IDs, status); Meshflow API code does **not** read this DB directly — only HTTP calls to the engine (see [docs/features/rf_propagation/README.md](features/rf_propagation/README.md)).
+  - **Important:** DB **2** must **not** be reused for Site Planner: it is already Django cache (see above). Configure the engine with `REDIS_URL=redis://redis:6379/3` locally, or `redis://:${REDIS_PASSWORD}@redis:6379/3` in Portainer where Redis runs with `--requirepass`.
 
 ---
 
@@ -57,7 +57,7 @@ Redis-related variables used by Meshflow settings:
 | `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` | Build URLs for Channels (DB 0), Celery (DB 1), cache (DB 2) in `settings/base.py`. |
 | `CELERY_BROKER_URL` | Optional override for Celery broker + result backend (defaults to `redis://…/1`). |
 
-RF propagation engine (when deployed): **`RF_PROPAGATION_ENGINE_URL`** is consumed by Meshflow task code (planned); the engine container uses **`REDIS_URL`** pointing at DB **3** so it does not collide with Django cache on DB 2.
+RF propagation engine: **`RF_PROPAGATION_ENGINE_URL`** is consumed by the Celery render task (`rf_propagation.tasks.render_rf_propagation`); the engine container uses **`REDIS_URL`** pointing at DB **3** so it does not collide with Django cache on DB 2.
 
 ---
 

--- a/docs/features/rf_propagation/README.md
+++ b/docs/features/rf_propagation/README.md
@@ -1,0 +1,136 @@
+# RF propagation renders
+
+Owners of observed nodes can request a predicted RF coverage map for their
+hardware, rendered as a Leaflet PNG overlay. This document covers how the
+pipeline fits together in production.
+
+## Architecture
+
+```
+UI                 api (Django)            celery-rf-worker         rf-propagation (Site Planner)
+ │                      │                         │                           │
+ │ POST /rf-propagation/recompute ─────────────── │                           │
+ │                      │── enqueue (rf_renders)─►│                           │
+ │ 201 { status: pending, … }                    │ POST /predict ────────────►│
+ │                      │                         │ GET /status (polling)◄────│
+ │                      │                         │ GET /result (GeoTIFF)◄────│
+ │                      │                         │ tiff → png → rf_assets    │
+ │                      │                         │ update render row         │
+ │ GET /rf-propagation/ (polling)                 │                           │
+ │ 200 { status: ready, asset_url, bounds }       │                           │
+ │ GET {asset_url} (public PNG) ─────────────────►│                           │
+```
+
+Three containers collaborate on every render:
+
+- **api** accepts the request and holds the `NodeRfProfile` /
+  `NodeRfPropagationRender` rows. See `nodes/views.py::rf_propagation_recompute`.
+- **celery-rf-worker** consumes the dedicated `rf_renders` queue and drives
+  one render to completion. See `rf_propagation/tasks.py`.
+- **rf-propagation** (image `ghcr.io/pskillen/meshflow-rf-propagation`) is
+  an external FastAPI service that wraps SPLAT! and returns a GeoTIFF.
+
+## Engine dependency
+
+The engine is pulled (not built) from GHCR; the source lives in the
+`meshflow-rf-propagation` repository. Local stacks default to the
+`latest-dev` tag; Portainer stacks pin an explicit `RF_PROPAGATION_TAG`
+in `.env.portainer.*`.
+
+Smoke-test the engine without the UI:
+
+```bash
+# local docker compose
+docker compose exec api curl -sf http://rf-propagation:8080/docs >/dev/null && echo ok
+
+# portainer stack (service is named "site-planner" there)
+docker compose exec api curl -sf http://site-planner:8080/docs >/dev/null && echo ok
+```
+
+## Redis layout
+
+Redis is shared across services with logical database partitioning — see
+[docs/REDIS.md](../../REDIS.md). In short: Channels on DB 0, Celery broker
+on DB 1, Django cache on DB 2, and the Site Planner engine on **DB 3**
+for its own task state.
+
+## Hashing and cache strategy
+
+`rf_propagation.hashing.compute_input_hash` produces a SHA256 digest over:
+
+- The rounded RF profile fields (lat/lng to 6 dp, metres to 2 dp, dB to
+  1 dp, frequency to 3 dp).
+- `antenna_pattern`, azimuth, beamwidth (captured even though Site Planner
+  currently ignores them — future engines may use them).
+- `render_version` from `settings.RF_PROPAGATION_RENDER_VERSION`.
+- The target radius (so changing `RF_PROPAGATION_DEFAULT_RADIUS_M`
+  invalidates existing renders).
+
+The hash doubles as the on-disk filename (`{hash}.png`). Two nodes with
+identical RF profiles therefore share a PNG.
+
+### Single-inflight dedup
+
+`rf_propagation_recompute` will:
+
+1. Reuse a `ready` render with a matching hash (no new row, no engine
+   call) whose asset still exists on disk.
+2. Otherwise return any `pending`/`running` row that already exists for
+   the same node without enqueueing another task.
+3. Otherwise create a fresh `pending` row and `.delay()` the render task.
+
+### Bumping `render_version`
+
+Any time the render recipe changes (colormap, colour scale, default
+radius, radio climate, post-processing) bump
+`RF_PROPAGATION_RENDER_VERSION` so the next request per node produces a
+fresh cache entry instead of reusing a stale PNG. The old PNG files are
+cleaned up lazily by the retention rule below.
+
+## Retention
+
+On every successful render, the task keeps the **3 most recent** ready
+renders per node (configurable via `RF_PROPAGATION_READY_RETENTION`) and
+deletes any older ready rows plus their PNG files. `failed` rows older
+than 7 days are also pruned per node.
+
+## Environment variables
+
+| Variable | Default | Where used | Notes |
+| --- | --- | --- | --- |
+| `RF_PROPAGATION_ENGINE_URL` | _(empty)_ | worker | Internal URL of the engine, e.g. `http://rf-propagation:8080`. Required for real renders. |
+| `RF_PROPAGATION_ASSET_DIR` | `/var/meshflow/generated-assets/rf-propagation` | api + worker | Mounted from the `rf_assets` named volume; must be shared between `api` and `celery-rf-worker`. |
+| `RF_PROPAGATION_IMAGE_TAG` | `latest-dev` | compose | Tag for the engine image. |
+| `RF_PROPAGATION_RENDER_VERSION` | `1` | api + worker | Bump to invalidate all cached renders. |
+| `RF_PROPAGATION_DEFAULT_RADIUS_M` | `20000` | api + worker | Radius of the predicted coverage bbox in metres. |
+| `RF_PROPAGATION_POLL_MAX_SECONDS` | `300` | worker | Cap on cumulative polling before the render is marked failed. |
+| `RF_PROPAGATION_READY_RETENTION` | `3` | worker | Number of `ready` renders kept per node. |
+
+## Known limitations
+
+- **Directional antennas**: Site Planner's current model is omni-only.
+  The UI still collects azimuth/beamwidth so we can render directional
+  predictions once the engine supports them; for now we log a WARN and
+  render an omni coverage map. Azimuth/beamwidth are still folded into
+  the hash, so an operator toggling between omni and directional gets a
+  fresh cache entry.
+- **SRTM coverage**: The default engine image ships UK SRTM tiles.
+  Requests for nodes outside the shipped coverage fail with an
+  `engine task … reported status=failed` and are surfaced on the row's
+  `error_message`.
+- **Pillow first, tifffile fallback**: some non-baseline GeoTIFFs trip
+  Pillow. The converter falls back to `tifffile`; adding `rasterio`
+  later would only be necessary if we see unreadable variants in
+  production.
+
+## Operational runbook
+
+- **Stuck render?** Check the row: `status`, `error_message`, and
+  `completed_at`. A pending row with no matching celery log usually
+  means the queue is unconsumed — check `celery-rf-worker` logs.
+- **Force re-render**: bump `RF_PROPAGATION_RENDER_VERSION` or PATCH the
+  profile to invalidate the hash.
+- **Purge disk**: `RF_PROPAGATION_READY_RETENTION=0` will GC on the next
+  render; otherwise `ls $RF_PROPAGATION_ASSET_DIR` and remove by hand.
+- **Engine upgrade**: bump `RF_PROPAGATION_IMAGE_TAG` in the env file
+  and redeploy only the `rf-propagation`/`site-planner` service.

--- a/docs/features/rf_propagation/README.md
+++ b/docs/features/rf_propagation/README.md
@@ -6,19 +6,36 @@ pipeline fits together in production.
 
 ## Architecture
 
-```
-UI                 api (Django)            celery-rf-worker         rf-propagation (Site Planner)
- │                      │                         │                           │
- │ POST /rf-propagation/recompute ─────────────── │                           │
- │                      │── enqueue (rf_renders)─►│                           │
- │ 201 { status: pending, … }                    │ POST /predict ────────────►│
- │                      │                         │ GET /status (polling)◄────│
- │                      │                         │ GET /result (GeoTIFF)◄────│
- │                      │                         │ tiff → png → rf_assets    │
- │                      │                         │ update render row         │
- │ GET /rf-propagation/ (polling)                 │                           │
- │ 200 { status: ready, asset_url, bounds }       │                           │
- │ GET {asset_url} (public PNG) ─────────────────►│                           │
+```mermaid
+sequenceDiagram
+    participant UI
+    participant API as api (Django)
+    participant Q as Redis (DB 1)<br/>rf_renders queue
+    participant W as celery-rf-worker
+    participant E as rf-propagation<br/>(Site Planner)
+    participant FS as rf_assets volume
+
+    UI->>API: POST /rf-propagation/recompute/
+    API->>API: hash profile &amp; dedup (cache / in-flight)
+    API->>Q: enqueue render task (rf_renders)
+    API-->>UI: 201 { status: pending, input_hash }
+
+    W->>Q: BRPOP rf_renders
+    W->>E: POST /predict (lat, lon, frequency_mhz, …)
+    E-->>W: 200 { task_id }
+    loop poll until done
+        W->>E: GET /status/{task_id}
+        E-->>W: { status }
+    end
+    W->>E: GET /result/{task_id}
+    E-->>W: GeoTIFF bytes
+    W->>W: GeoTIFF → PNG
+    W->>FS: write {hash}.png
+    W->>API: UPDATE render row status=ready, bounds, asset_filename
+
+    UI->>API: GET /rf-propagation/ (polling, 5s)
+    API-->>UI: { status: ready, asset_url, bounds }
+    UI->>FS: GET {asset_url} (public PNG)
 ```
 
 Three containers collaborate on every render:
@@ -78,6 +95,48 @@ identical RF profiles therefore share a PNG.
 2. Otherwise return any `pending`/`running` row that already exists for
    the same node without enqueueing another task.
 3. Otherwise create a fresh `pending` row and `.delay()` the render task.
+
+### Cancelling / dismissing a render
+
+There are two flavours of "stop" for non-`ready` rows, both scoped to a
+single node and both requiring the same permission as `recompute`:
+
+- **`POST .../rf-propagation/cancel/`** — audit-preserving. Flips any
+  `pending`/`running` rows to `failed` with
+  `error_message="Cancelled by user"` and stamps `completed_at`. The
+  row stays in the database so operators can see _why_ a render was
+  aborted. `failed` rows are untouched (nothing to cancel).
+- **`POST .../rf-propagation/dismiss/`** — destructive. Deletes every
+  non-`ready` row for the node (`pending`, `running`, **and**
+  `failed`). Returns `{ "deleted": <count> }`. Use this from the UI
+  when the operator clicks "Cancel" (while in flight) or "Dismiss"
+  (on a failed row) — the end state is the same: the row is gone and
+  the next recompute starts from a clean slate.
+
+The worker is resilient to both: it performs three checks and treats
+"row gone" (`DoesNotExist`) and "row in terminal state" the same way
+— log and bail without writing:
+
+1. On task pickup — skip if the row is already terminal (cancel) or
+   missing (dismiss).
+2. Just before the engine call — avoids the expensive roundtrip.
+3. After the engine returns and the PNG is on disk — the worker
+   refuses to revive a cancelled/dismissed row. The PNG stays on disk
+   (it is content-addressed, so retention will reap it if nothing
+   else references the hash).
+
+There is no way to interrupt a running `/predict` call on the engine
+side, so a cancel/dismiss during engine polling will still let the
+current engine request finish; the worker just won't mark the row
+`ready`.
+
+Typical flows:
+
+- Render is stuck in `pending` (e.g. worker was down, engine URL was
+  misconfigured) → operator hits **dismiss** and then **recompute**.
+- Engine returns a permanent `422` for an unfixable profile → row
+  lands in `failed` → operator fixes the profile, clicks **dismiss**
+  on the error card, then **recompute**.
 
 ### Bumping `render_version`
 


### PR DESCRIPTION
## Summary

Builds the actual generation pipeline on top of #184 so the existing `NodeRfPropagationRender` rows and the PNG asset route start getting populated with real renders instead of stubs.

High-level:

- **Engine dependency**: the [Meshtastic Site Planner](https://github.com/pskillen/meshflow-rf-propagation) FastAPI service runs as a sibling container and does the actual RF prediction. Its own async task state lives on Redis **DB 3** so it never collides with Django cache (DB 2), Celery broker (DB 1), or Channels (DB 0) — see `docs/REDIS.md`.
- **Dedicated Celery worker**: `celery-rf-worker` consumes a new `rf_renders` queue so long RF renders can't back up the main worker. Route is configured via `CELERY_TASK_ROUTES`.
- **Content-addressed cache**: `rf_propagation.hashing.compute_input_hash` produces a SHA256 over the normalised profile (rounded lat/lng, antenna/tx fields, frequency, pattern, radius) plus `RF_PROPAGATION_RENDER_VERSION`. Identical inputs reuse an existing `READY` render instead of re-running the engine. Bumping the render version invalidates everything.
- **Single in-flight dedup**: while a node has a `PENDING`/`RUNNING` render, `POST /.../rf-propagation/recompute/` returns that row untouched instead of stacking jobs.
- **Retention**: the Celery task keeps the most recent `RF_PROPAGATION_READY_RETENTION` (default 3) `READY` renders per node and prunes `FAILED` rows older than 7 days, deleting PNG assets that are no longer referenced.
- **Portainer parity**: `deployment/portainer/docker-compose.portainer.yaml` and `.env.portainer.example` now mirror the root compose (celery-rf-worker, `rf_assets` volume, engine wired to authenticated Redis, attached to `redis` + `site-planner` networks).
- **Docs**: new `docs/features/rf_propagation/README.md` covers architecture, env vars, ops, and known limitations; `AGENTS.md` and `docs/REDIS.md` cross-link to it.

Modules added under `Meshflow/rf_propagation/`:

- `client.py` — thin `httpx` Site Planner client with transient vs fatal error types
- `hashing.py` — content-addressed SHA256 with per-field rounding
- `payload.py` — builds `CoveragePredictionRequest` from a `NodeRfProfile`
- `bounds.py` — WGS84 bbox from `(lat, lng, radius_m)` for the Leaflet `imageOverlay`
- `image.py` — GeoTIFF → PNG via Pillow with a `tifffile` fallback
- `tasks.py` — the `nodes.tasks.render_rf_propagation` Celery task (cache/engine/convert/persist/retention)

Stacked on #184 (Plan 1) — merge that first, or rebase this onto `main` after it lands.

Closes #181.

## Related

- Parent PR: #184
- UI: [meshtastic-bot-ui#183](https://github.com/pskillen/meshtastic-bot-ui/pull/183)

## Testing performed

- `pytest` (380 passed) — covers unit tests for hashing, bounds, payload, image, client, and an eager integration test of the render task for happy-path, cache hits, transient retries, fatal errors, retention, and graceful failure when the engine URL or profile is missing.
- `black` / `isort` / `flake8` (clean at repo's `max-line-length = 120`).
- Existing `nodes/tests/test_rf_propagation.py` updated to stub the Celery task and cover the cache-hit + in-flight dedup branches on `rf-propagation/recompute`.
- Local compose spin-up of `rf-propagation` engine verified via `docker compose exec api curl http://rf-propagation:8080/docs`.
- Portainer compose visually diffed against the updated root compose for parity (env vars, volumes, networks, Redis auth).
