### PR TITLE
feat(rf-propagation): transparent PNG nodata alpha

### DIFF
--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -157,7 +157,26 @@ RF_PROPAGATION_ASSET_DIR = Path(
 # Meshtastic Site Planner engine base URL (FastAPI service, see deployment/docker-compose.yaml).
 RF_PROPAGATION_ENGINE_URL = os.environ.get("RF_PROPAGATION_ENGINE_URL", "")
 # Bump this to invalidate every cached render (pipeline or post-processing change).
-RF_PROPAGATION_RENDER_VERSION = os.environ.get("RF_PROPAGATION_RENDER_VERSION", "1")
+RF_PROPAGATION_RENDER_VERSION = os.environ.get("RF_PROPAGATION_RENDER_VERSION", "2")
+
+
+def _rf_propagation_nodata_rgb() -> tuple[int, int, int]:
+    raw = os.environ.get("RF_PROPAGATION_NODATA_RGB", "0,0,0")
+    try:
+        parts = [int(x.strip()) for x in raw.split(",")]
+        if len(parts) == 3 and all(0 <= p <= 255 for p in parts):
+            return (parts[0], parts[1], parts[2])
+    except ValueError:
+        pass
+    return (0, 0, 0)
+
+
+# GeoTIFF coverage rasters use this colour for "no signal"; strip to transparent in PNG for map overlay.
+RF_PROPAGATION_NODATA_RGB = _rf_propagation_nodata_rgb()
+RF_PROPAGATION_NODATA_TOLERANCE = max(
+    0,
+    min(255, int(os.environ.get("RF_PROPAGATION_NODATA_TOLERANCE", "8"))),
+)
 # Default bbox radius around the tx (metres) when the profile does not specify one.
 RF_PROPAGATION_DEFAULT_RADIUS_M = int(os.environ.get("RF_PROPAGATION_DEFAULT_RADIUS_M", "20000"))
 # Upper bound (seconds) for polling engine job status inside the Celery task.

--- a/Meshflow/rf_propagation/image.py
+++ b/Meshflow/rf_propagation/image.py
@@ -36,16 +36,41 @@ def geotiff_bytes_to_png(tiff_bytes: bytes) -> bytes:
         raise TiffDecodeError(f"could not decode GeoTIFF: {exc}") from exc
 
 
+def _apply_nodata_alpha(img):
+    """Set alpha to 0 for pixels within tolerance of the configured nodata RGB."""
+    from django.conf import settings
+
+    import numpy as np
+    from PIL import Image
+
+    if img.mode != "RGBA":
+        img = img.convert("RGBA")
+    nodata = settings.RF_PROPAGATION_NODATA_RGB
+    tol = int(settings.RF_PROPAGATION_NODATA_TOLERANCE)
+    r0, g0, b0 = (int(nodata[0]), int(nodata[1]), int(nodata[2]))
+    arr = np.asarray(img, dtype=np.uint8)
+    r = arr[:, :, 0].astype(np.int16)
+    g = arr[:, :, 1].astype(np.int16)
+    b = arr[:, :, 2].astype(np.int16)
+    mask = (np.abs(r - r0) <= tol) & (np.abs(g - g0) <= tol) & (np.abs(b - b0) <= tol)
+    out = arr.copy()
+    out[mask, 3] = 0
+    return Image.fromarray(out, mode="RGBA")
+
+
+def _png_bytes_from_rgba(img) -> bytes:
+    buf = BytesIO()
+    _apply_nodata_alpha(img).save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
+
+
 def _pillow_convert(tiff_bytes: bytes) -> bytes:
     from PIL import Image  # local import so test runners without Pillow can skip
 
     with Image.open(BytesIO(tiff_bytes)) as img:
         img.load()
-        if img.mode != "RGBA":
-            img = img.convert("RGBA")
-        buf = BytesIO()
-        img.save(buf, format="PNG", optimize=True)
-        return buf.getvalue()
+        pil_img = img.convert("RGBA") if img.mode != "RGBA" else img.copy()
+    return _png_bytes_from_rgba(pil_img)
 
 
 def _tifffile_convert(tiff_bytes: bytes) -> bytes:
@@ -62,6 +87,4 @@ def _tifffile_convert(tiff_bytes: bytes) -> bytes:
     else:
         raise TiffDecodeError(f"unexpected TIFF shape: {arr.shape}")
 
-    buf = BytesIO()
-    img.save(buf, format="PNG", optimize=True)
-    return buf.getvalue()
+    return _png_bytes_from_rgba(img)

--- a/Meshflow/rf_propagation/tests/test_image.py
+++ b/Meshflow/rf_propagation/tests/test_image.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from io import BytesIO
 
+from django.test import override_settings
+
 import pytest
 from PIL import Image
 
@@ -40,3 +42,49 @@ def test_rejects_empty_payload():
 def test_rejects_unreadable_bytes():
     with pytest.raises(TiffDecodeError):
         geotiff_bytes_to_png(b"not-a-real-tiff")
+
+
+def _rgb_tiff_mostly_black_with_one_red_pixel() -> bytes:
+    img = Image.new("RGB", (4, 4), (0, 0, 0))
+    px = img.load()
+    px[3, 3] = (255, 0, 0)
+    buf = BytesIO()
+    img.save(buf, format="TIFF")
+    return buf.getvalue()
+
+
+@override_settings(RF_PROPAGATION_NODATA_RGB=(0, 0, 0), RF_PROPAGATION_NODATA_TOLERANCE=0)
+def test_black_background_pixels_become_fully_transparent():
+    png_bytes = geotiff_bytes_to_png(_rgb_tiff_mostly_black_with_one_red_pixel())
+    with Image.open(BytesIO(png_bytes)) as img:
+        assert img.mode == "RGBA"
+        px = img.load()
+        assert px[0, 0][3] == 0
+        assert px[3, 3][3] == 255
+
+
+@override_settings(RF_PROPAGATION_NODATA_RGB=(0, 0, 0), RF_PROPAGATION_NODATA_TOLERANCE=8)
+def test_near_black_within_tolerance_becomes_transparent():
+    img = Image.new("RGB", (2, 2), (0, 0, 0))
+    px = img.load()
+    px[1, 1] = (7, 0, 0)
+    px[0, 1] = (20, 0, 0)
+    buf = BytesIO()
+    img.save(buf, format="TIFF")
+    png_bytes = geotiff_bytes_to_png(buf.getvalue())
+    with Image.open(BytesIO(png_bytes)) as out:
+        opx = out.load()
+        assert opx[1, 1][3] == 0
+        assert opx[0, 1][3] == 255
+
+
+@override_settings(RF_PROPAGATION_NODATA_RGB=(0, 0, 0), RF_PROPAGATION_NODATA_TOLERANCE=8)
+def test_far_from_nodata_stays_opaque():
+    img = Image.new("RGB", (2, 2), (0, 0, 0))
+    px = img.load()
+    px[0, 0] = (30, 0, 0)
+    buf = BytesIO()
+    img.save(buf, format="TIFF")
+    png_bytes = geotiff_bytes_to_png(buf.getvalue())
+    with Image.open(BytesIO(png_bytes)) as out:
+        assert out.getpixel((0, 0))[3] == 255

--- a/deployment/portainer/.env.portainer.example
+++ b/deployment/portainer/.env.portainer.example
@@ -28,7 +28,10 @@ RF_PROPAGATION_HTTP_PORT=8020
 # Leave default unless you rename the service.
 # RF_PROPAGATION_ENGINE_URL=http://site-planner:8080
 # Bump this to invalidate all cached renders (e.g. after a recipe change).
-# RF_PROPAGATION_RENDER_VERSION=1
+# RF_PROPAGATION_RENDER_VERSION=2
+# PNG nodata: pixels near this RGB (comma-separated) become transparent on the map overlay.
+# RF_PROPAGATION_NODATA_RGB=0,0,0
+# RF_PROPAGATION_NODATA_TOLERANCE=8
 # Default bbox radius in metres around the tx when the profile does not specify one.
 # RF_PROPAGATION_DEFAULT_RADIUS_M=20000
 # Cap on how long the render task polls the engine before giving up.

--- a/docs/features/rf_propagation/README.md
+++ b/docs/features/rf_propagation/README.md
@@ -153,6 +153,13 @@ renders per node (configurable via `RF_PROPAGATION_READY_RETENTION`) and
 deletes any older ready rows plus their PNG files. `failed` rows older
 than 7 days are also pruned per node.
 
+## PNG overlay transparency
+
+After GeoTIFF→PNG, pixels within **`RF_PROPAGATION_NODATA_TOLERANCE`**
+of **`RF_PROPAGATION_NODATA_RGB`** (comma-separated `R,G,B`, default
+`0,0,0`) are written with alpha 0 so the Leaflet basemap shows through
+outside the tinted coverage.
+
 ## Environment variables
 
 | Variable | Default | Where used | Notes |
@@ -160,7 +167,9 @@ than 7 days are also pruned per node.
 | `RF_PROPAGATION_ENGINE_URL` | _(empty)_ | worker | Internal URL of the engine, e.g. `http://rf-propagation:8080`. Required for real renders. |
 | `RF_PROPAGATION_ASSET_DIR` | `/var/meshflow/generated-assets/rf-propagation` | api + worker | Mounted from the `rf_assets` named volume; must be shared between `api` and `celery-rf-worker`. |
 | `RF_PROPAGATION_IMAGE_TAG` | `latest-dev` | compose | Tag for the engine image. |
-| `RF_PROPAGATION_RENDER_VERSION` | `1` | api + worker | Bump to invalidate all cached renders. |
+| `RF_PROPAGATION_RENDER_VERSION` | `2` | api + worker | Bump to invalidate all cached renders. |
+| `RF_PROPAGATION_NODATA_RGB` | `0,0,0` | api + worker | RGB colour treated as transparent background in the PNG overlay. |
+| `RF_PROPAGATION_NODATA_TOLERANCE` | `8` | api + worker | Per-channel distance from nodata RGB (0–255) to clear alpha. |
 | `RF_PROPAGATION_DEFAULT_RADIUS_M` | `20000` | api + worker | Radius of the predicted coverage bbox in metres. |
 | `RF_PROPAGATION_POLL_MAX_SECONDS` | `300` | worker | Cap on cumulative polling before the render is marked failed. |
 | `RF_PROPAGATION_READY_RETENTION` | `3` | worker | Number of `ready` renders kept per node. |


### PR DESCRIPTION
# Summary

- GeoTIFF→PNG: pixels within tolerance of configurable nodata RGB get alpha 0 for Leaflet overlay.
- New settings: `RF_PROPAGATION_NODATA_RGB`, `RF_PROPAGATION_NODATA_TOLERANCE`.
- Default `RF_PROPAGATION_RENDER_VERSION` bumped to `2` to invalidate cached opaque PNGs.
- Docs + Portainer env example updated.

Paired UI PR: pskillen/meshtastic-bot-ui#187 (meshtastic-bot-ui#185).

Closes #188

## Testing performed

- `black` / `isort` / `flake8` on touched Python files
- `pytest` (392 tests) in `Meshflow/`