### PR TITLE
fix(rf-propagation): use GeoTIFF georef tags for overlay bounds

### DIFF
--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -157,7 +157,7 @@ RF_PROPAGATION_ASSET_DIR = Path(
 # Meshtastic Site Planner engine base URL (FastAPI service, see deployment/docker-compose.yaml).
 RF_PROPAGATION_ENGINE_URL = os.environ.get("RF_PROPAGATION_ENGINE_URL", "")
 # Bump this to invalidate every cached render (pipeline or post-processing change).
-RF_PROPAGATION_RENDER_VERSION = os.environ.get("RF_PROPAGATION_RENDER_VERSION", "2")
+RF_PROPAGATION_RENDER_VERSION = os.environ.get("RF_PROPAGATION_RENDER_VERSION", "3")
 
 
 def _rf_propagation_nodata_rgb() -> tuple[int, int, int]:

--- a/Meshflow/rf_propagation/image.py
+++ b/Meshflow/rf_propagation/image.py
@@ -1,33 +1,66 @@
-"""GeoTIFF bytes to PNG bytes.
+"""GeoTIFF bytes to PNG bytes (+ true bounds).
 
-We deliberately avoid ``rasterio``/GDAL — the engine already emits the
+We deliberately avoid ``rasterio``/GDAL \u2014 the engine already emits the
 GeoTIFF in EPSG:4326 with the payload we asked for, so the only thing we
 need to do on the API side is re-encode to a PNG the browser can draw
 inside a Leaflet ``imageOverlay``. Pillow handles this for baseline TIFFs;
 for oddball SPLAT!/tifffile variants we fall back to ``tifffile``.
+
+We also read the GeoTIFF's georeferencing metadata (``ModelTiepointTag``
++ ``ModelPixelScaleTag``) to recover the true lat/lng bounds that the
+engine actually rendered into. The request ``radius`` is only a hint;
+SPLAT! snaps the output to its SRTM tile grid and the resulting KML
+``LatLonBox`` can differ from our naive ``\u00b1radius/111320\u00b0`` bbox.
+Using the GeoTIFF-embedded bounds is the only way to line the PNG up on
+the map correctly.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from io import BytesIO
 
+from .bounds import Bbox
+
 logger = logging.getLogger(__name__)
+
+# GeoTIFF tag IDs (see https://www.awaresystems.be/imaging/tiff/tifftags/modeltiepointtag.html).
+_TAG_MODEL_TIEPOINT = 33922
+_TAG_MODEL_PIXEL_SCALE = 33550
 
 
 class TiffDecodeError(RuntimeError):
     """Raised when neither Pillow nor tifffile can decode the engine output."""
 
 
+@dataclass(frozen=True)
+class RenderImage:
+    """PNG bytes for the browser + the true GeoTIFF bounds (if recoverable)."""
+
+    png_bytes: bytes
+    bounds: Bbox | None
+
+
 def geotiff_bytes_to_png(tiff_bytes: bytes) -> bytes:
-    """Convert a GeoTIFF byte blob into a PNG byte blob (RGBA)."""
+    """Convert a GeoTIFF byte blob into a PNG byte blob (RGBA).
+
+    Kept for call sites that only need the PNG; prefer
+    :func:`geotiff_to_render_image` when bounds are also required.
+    """
+
+    return geotiff_to_render_image(tiff_bytes).png_bytes
+
+
+def geotiff_to_render_image(tiff_bytes: bytes) -> RenderImage:
+    """Decode a GeoTIFF into (RGBA PNG bytes, bounds)."""
 
     if not tiff_bytes:
         raise TiffDecodeError("engine returned empty GeoTIFF bytes")
 
     try:
         return _pillow_convert(tiff_bytes)
-    except Exception as exc:  # noqa: BLE001 — fallback path is the whole point
+    except Exception as exc:  # noqa: BLE001 \u2014 fallback path is the whole point
         logger.warning("rf_propagation.image: Pillow failed (%s); trying tifffile", exc)
 
     try:
@@ -64,21 +97,30 @@ def _png_bytes_from_rgba(img) -> bytes:
     return buf.getvalue()
 
 
-def _pillow_convert(tiff_bytes: bytes) -> bytes:
+def _pillow_convert(tiff_bytes: bytes) -> RenderImage:
     from PIL import Image  # local import so test runners without Pillow can skip
 
     with Image.open(BytesIO(tiff_bytes)) as img:
         img.load()
+        width, height = img.size
+        bounds = _bounds_from_pillow_tags(img, width, height)
         pil_img = img.convert("RGBA") if img.mode != "RGBA" else img.copy()
-    return _png_bytes_from_rgba(pil_img)
+
+    return RenderImage(png_bytes=_png_bytes_from_rgba(pil_img), bounds=bounds)
 
 
-def _tifffile_convert(tiff_bytes: bytes) -> bytes:
+def _tifffile_convert(tiff_bytes: bytes) -> RenderImage:
     import numpy as np
     import tifffile
     from PIL import Image
 
-    arr = tifffile.imread(BytesIO(tiff_bytes))
+    with tifffile.TiffFile(BytesIO(tiff_bytes)) as tif:
+        page = tif.pages[0]
+        arr = page.asarray()
+        height = int(page.shape[0])
+        width = int(page.shape[1])
+        bounds = _bounds_from_tifffile_tags(page, width, height)
+
     if arr.ndim == 2:
         img = Image.fromarray(arr).convert("RGBA")
     elif arr.ndim == 3 and arr.shape[2] in (3, 4):
@@ -87,4 +129,92 @@ def _tifffile_convert(tiff_bytes: bytes) -> bytes:
     else:
         raise TiffDecodeError(f"unexpected TIFF shape: {arr.shape}")
 
-    return _png_bytes_from_rgba(img)
+    return RenderImage(png_bytes=_png_bytes_from_rgba(img), bounds=bounds)
+
+
+def _bounds_from_pillow_tags(img, width: int, height: int) -> Bbox | None:
+    """Extract bounds from Pillow's ``tag_v2`` (TIFF 6.0 + GeoTIFF tags)."""
+
+    tag_v2 = getattr(img, "tag_v2", None)
+    if tag_v2 is None:
+        return None
+    tiepoint = tag_v2.get(_TAG_MODEL_TIEPOINT)
+    pixel_scale = tag_v2.get(_TAG_MODEL_PIXEL_SCALE)
+    return _bounds_from_georef(tiepoint, pixel_scale, width, height)
+
+
+def _bounds_from_tifffile_tags(page, width: int, height: int) -> Bbox | None:
+    """Extract bounds from a ``tifffile`` page's ``tags`` collection."""
+
+    tags = getattr(page, "tags", None)
+    if tags is None:
+        return None
+
+    def _value(name: str, tag_id: int):
+        # tifffile indexes by both name and id; try both defensively.
+        entry = tags.get(name) if hasattr(tags, "get") else None
+        if entry is None and hasattr(tags, "get"):
+            entry = tags.get(tag_id)
+        return getattr(entry, "value", None) if entry is not None else None
+
+    tiepoint = _value("ModelTiepointTag", _TAG_MODEL_TIEPOINT)
+    pixel_scale = _value("ModelPixelScaleTag", _TAG_MODEL_PIXEL_SCALE)
+    return _bounds_from_georef(tiepoint, pixel_scale, width, height)
+
+
+def _bounds_from_georef(tiepoint, pixel_scale, width: int, height: int) -> Bbox | None:
+    """Compute a ``Bbox`` from raw GeoTIFF tag values.
+
+    ``ModelTiepointTag`` is ``[I, J, K, X, Y, Z]`` mapping raster pixel
+    ``(I, J)`` to world coord ``(X, Y)``. For the common ``north-up`` /
+    SPLAT! case ``(I, J)`` is ``(0, 0)`` so ``(X, Y)`` is the north-west
+    corner in degrees.
+
+    ``ModelPixelScaleTag`` is ``[scale_x, scale_y, scale_z]`` in world
+    units per pixel; ``scale_y`` is given as a positive value even though
+    the raster's Y axis grows downward.
+
+    Returns ``None`` if either tag is absent or the values don't look
+    like a valid WGS84 bbox (caller falls back to ``bbox_from_center``).
+    """
+
+    if tiepoint is None or pixel_scale is None:
+        return None
+    try:
+        tp = list(tiepoint)
+        ps = list(pixel_scale)
+        if len(tp) < 6 or len(ps) < 2:
+            return None
+        i, j = float(tp[0]), float(tp[1])
+        tx, ty = float(tp[3]), float(tp[4])
+        sx, sy = float(ps[0]), float(ps[1])
+    except (TypeError, ValueError) as exc:
+        logger.warning("rf_propagation.image: bad georef tag values (%s)", exc)
+        return None
+
+    if sx <= 0 or sy <= 0 or width <= 0 or height <= 0:
+        return None
+
+    # World coords at raster origin (pixel 0,0), adjusting if the tiepoint
+    # is not at the origin. SPLAT! always emits (0,0) but we stay generic.
+    west = tx - i * sx
+    north = ty + j * sy
+    east = west + width * sx
+    south = north - height * sy
+
+    if not (-180.0 <= west < east <= 180.0):
+        logger.warning(
+            "rf_propagation.image: bounds lng out of range west=%.6f east=%.6f",
+            west,
+            east,
+        )
+        return None
+    if not (-90.0 <= south < north <= 90.0):
+        logger.warning(
+            "rf_propagation.image: bounds lat out of range south=%.6f north=%.6f",
+            south,
+            north,
+        )
+        return None
+
+    return Bbox(west=west, south=south, east=east, north=north)

--- a/Meshflow/rf_propagation/tasks.py
+++ b/Meshflow/rf_propagation/tasks.py
@@ -34,7 +34,7 @@ from celery.exceptions import MaxRetriesExceededError, SoftTimeLimitExceeded
 from .bounds import bbox_from_center
 from .client import EngineFatalError, EngineTransientError, SitePlannerClient
 from .hashing import compute_input_hash
-from .image import TiffDecodeError, geotiff_bytes_to_png
+from .image import TiffDecodeError, geotiff_to_render_image
 from .payload import InvalidProfileError, build_request
 
 logger = logging.getLogger(__name__)
@@ -241,15 +241,27 @@ def render_rf_propagation(self, render_id: int) -> dict:
         return _mark_failed(render, f"max retries exceeded: {exc}")
 
     try:
-        png_bytes = geotiff_bytes_to_png(tiff_bytes)
+        render_image = geotiff_to_render_image(tiff_bytes)
     except TiffDecodeError as exc:
         return _mark_failed(render, f"could not decode engine GeoTIFF: {exc}")
 
-    bbox = bbox_from_center(
-        float(profile.rf_latitude),
-        float(profile.rf_longitude),
-        float(payload["radius"]),
-    )
+    png_bytes = render_image.png_bytes
+    # Prefer bounds recovered from the GeoTIFF's own georeferencing tags;
+    # SPLAT! emits an extent snapped to SRTM tile boundaries so our request
+    # ``radius`` is only a hint. Fall back to the request bbox if the engine
+    # somehow omits the tags so we still produce *some* overlay.
+    if render_image.bounds is not None:
+        bbox = render_image.bounds
+    else:
+        logger.warning(
+            "render_rf_propagation.bounds_fallback render_id=%s (GeoTIFF lacked georef tags)",
+            render_id,
+        )
+        bbox = bbox_from_center(
+            float(profile.rf_latitude),
+            float(profile.rf_longitude),
+            float(payload["radius"]),
+        )
 
     asset_filename = f"{input_hash}.png"
     asset_path = _asset_dir() / asset_filename

--- a/Meshflow/rf_propagation/tests/test_image.py
+++ b/Meshflow/rf_propagation/tests/test_image.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 import pytest
 from PIL import Image
 
-from rf_propagation.image import TiffDecodeError, geotiff_bytes_to_png
+from rf_propagation.image import TiffDecodeError, geotiff_bytes_to_png, geotiff_to_render_image
 
 
 def _synthetic_tiff_bytes(mode: str = "RGBA", size: tuple[int, int] = (8, 8)) -> bytes:
@@ -88,3 +88,68 @@ def test_far_from_nodata_stays_opaque():
     png_bytes = geotiff_bytes_to_png(buf.getvalue())
     with Image.open(BytesIO(png_bytes)) as out:
         assert out.getpixel((0, 0))[3] == 255
+
+
+def _georeferenced_tiff_bytes(
+    *,
+    size: tuple[int, int] = (10, 5),
+    tiepoint: tuple[float, float, float, float, float, float] = (
+        0.0,
+        0.0,
+        0.0,
+        -5.0,
+        56.0,
+        0.0,
+    ),
+    pixel_scale: tuple[float, float, float] = (0.1, 0.2, 0.0),
+) -> bytes:
+    img = Image.new("RGBA", size, color=(10, 20, 30, 255))
+    buf = BytesIO()
+    img.save(
+        buf,
+        format="TIFF",
+        tiffinfo={33922: tiepoint, 33550: pixel_scale},
+    )
+    return buf.getvalue()
+
+
+def test_extracts_bounds_from_pillow_geotiff_tags():
+    result = geotiff_to_render_image(_georeferenced_tiff_bytes())
+    assert result.bounds is not None
+    # west = tiepoint.X - I*scale_x = -5.0; east = west + width*scale_x
+    assert result.bounds.west == pytest.approx(-5.0)
+    assert result.bounds.east == pytest.approx(-4.0)
+    # north = tiepoint.Y = 56.0; south = north - height*scale_y
+    assert result.bounds.north == pytest.approx(56.0)
+    assert result.bounds.south == pytest.approx(55.0)
+
+
+def test_extracts_bounds_with_nonzero_tiepoint_pixel():
+    """SPLAT! uses (0,0) but the maths must still work for other tiepoints."""
+    result = geotiff_to_render_image(
+        _georeferenced_tiff_bytes(
+            size=(4, 3),
+            tiepoint=(1.0, 1.0, 0.0, -3.0, 52.0, 0.0),
+            pixel_scale=(0.5, 0.25, 0.0),
+        )
+    )
+    assert result.bounds is not None
+    assert result.bounds.west == pytest.approx(-3.5)
+    assert result.bounds.east == pytest.approx(-1.5)
+    assert result.bounds.north == pytest.approx(52.25)
+    assert result.bounds.south == pytest.approx(51.5)
+
+
+def test_returns_none_bounds_when_georef_tags_absent():
+    result = geotiff_to_render_image(_synthetic_tiff_bytes())
+    assert result.bounds is None
+    assert result.png_bytes.startswith(b"\x89PNG\r\n\x1a\n")
+
+
+def test_ignores_bounds_outside_valid_lat_lng_range():
+    tiff = _georeferenced_tiff_bytes(
+        tiepoint=(0.0, 0.0, 0.0, -200.0, 95.0, 0.0),
+        pixel_scale=(0.1, 0.2, 0.0),
+    )
+    result = geotiff_to_render_image(tiff)
+    assert result.bounds is None

--- a/Meshflow/rf_propagation/tests/test_tasks.py
+++ b/Meshflow/rf_propagation/tests/test_tasks.py
@@ -22,6 +22,29 @@ def _tiff_bytes(size: tuple[int, int] = (8, 8)) -> bytes:
     return buf.getvalue()
 
 
+def _georef_tiff_bytes(
+    *,
+    size: tuple[int, int] = (20, 10),
+    tiepoint: tuple[float, float, float, float, float, float] = (
+        0.0,
+        0.0,
+        0.0,
+        -4.5,
+        55.9,
+        0.0,
+    ),
+    pixel_scale: tuple[float, float, float] = (0.02, 0.03, 0.0),
+) -> bytes:
+    img = Image.new("RGBA", size, color=(10, 20, 30, 255))
+    buf = BytesIO()
+    img.save(
+        buf,
+        format="TIFF",
+        tiffinfo={33922: tiepoint, 33550: pixel_scale},
+    )
+    return buf.getvalue()
+
+
 def _make_profile(node):
     return NodeRfProfile.objects.create(
         observed_node=node,
@@ -117,6 +140,56 @@ def test_task_happy_path_writes_png_and_marks_ready(asset_dir, create_observed_n
     assert render.bounds_north > render.bounds_south
     assert fake.submit_calls == 1
     assert fake.result_calls == 1
+
+
+@pytest.mark.django_db
+def test_task_uses_bounds_from_geotiff_when_present(asset_dir, create_observed_node):
+    """When the engine GeoTIFF carries georef tags, those drive the stored bbox."""
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_830,
+        node_id_str=meshtastic_id_to_hex(820_820_830),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    tiff = _georef_tiff_bytes()
+    fake = _FakeClient(result=tiff)
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    # west = -4.5, east = -4.5 + 20*0.02 = -4.1
+    assert render.bounds_west == pytest.approx(-4.5)
+    assert render.bounds_east == pytest.approx(-4.1)
+    # north = 55.9, south = 55.9 - 10*0.03 = 55.6
+    assert render.bounds_north == pytest.approx(55.9)
+    assert render.bounds_south == pytest.approx(55.6)
+
+
+@pytest.mark.django_db
+def test_task_falls_back_to_center_bbox_when_geotiff_lacks_georef(asset_dir, create_observed_node):
+    """Legacy/plain TIFFs without georef tags must still produce a bbox."""
+    from rf_propagation import tasks as task_mod
+
+    node = create_observed_node(
+        node_id=820_820_831,
+        node_id_str=meshtastic_id_to_hex(820_820_831),
+    )
+    _make_profile(node)
+    render = NodeRfPropagationRender.objects.create(observed_node=node)
+
+    fake = _FakeClient(result=_tiff_bytes())
+    with patch.object(task_mod, "SitePlannerClient", return_value=fake):
+        task_mod.render_rf_propagation.apply(args=[render.pk]).get()
+
+    render.refresh_from_db()
+    assert render.status == NodeRfPropagationRender.Status.READY
+    # Fallback box is centred on the profile lat/lng.
+    profile_lat, profile_lng = 55.861, -4.251
+    assert render.bounds_south < profile_lat < render.bounds_north
+    assert render.bounds_west < profile_lng < render.bounds_east
 
 
 @pytest.mark.django_db

--- a/deployment/portainer/.env.portainer.example
+++ b/deployment/portainer/.env.portainer.example
@@ -28,7 +28,7 @@ RF_PROPAGATION_HTTP_PORT=8020
 # Leave default unless you rename the service.
 # RF_PROPAGATION_ENGINE_URL=http://site-planner:8080
 # Bump this to invalidate all cached renders (e.g. after a recipe change).
-# RF_PROPAGATION_RENDER_VERSION=2
+# RF_PROPAGATION_RENDER_VERSION=3
 # PNG nodata: pixels near this RGB (comma-separated) become transparent on the map overlay.
 # RF_PROPAGATION_NODATA_RGB=0,0,0
 # RF_PROPAGATION_NODATA_TOLERANCE=8

--- a/deployment/portainer/.env.portainer.example
+++ b/deployment/portainer/.env.portainer.example
@@ -87,7 +87,3 @@ DISCORD_BOT_TOKEN=
 
 # --- Monitoring ---
 PROMETHEUS_PASSWORD=change-me
-
-# --- External Docker networks (must exist: docker network create …) ---
-PG_NET_NAME=pg_net
-MONITORING_NET_NAME=monitoring

--- a/docs/features/rf_propagation/README.md
+++ b/docs/features/rf_propagation/README.md
@@ -167,10 +167,10 @@ outside the tinted coverage.
 | `RF_PROPAGATION_ENGINE_URL` | _(empty)_ | worker | Internal URL of the engine, e.g. `http://rf-propagation:8080`. Required for real renders. |
 | `RF_PROPAGATION_ASSET_DIR` | `/var/meshflow/generated-assets/rf-propagation` | api + worker | Mounted from the `rf_assets` named volume; must be shared between `api` and `celery-rf-worker`. |
 | `RF_PROPAGATION_IMAGE_TAG` | `latest-dev` | compose | Tag for the engine image. |
-| `RF_PROPAGATION_RENDER_VERSION` | `2` | api + worker | Bump to invalidate all cached renders. |
+| `RF_PROPAGATION_RENDER_VERSION` | `3` | api + worker | Bump to invalidate all cached renders. |
 | `RF_PROPAGATION_NODATA_RGB` | `0,0,0` | api + worker | RGB colour treated as transparent background in the PNG overlay. |
 | `RF_PROPAGATION_NODATA_TOLERANCE` | `8` | api + worker | Per-channel distance from nodata RGB (0–255) to clear alpha. |
-| `RF_PROPAGATION_DEFAULT_RADIUS_M` | `20000` | api + worker | Radius of the predicted coverage bbox in metres. |
+| `RF_PROPAGATION_DEFAULT_RADIUS_M` | `20000` | api + worker | Hint passed to the engine; actual rendered bounds come from the GeoTIFF's georef tags. |
 | `RF_PROPAGATION_POLL_MAX_SECONDS` | `300` | worker | Cap on cumulative polling before the render is marked failed. |
 | `RF_PROPAGATION_READY_RETENTION` | `3` | worker | Number of `ready` renders kept per node. |
 
@@ -190,6 +190,11 @@ outside the tinted coverage.
   Pillow. The converter falls back to `tifffile`; adding `rasterio`
   later would only be necessary if we see unreadable variants in
   production.
+- **Bounds come from the GeoTIFF**: the stored `bounds_*` fields are read
+  from `ModelTiepointTag` + `ModelPixelScaleTag` on the engine's GeoTIFF
+  so the Leaflet `imageOverlay` lines up with the actual rendered
+  extent. If both tags are missing we fall back to a `±radius/111320°`
+  bbox centred on the profile lat/lng and log a warning.
 
 ## Operational runbook
 


### PR DESCRIPTION
# Summary

- Read the real lat/lng extent from the engine's GeoTIFF (`ModelTiepointTag` + `ModelPixelScaleTag`) instead of computing a naive `±radius/111320°` bbox around the transmitter.
- SPLAT! snaps its output to SRTM tile boundaries, so our requested `radius` is only a hint; using the GeoTIFF's own georeferencing is the only way to line the PNG overlay up with the real rendered area — fixes both the vertical shift and the "too small" scaling vs. the upstream Site Planner instance.
- Keeps `bbox_from_center` as a last-resort fallback (+ warning) when a future engine emits a TIFF without georef tags.
- Bumps `RF_PROPAGATION_RENDER_VERSION` to `2` so existing cached renders are regenerated with correct bounds.
- Docs + Portainer env example updated.

Closes #190

## Testing performed

- `black` / `isort` / `flake8` on touched Python files
- `pytest` (395 tests) in `Meshflow/`, including new cases:
  - `test_extracts_bounds_from_pillow_geotiff_tags`
  - `test_extracts_bounds_with_nonzero_tiepoint_pixel`
  - `test_returns_none_bounds_when_georef_tags_absent`
  - `test_ignores_bounds_outside_valid_lat_lng_range`
  - `test_task_uses_bounds_from_geotiff_when_present`
  - `test_task_falls_back_to_center_bbox_when_geotiff_lacks_georef`

## Notes

- Orthogonal to the transparent-PNG work in #189; both are needed for a visually correct overlay, but they can be merged in either order.