### PR TITLE
fix(traceroute): cascade scheduler sources/strategies to avoid LRU stalemate

### DIFF
--- a/Meshflow/traceroute/source_selection.py
+++ b/Meshflow/traceroute/source_selection.py
@@ -33,15 +33,51 @@ logger = logging.getLogger(__name__)
 DEFAULT_ALGO = "least_recently_used"
 
 
-def _select_random(qs):
+def _select_random_ordered(qs):
     nodes = list(qs)
-    return random.choice(nodes) if nodes else None
+    random.shuffle(nodes)
+    return nodes
+
+
+def _select_random(qs):
+    ordered = _select_random_ordered(qs)
+    return random.choice(ordered) if ordered else None
+
+
+def _select_lru_ordered(qs):
+    if not qs.exists():
+        return []
+    return list(qs.annotate(last_tr=Max("traceroutes_sent__triggered_at")).order_by(F("last_tr").asc(nulls_first=True)))
 
 
 def _select_lru(qs):
-    return (
-        qs.annotate(last_tr=Max("traceroutes_sent__triggered_at")).order_by(F("last_tr").asc(nulls_first=True)).first()
+    ordered = _select_lru_ordered(qs)
+    return ordered[0] if ordered else None
+
+
+def _select_stratified_lru_ordered(qs):
+    """
+    Eligible sources ordered for cascade: constellations by oldest cluster-wide last TR,
+    then feeders within each constellation by LRU (same ordering as stratified pick).
+    """
+    eligible = list(qs.values_list("pk", flat=True))
+    if not eligible:
+        return []
+
+    rows = list(
+        ManagedNode.objects.filter(pk__in=eligible)
+        .values("constellation_id")
+        .annotate(c_last_tr=Max("traceroutes_sent__triggered_at"))
+        .order_by(F("c_last_tr").asc(nulls_first=True))
     )
+    if not rows:
+        return _select_lru_ordered(qs)
+
+    ordered: list[ManagedNode] = []
+    for row in rows:
+        cid = row["constellation_id"]
+        ordered.extend(_select_lru_ordered(qs.filter(constellation_id=cid)))
+    return ordered
 
 
 def _select_stratified_lru(qs):
@@ -49,21 +85,8 @@ def _select_stratified_lru(qs):
     Two-level LRU: pick the constellation whose most recent TR (any feeder) is oldest,
     then LRU among feeders in that constellation.
     """
-    eligible = list(qs.values_list("pk", flat=True))
-    if not eligible:
-        return None
-
-    last_per_constellation = (
-        ManagedNode.objects.filter(pk__in=eligible)
-        .values("constellation_id")
-        .annotate(c_last_tr=Max("traceroutes_sent__triggered_at"))
-        .order_by(F("c_last_tr").asc(nulls_first=True))
-    )
-    row = last_per_constellation.first()
-    if not row:
-        return _select_lru(qs)
-    cid = row["constellation_id"]
-    return _select_lru(qs.filter(constellation_id=cid))
+    ordered = _select_stratified_lru_ordered(qs)
+    return ordered[0] if ordered else None
 
 
 def select_traceroute_source():
@@ -96,8 +119,37 @@ def select_traceroute_source():
     return chosen
 
 
+def eligible_traceroute_sources_ordered() -> list[ManagedNode]:
+    """
+    All eligible auto-traceroute sources in scheduler order (same env algo as
+    :func:`select_traceroute_source`, but full list for per-tick cascade).
+
+    Env: ``AUTO_TR_SOURCE_SELECTION_ALGO`` — ``least_recently_used`` (default),
+    ``random``, or ``stratified_lru``.
+    """
+    raw = os.environ.get("AUTO_TR_SOURCE_SELECTION_ALGO", DEFAULT_ALGO)
+    name = raw.strip().lower() if raw else DEFAULT_ALGO
+    selector = SOURCE_SELECTORS_ORDERED.get(name)
+    if selector is None:
+        logger.warning(
+            "Unknown AUTO_TR_SOURCE_SELECTION_ALGO=%r, falling back to %s",
+            name,
+            DEFAULT_ALGO,
+        )
+        selector = SOURCE_SELECTORS_ORDERED[DEFAULT_ALGO]
+
+    qs = eligible_auto_traceroute_sources_queryset()
+    return selector(qs)
+
+
 SOURCE_SELECTORS = {
     "random": _select_random,
     "least_recently_used": _select_lru,
     "stratified_lru": _select_stratified_lru,
+}
+
+SOURCE_SELECTORS_ORDERED = {
+    "random": _select_random_ordered,
+    "least_recently_used": _select_lru_ordered,
+    "stratified_lru": _select_stratified_lru_ordered,
 }

--- a/Meshflow/traceroute/strategy_rotation.py
+++ b/Meshflow/traceroute/strategy_rotation.py
@@ -71,26 +71,30 @@ def _strategy_sort_tuple(strategy: str, last_iso: str | None) -> tuple:
     return (1, last_iso, ti)
 
 
-def pick_strategy_for_feeder(managed_node: ManagedNode) -> str | None:
+def ordered_strategies_for_feeder(managed_node: ManagedNode) -> list[str]:
+    """
+    Applicable strategies for *managed_node* ordered by Redis LRU (stalest first),
+    matching :func:`pick_strategy_for_feeder` tie-breaking.
+    """
     strategies = applicable_strategies(managed_node)
     if not strategies:
-        return None
+        return []
 
     keys = [KEY_FMT.format(feeder_pk=managed_node.pk, strategy=s) for s in strategies]
     lasts = cache.get_many(keys)
 
-    best: str | None = None
-    best_key_tuple: tuple | None = None
-
+    decorated: list[tuple[tuple, str]] = []
     for s in strategies:
         k = KEY_FMT.format(feeder_pk=managed_node.pk, strategy=s)
         iso = lasts.get(k)
-        t = _strategy_sort_tuple(s, iso)
-        if best_key_tuple is None or t < best_key_tuple:
-            best_key_tuple = t
-            best = s
+        decorated.append((_strategy_sort_tuple(s, iso), s))
+    decorated.sort(key=lambda x: x[0])
+    return [s for _, s in decorated]
 
-    return best
+
+def pick_strategy_for_feeder(managed_node: ManagedNode) -> str | None:
+    ordered = ordered_strategies_for_feeder(managed_node)
+    return ordered[0] if ordered else None
 
 
 def record_strategy_run(managed_node: ManagedNode, strategy: str | None) -> None:

--- a/Meshflow/traceroute/tasks.py
+++ b/Meshflow/traceroute/tasks.py
@@ -13,8 +13,8 @@ from channels.layers import get_channel_layer
 from tqdm import tqdm
 
 from .models import AutoTraceRoute
-from .source_selection import select_traceroute_source
-from .strategy_rotation import pick_strategy_for_feeder, record_strategy_run
+from .source_selection import eligible_traceroute_sources_ordered
+from .strategy_rotation import ordered_strategies_for_feeder, record_strategy_run
 from .target_selection import pick_traceroute_target
 from .ws_notify import notify_traceroute_status_changed
 
@@ -27,63 +27,81 @@ FAILED_TR_TIMEOUT_SECONDS = int(FAILED_TR_TIMEOUT_SECONDS)
 @shared_task
 def schedule_traceroutes():
     """
-    Run periodically (cadence may vary). Pick one eligible ManagedNode via
-    ``select_traceroute_source``, rotate target strategy via Redis LRU, pick target,
-    create AutoTraceRoute (trigger_type=auto, trigger_source=scheduler), send command.
+    Run periodically (cadence may vary). For each eligible source (LRU order), try
+    hypothesis strategies (Redis LRU order), then legacy; first hit creates an
+    AutoTraceRoute and sends the command. Avoids stalemate when one strategy never
+    finds a target (meshflow-api#196).
     """
     channel_layer = get_channel_layer()
 
-    source_node = select_traceroute_source()
-    if not source_node:
+    sources = eligible_traceroute_sources_ordered()
+    if not sources:
         logger.warning(
             "schedule_traceroutes: no eligible sources (allow_auto_traceroute with "
             "ingestion within SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS)"
         )
         return {"created": 0}
 
-    strategy = pick_strategy_for_feeder(source_node)
-    if not strategy:
-        logger.warning("schedule_traceroutes: no applicable strategy for node %s", source_node.node_id_str)
-        return {"created": 0}
+    attempts: list[tuple[str, str, bool]] = []
 
-    target_node = pick_traceroute_target(source_node, strategy=strategy)
-    if not target_node:
-        logger.warning(
-            "schedule_traceroutes: no target for node %s strategy=%s",
-            source_node.node_id_str,
-            strategy,
+    for source_node in sources:
+        strategies = ordered_strategies_for_feeder(source_node)
+        chosen_strategy: str | None = None
+        target_node = None
+
+        for strategy in strategies:
+            target_node = pick_traceroute_target(source_node, strategy=strategy)
+            attempts.append((source_node.node_id_str, strategy, target_node is not None))
+            if target_node:
+                chosen_strategy = strategy
+                break
+
+        if not target_node:
+            target_node = pick_traceroute_target(
+                source_node,
+                strategy=AutoTraceRoute.TARGET_STRATEGY_LEGACY,
+            )
+            attempts.append((source_node.node_id_str, "legacy", target_node is not None))
+
+        if not target_node:
+            continue
+
+        row_strategy = chosen_strategy or AutoTraceRoute.TARGET_STRATEGY_LEGACY
+
+        auto_tr = AutoTraceRoute.objects.create(
+            source_node=source_node,
+            target_node=target_node,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+            triggered_by=None,
+            trigger_source="scheduler",
+            target_strategy=row_strategy,
+            status=AutoTraceRoute.STATUS_PENDING,
         )
-        return {"created": 0}
+        if chosen_strategy is not None:
+            record_strategy_run(source_node, chosen_strategy)
 
-    auto_tr = AutoTraceRoute.objects.create(
-        source_node=source_node,
-        target_node=target_node,
-        trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
-        triggered_by=None,
-        trigger_source="scheduler",
-        target_strategy=strategy,
-        status=AutoTraceRoute.STATUS_PENDING,
-    )
-    record_strategy_run(source_node, strategy)
+        async_to_sync(channel_layer.group_send)(
+            f"node_{source_node.node_id}",
+            {
+                "type": "node_command",
+                "command": {"type": "traceroute", "target": target_node.node_id},
+            },
+        )
 
-    async_to_sync(channel_layer.group_send)(
-        f"node_{source_node.node_id}",
-        {
-            "type": "node_command",
-            "command": {"type": "traceroute", "target": target_node.node_id},
-        },
-    )
+        auto_tr.status = AutoTraceRoute.STATUS_SENT
+        auto_tr.save(update_fields=["status"])
+        logger.info(
+            "schedule_traceroutes: sent TR %s -> %s strategy=%s (id=%s)",
+            source_node.node_id_str,
+            target_node.node_id_str,
+            row_strategy,
+            auto_tr.id,
+        )
 
-    auto_tr.status = AutoTraceRoute.STATUS_SENT
-    auto_tr.save(update_fields=["status"])
-    logger.info(
-        "schedule_traceroutes: sent TR %s -> %s (id=%s)",
-        source_node.node_id_str,
-        target_node.node_id_str,
-        auto_tr.id,
-    )
+        return {"created": 1}
 
-    return {"created": 1}
+    logger.warning("schedule_traceroutes: cascade exhausted, no TR created: %s", attempts)
+    return {"created": 0}
 
 
 @shared_task

--- a/Meshflow/traceroute/tests/test_schedule_traceroutes.py
+++ b/Meshflow/traceroute/tests/test_schedule_traceroutes.py
@@ -54,11 +54,15 @@ def test_schedule_traceroutes_creates_when_recent_observation(
     with patch("traceroute.tasks.async_to_sync", side_effect=immediate_async_to_sync):
         with patch("traceroute.tasks.get_channel_layer", return_value=channel_layer):
             with patch(
-                "traceroute.tasks.pick_strategy_for_feeder",
-                return_value=AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+                "traceroute.tasks.eligible_traceroute_sources_ordered",
+                return_value=[mn],
             ):
-                with patch("traceroute.tasks.pick_traceroute_target", return_value=target):
-                    assert schedule_traceroutes() == {"created": 1}
+                with patch(
+                    "traceroute.tasks.ordered_strategies_for_feeder",
+                    return_value=[AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS],
+                ):
+                    with patch("traceroute.tasks.pick_traceroute_target", return_value=target):
+                        assert schedule_traceroutes() == {"created": 1}
 
     assert AutoTraceRoute.objects.filter(
         source_node=mn,

--- a/Meshflow/traceroute/tests/test_schedule_traceroutes_cascade.py
+++ b/Meshflow/traceroute/tests/test_schedule_traceroutes_cascade.py
@@ -1,0 +1,151 @@
+"""Cascade behaviour for schedule_traceroutes (meshflow-api#196)."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+import packets.tests.conftest  # noqa: F401
+from traceroute.models import AutoTraceRoute
+from traceroute.tasks import schedule_traceroutes
+
+
+@pytest.mark.django_db
+def test_first_strategy_wins_records_strategy(
+    monkeypatch,
+    create_managed_node,
+    create_packet_observation,
+    create_observed_node,
+):
+    monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
+    mn = create_managed_node(allow_auto_traceroute=True)
+    create_packet_observation(observer=mn)
+    target = create_observed_node(node_id=999888777)
+
+    channel_layer = MagicMock()
+
+    def immediate_async_to_sync(async_func):
+        return async_func
+
+    with patch("traceroute.tasks.async_to_sync", side_effect=immediate_async_to_sync):
+        with patch("traceroute.tasks.get_channel_layer", return_value=channel_layer):
+            with patch("traceroute.tasks.eligible_traceroute_sources_ordered", return_value=[mn]):
+                with patch(
+                    "traceroute.tasks.ordered_strategies_for_feeder",
+                    return_value=[AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS],
+                ):
+                    with patch("traceroute.tasks.pick_traceroute_target", return_value=target):
+                        with patch("traceroute.tasks.record_strategy_run") as rec:
+                            assert schedule_traceroutes() == {"created": 1}
+
+    rec.assert_called_once_with(mn, AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS)
+    tr = AutoTraceRoute.objects.get()
+    assert tr.status == AutoTraceRoute.STATUS_SENT
+    assert tr.target_strategy == AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS
+
+
+@pytest.mark.django_db
+def test_strategy_cascade_then_legacy_skips_record_strategy_run(
+    monkeypatch,
+    create_managed_node,
+    create_packet_observation,
+    create_observed_node,
+):
+    monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
+    mn = create_managed_node(allow_auto_traceroute=True)
+    create_packet_observation(observer=mn)
+    target = create_observed_node(node_id=444555666)
+
+    channel_layer = MagicMock()
+
+    def immediate_async_to_sync(async_func):
+        return async_func
+
+    with patch("traceroute.tasks.async_to_sync", side_effect=immediate_async_to_sync):
+        with patch("traceroute.tasks.get_channel_layer", return_value=channel_layer):
+            with patch("traceroute.tasks.eligible_traceroute_sources_ordered", return_value=[mn]):
+                with patch(
+                    "traceroute.tasks.ordered_strategies_for_feeder",
+                    return_value=[
+                        AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+                        AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+                    ],
+                ):
+                    with patch(
+                        "traceroute.tasks.pick_traceroute_target",
+                        side_effect=[None, None, target],
+                    ):
+                        with patch("traceroute.tasks.record_strategy_run") as rec:
+                            assert schedule_traceroutes() == {"created": 1}
+
+    rec.assert_not_called()
+    tr = AutoTraceRoute.objects.get()
+    assert tr.target_strategy == AutoTraceRoute.TARGET_STRATEGY_LEGACY
+
+
+@pytest.mark.django_db
+def test_total_failure_logs_attempts(
+    monkeypatch,
+    create_managed_node,
+    create_packet_observation,
+    caplog,
+):
+    monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
+    mn1 = create_managed_node(allow_auto_traceroute=True, node_id=101010101)
+    mn2 = create_managed_node(allow_auto_traceroute=True, node_id=202020202)
+    create_packet_observation(observer=mn1)
+    create_packet_observation(observer=mn2)
+
+    with patch("traceroute.tasks.eligible_traceroute_sources_ordered", return_value=[mn1, mn2]):
+        with patch(
+            "traceroute.tasks.ordered_strategies_for_feeder",
+            return_value=[AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS],
+        ):
+            with patch("traceroute.tasks.pick_traceroute_target", return_value=None):
+                with caplog.at_level(logging.WARNING):
+                    assert schedule_traceroutes() == {"created": 0}
+
+    assert "cascade exhausted" in caplog.text
+    assert AutoTraceRoute.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_second_source_after_first_exhausts_including_legacy(
+    monkeypatch,
+    create_managed_node,
+    create_packet_observation,
+    create_observed_node,
+):
+    """First source: hypothesis miss + legacy miss; second source wins on first strategy."""
+    monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
+    mn1 = create_managed_node(allow_auto_traceroute=True, node_id=301301301)
+    mn2 = create_managed_node(allow_auto_traceroute=True, node_id=302302302)
+    create_packet_observation(observer=mn1)
+    create_packet_observation(observer=mn2)
+    target = create_observed_node(node_id=888777666)
+
+    channel_layer = MagicMock()
+
+    def immediate_async_to_sync(async_func):
+        return async_func
+
+    with patch("traceroute.tasks.async_to_sync", side_effect=immediate_async_to_sync):
+        with patch("traceroute.tasks.get_channel_layer", return_value=channel_layer):
+            with patch(
+                "traceroute.tasks.eligible_traceroute_sources_ordered",
+                return_value=[mn1, mn2],
+            ):
+                with patch(
+                    "traceroute.tasks.ordered_strategies_for_feeder",
+                    return_value=[AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS],
+                ):
+                    with patch(
+                        "traceroute.tasks.pick_traceroute_target",
+                        side_effect=[None, None, target],
+                    ):
+                        with patch("traceroute.tasks.record_strategy_run") as rec:
+                            assert schedule_traceroutes() == {"created": 1}
+
+    rec.assert_called_once_with(mn2, AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS)
+    assert AutoTraceRoute.objects.filter(source_node=mn2).exists()

--- a/Meshflow/traceroute/tests/test_source_selection.py
+++ b/Meshflow/traceroute/tests/test_source_selection.py
@@ -9,7 +9,11 @@ import pytest
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
 from traceroute.models import AutoTraceRoute
-from traceroute.source_selection import SOURCE_SELECTORS, select_traceroute_source
+from traceroute.source_selection import (
+    SOURCE_SELECTORS,
+    eligible_traceroute_sources_ordered,
+    select_traceroute_source,
+)
 
 
 @pytest.mark.django_db
@@ -37,6 +41,9 @@ def test_select_lru_prefers_never_used_feeder(
 
     picked = select_traceroute_source()
     assert picked.node_id == b.node_id
+
+    ordered = eligible_traceroute_sources_ordered()
+    assert [n.node_id for n in ordered] == [b.node_id, a.node_id]
 
 
 @pytest.mark.django_db

--- a/Meshflow/traceroute/tests/test_strategy_rotation.py
+++ b/Meshflow/traceroute/tests/test_strategy_rotation.py
@@ -8,6 +8,7 @@ import nodes.tests.conftest  # noqa: F401
 from constellations.models import Constellation
 from traceroute.strategy_rotation import (
     applicable_strategies,
+    ordered_strategies_for_feeder,
     pick_strategy_for_feeder,
     record_strategy_run,
 )
@@ -37,3 +38,20 @@ def test_pick_strategy_rotates_cold_cache(create_user, create_managed_node):
     second = pick_strategy_for_feeder(mn)
     assert second in applicable_strategies(mn)
     assert second != first
+
+
+@pytest.mark.django_db
+def test_ordered_strategies_first_matches_pick(create_user, create_managed_node):
+    user = create_user()
+    c = Constellation.objects.create(name="C2", created_by=user)
+    mn = create_managed_node(
+        constellation=c,
+        allow_auto_traceroute=True,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.2,
+        node_id=0xB0000002,
+    )
+    ordered = ordered_strategies_for_feeder(mn)
+    assert ordered[0] == pick_strategy_for_feeder(mn)
+    assert set(ordered) == set(applicable_strategies(mn))
+    assert len(ordered) == len(applicable_strategies(mn))


### PR DESCRIPTION
## Summary

Fixes scheduler deadlock from meshflow-api#196: when the LRU picked a perimeter feeder + hypothesis strategy with no valid target, neither strategy LRU nor source LRU advanced, so every tick returned `created=0` forever.

## Changes

- **`eligible_traceroute_sources_ordered()`** — same env algos as `select_traceroute_source`, returns full ordered list (LRU / shuffled random / stratified constellation order + per-constellation LRU).
- **`ordered_strategies_for_feeder()`** — Redis LRU order; `pick_strategy_for_feeder` delegates to first element.
- **`schedule_traceroutes`** — for each eligible source in order: try all hypothesis strategies, then `legacy`; first hit creates `AutoTraceRoute`, sends command, `record_strategy_run` **only** when a hypothesis strategy won (legacy skips Redis rotation). If all sources exhaust, log `cascade exhausted` with attempt tuples and return `created=0`.
- **Logging** — success line includes `strategy=`; failure includes attempts list.

## Testing

- New: `test_schedule_traceroutes_cascade.py` (cascade + legacy + second source + total failure).
- Extended: `test_schedule_traceroutes.py`, `test_source_selection.py`, `test_strategy_rotation.py`.

Closes #196