### PR TITLE
feat(traceroute): constellation coverage targets, strategy filter, feeder list

### DIFF
--- a/Meshflow/traceroute/reach.py
+++ b/Meshflow/traceroute/reach.py
@@ -32,6 +32,24 @@ from nodes.models import ManagedNode, NodeLatestStatus, ObservedNode
 from .models import AutoTraceRoute
 
 
+def target_strategy_tokens_to_q(tokens: Iterable[str]) -> Q | None:
+    """Build an OR filter over ``AutoTraceRoute.target_strategy`` for CSV tokens.
+
+    ``legacy`` matches null or explicit legacy strategy, matching traceroute list
+    behaviour.
+    """
+    strat_q = Q()
+    any_valid = False
+    for t in tokens:
+        if t in ("legacy", AutoTraceRoute.TARGET_STRATEGY_LEGACY):
+            strat_q |= Q(target_strategy__isnull=True) | Q(target_strategy=AutoTraceRoute.TARGET_STRATEGY_LEGACY)
+            any_valid = True
+        elif t in dict(AutoTraceRoute.TARGET_STRATEGY_CHOICES):
+            strat_q |= Q(target_strategy=t)
+            any_valid = True
+    return strat_q if any_valid else None
+
+
 @dataclass(frozen=True)
 class ReachRow:
     """One (feeder, target) pair with attempt and success counts in window."""
@@ -126,11 +144,16 @@ def compute_reach(
     triggered_at_before: datetime | None = None,
     constellation_id: int | None = None,
     feeder_id: int | None = None,
+    target_strategy_tokens: list[str] | None = None,
 ) -> list[ReachRow]:
     """Aggregate per-(feeder, target) attempt and success counts.
 
     ``feeder_id`` is the meshtastic node id of a ManagedNode (not the internal
     UUID) so callers can use the same id space as the rest of the API.
+
+    ``target_strategy_tokens`` optionally restricts to traceroutes whose
+    ``target_strategy`` matches one of the tokens (``legacy`` matches null or
+    explicit legacy).
 
     Rows where the target has no known position are dropped. Rows where the
     feeder has no known position are dropped. Pending and sent traceroutes are
@@ -148,6 +171,11 @@ def compute_reach(
     if feeder_id is not None:
         qs = qs.filter(source_node__node_id=feeder_id)
     qs = qs.filter(source_node__isnull=False, target_node__isnull=False)
+
+    if target_strategy_tokens:
+        fq = target_strategy_tokens_to_q(target_strategy_tokens)
+        if fq is not None:
+            qs = qs.filter(fq)
 
     grouped = list(
         qs.values("source_node_id", "target_node_id").annotate(
@@ -216,4 +244,68 @@ def compute_reach(
                 successes=g["successes"],
             )
         )
+    return out
+
+
+def aggregate_reach_rows_to_constellation_targets(rows: list[ReachRow]) -> list[dict]:
+    """Merge per-(feeder, target) rows into one dict per target for constellation maps."""
+    by_target: dict[int, dict] = {}
+    for r in rows:
+        tid = r.target_node_id
+        if tid not in by_target:
+            by_target[tid] = {
+                "node_id": tid,
+                "node_id_str": r.target_node_id_str,
+                "short_name": r.target_short_name,
+                "long_name": r.target_long_name,
+                "lat": r.target_lat,
+                "lng": r.target_lng,
+                "attempts": 0,
+                "successes": 0,
+                "feeder_node_ids": set(),
+            }
+        agg = by_target[tid]
+        agg["attempts"] += r.attempts
+        agg["successes"] += r.successes
+        agg["feeder_node_ids"].add(r.feeder_node_id)
+
+    targets = []
+    for agg in by_target.values():
+        feeder_ids = agg.pop("feeder_node_ids")
+        targets.append({**agg, "contributing_feeders": len(feeder_ids)})
+    targets.sort(key=lambda t: t["node_id"])
+    return targets
+
+
+def constellation_feeder_markers(constellation_id: int) -> list[dict]:
+    """All managed nodes in a constellation with a resolvable map position."""
+    feeders = list(ManagedNode.objects.filter(constellation_id=constellation_id))
+    if not feeders:
+        return []
+
+    positions = _bulk_feeder_positions(feeders)
+    node_ids = {mn.node_id for mn in feeders}
+    feeder_display = {
+        row["node_id"]: row
+        for row in ObservedNode.objects.filter(node_id__in=node_ids).values("node_id", "short_name", "long_name")
+    }
+
+    out: list[dict] = []
+    for mn in feeders:
+        pos = positions.get(mn.internal_id)
+        if pos is None:
+            continue
+        display = feeder_display.get(mn.node_id) or {}
+        out.append(
+            {
+                "managed_node_id": str(mn.internal_id),
+                "node_id": mn.node_id,
+                "node_id_str": meshtastic_id_to_hex(mn.node_id),
+                "short_name": display.get("short_name") or mn.name,
+                "long_name": display.get("long_name"),
+                "lat": pos[0],
+                "lng": pos[1],
+            }
+        )
+    out.sort(key=lambda x: x["node_id"])
     return out

--- a/Meshflow/traceroute/tests/test_reach.py
+++ b/Meshflow/traceroute/tests/test_reach.py
@@ -8,7 +8,7 @@ import pytest
 
 from nodes.models import NodeLatestStatus
 from traceroute.models import AutoTraceRoute
-from traceroute.reach import compute_reach
+from traceroute.reach import compute_reach, target_strategy_tokens_to_q
 
 pytestmark = pytest.mark.django_db
 
@@ -217,6 +217,76 @@ def test_window_filter(create_managed_node, create_observed_node, create_auto_tr
     assert len(rows) == 1
     assert rows[0].attempts == 1
     assert rows[0].successes == 1
+
+
+def test_target_strategy_tokens_filter(create_managed_node, create_observed_node, create_auto_traceroute):
+    feeder = create_managed_node(
+        node_id=0xF11D_E00C,
+        default_location_latitude=55.86,
+        default_location_longitude=-4.25,
+    )
+    target = create_observed_node(node_id=0x7777_000A)
+    NodeLatestStatus.objects.create(node=target, latitude=55.86, longitude=-4.20)
+
+    create_auto_traceroute(
+        source_node=feeder,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+    )
+    create_auto_traceroute(
+        source_node=feeder,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        target_strategy=AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+    )
+
+    rows_all = compute_reach(feeder_id=feeder.node_id)
+    assert rows_all[0].attempts == 2
+
+    rows_intra = compute_reach(
+        feeder_id=feeder.node_id,
+        target_strategy_tokens=["intra_zone"],
+    )
+    assert len(rows_intra) == 1
+    assert rows_intra[0].attempts == 1
+
+
+def test_target_strategy_legacy_matches_null(create_managed_node, create_observed_node, create_auto_traceroute):
+    feeder = create_managed_node(
+        node_id=0xF11D_E00D,
+        default_location_latitude=55.86,
+        default_location_longitude=-4.25,
+    )
+    target = create_observed_node(node_id=0x7777_000B)
+    NodeLatestStatus.objects.create(node=target, latitude=55.86, longitude=-4.20)
+
+    create_auto_traceroute(
+        source_node=feeder,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        target_strategy=None,
+    )
+    create_auto_traceroute(
+        source_node=feeder,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        target_strategy=AutoTraceRoute.TARGET_STRATEGY_LEGACY,
+    )
+    create_auto_traceroute(
+        source_node=feeder,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+    )
+
+    rows = compute_reach(feeder_id=feeder.node_id, target_strategy_tokens=["legacy"])
+    assert len(rows) == 1
+    assert rows[0].attempts == 2
+
+
+def test_target_strategy_tokens_to_q_returns_none_for_invalid_only():
+    assert target_strategy_tokens_to_q(["not_a_real_strategy"]) is None
 
 
 def test_emits_display_metadata(create_managed_node, create_observed_node, create_auto_traceroute):

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -770,6 +770,47 @@ class TestFeederReach:
         assert row["attempts"] == 10
         assert row["successes"] == 7
 
+    def test_feeder_reach_target_strategy_filter(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        from nodes.models import NodeLatestStatus
+
+        api_client.force_authenticate(user=create_user())
+        feeder = create_managed_node(
+            node_id=0xAAAA_AA20,
+            default_location_latitude=55.86,
+            default_location_longitude=-4.25,
+        )
+        target = create_observed_node(node_id=0xCCCC_CC20)
+        NodeLatestStatus.objects.create(node=target, latitude=55.86, longitude=-4.20)
+
+        create_auto_traceroute(
+            source_node=feeder,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        )
+        create_auto_traceroute(
+            source_node=feeder,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+        )
+
+        resp = api_client.get(
+            "/api/traceroutes/feeder-reach/",
+            {"feeder_id": str(feeder.node_id), "target_strategy": "intra_zone"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["targets"]) == 1
+        assert body["targets"][0]["attempts"] == 1
+
 
 @pytest.mark.django_db
 class TestConstellationCoverage:
@@ -897,3 +938,137 @@ class TestConstellationCoverage:
         )
         assert resp.status_code == 200
         assert resp.json()["h3_resolution"] == 8
+
+    def test_include_targets_returns_targets_and_feeders(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+        create_constellation,
+    ):
+        from nodes.models import NodeLatestStatus
+
+        owner = create_user()
+        api_client.force_authenticate(user=owner)
+        constellation = create_constellation(created_by=owner)
+
+        feeder_a = create_managed_node(
+            owner=owner,
+            constellation=constellation,
+            node_id=0xAAAA_AA10,
+            default_location_latitude=55.86,
+            default_location_longitude=-4.25,
+        )
+        feeder_b = create_managed_node(
+            owner=owner,
+            constellation=constellation,
+            node_id=0xAAAA_AA11,
+            default_location_latitude=55.90,
+            default_location_longitude=-4.30,
+        )
+        target = create_observed_node(node_id=0xCCCC_CC10)
+        NodeLatestStatus.objects.create(node=target, latitude=55.87, longitude=-4.22)
+
+        create_auto_traceroute(
+            source_node=feeder_a,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+        create_auto_traceroute(
+            source_node=feeder_b,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_FAILED,
+        )
+
+        resp = api_client.get(
+            "/api/traceroutes/constellation-coverage/",
+            {
+                "constellation_id": str(constellation.id),
+                "include_targets": "1",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "targets" in body
+        assert "feeders" in body
+        assert len(body["targets"]) == 1
+        assert body["targets"][0]["attempts"] == 2
+        assert body["targets"][0]["successes"] == 1
+        assert body["targets"][0]["contributing_feeders"] == 2
+        feeder_ids = {f["node_id"] for f in body["feeders"]}
+        assert feeder_a.node_id in feeder_ids
+        assert feeder_b.node_id in feeder_ids
+
+    def test_omit_include_targets_has_no_targets_key(
+        self,
+        api_client,
+        create_user,
+        create_constellation,
+    ):
+        owner = create_user()
+        api_client.force_authenticate(user=owner)
+        constellation = create_constellation(created_by=owner)
+        resp = api_client.get(
+            "/api/traceroutes/constellation-coverage/",
+            {"constellation_id": str(constellation.id)},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "targets" not in body
+        assert "feeders" not in body
+
+    def test_constellation_target_strategy_filters_hexes(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+        create_constellation,
+    ):
+        from nodes.models import NodeLatestStatus
+
+        owner = create_user()
+        api_client.force_authenticate(user=owner)
+        constellation = create_constellation(created_by=owner)
+        feeder = create_managed_node(
+            owner=owner,
+            constellation=constellation,
+            node_id=0xAAAA_AA12,
+            default_location_latitude=55.86,
+            default_location_longitude=-4.25,
+        )
+        target = create_observed_node(node_id=0xCCCC_CC11)
+        NodeLatestStatus.objects.create(node=target, latitude=55.86, longitude=-4.20)
+
+        create_auto_traceroute(
+            source_node=feeder,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        )
+        create_auto_traceroute(
+            source_node=feeder,
+            target_node=target,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+        )
+
+        resp_all = api_client.get(
+            "/api/traceroutes/constellation-coverage/",
+            {"constellation_id": str(constellation.id)},
+        )
+        assert resp_all.status_code == 200
+        assert resp_all.json()["hexes"][0]["attempts"] == 2
+
+        resp_f = api_client.get(
+            "/api/traceroutes/constellation-coverage/",
+            {
+                "constellation_id": str(constellation.id),
+                "target_strategy": "intra_zone",
+            },
+        )
+        assert resp_f.status_code == 200
+        assert resp_f.json()["hexes"][0]["attempts"] == 1

--- a/Meshflow/traceroute/views.py
+++ b/Meshflow/traceroute/views.py
@@ -83,19 +83,15 @@ def traceroute_list(request):
     if trigger_type:
         qs = qs.filter(trigger_type=trigger_type)
 
+    from .reach import target_strategy_tokens_to_q
+
     target_strategy_param = request.query_params.get("target_strategy")
     if target_strategy_param:
         tokens = [t.strip() for t in target_strategy_param.split(",") if t.strip()]
         if tokens:
-            strat_q = Q()
-            for t in tokens:
-                if t in ("legacy", AutoTraceRoute.TARGET_STRATEGY_LEGACY):
-                    strat_q |= Q(target_strategy__isnull=True) | Q(
-                        target_strategy=AutoTraceRoute.TARGET_STRATEGY_LEGACY
-                    )
-                elif t in dict(AutoTraceRoute.TARGET_STRATEGY_CHOICES):
-                    strat_q |= Q(target_strategy=t)
-            qs = qs.filter(strat_q)
+            fq = target_strategy_tokens_to_q(tokens)
+            if fq is not None:
+                qs = qs.filter(fq)
 
     triggered_after = request.query_params.get("triggered_after")
     if triggered_after:
@@ -363,6 +359,22 @@ def _parse_window(request):
     return triggered_at_after, triggered_at_before
 
 
+def _parse_target_strategy_tokens(request) -> list[str] | None:
+    """Comma-separated ``target_strategy`` query values, or None if absent/empty."""
+    param = request.query_params.get("target_strategy")
+    if not param:
+        return None
+    tokens = [t.strip() for t in param.split(",") if t.strip()]
+    return tokens or None
+
+
+def _include_targets_from_request(request) -> bool:
+    val = request.query_params.get("include_targets")
+    if val is None:
+        return False
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def feeder_reach(request):
@@ -395,11 +407,13 @@ def feeder_reach(request):
         return Response({"detail": "Feeder not found."}, status=status.HTTP_404_NOT_FOUND)
 
     triggered_at_after, triggered_at_before = _parse_window(request)
+    strategy_tokens = _parse_target_strategy_tokens(request)
 
     rows = compute_reach(
         triggered_at_after=triggered_at_after,
         triggered_at_before=triggered_at_before,
         feeder_id=feeder_id,
+        target_strategy_tokens=strategy_tokens,
     )
 
     if rows:
@@ -466,8 +480,6 @@ def constellation_coverage(request):
     """
     import h3
 
-    from .reach import compute_reach
-
     constellation_param = request.query_params.get("constellation_id")
     if not constellation_param:
         return Response(
@@ -491,11 +503,16 @@ def constellation_coverage(request):
     h3_resolution = max(0, min(15, h3_resolution))
 
     triggered_at_after, triggered_at_before = _parse_window(request)
+    strategy_tokens = _parse_target_strategy_tokens(request)
+    include_targets = _include_targets_from_request(request)
+
+    from .reach import aggregate_reach_rows_to_constellation_targets, compute_reach, constellation_feeder_markers
 
     rows = compute_reach(
         triggered_at_after=triggered_at_after,
         triggered_at_before=triggered_at_before,
         constellation_id=constellation_id,
+        target_strategy_tokens=strategy_tokens,
     )
 
     bins: dict = {}
@@ -531,19 +548,22 @@ def constellation_coverage(request):
         )
     hexes.sort(key=lambda h: h["h3_index"])
 
-    return Response(
-        {
-            "constellation_id": constellation_id,
-            "h3_resolution": h3_resolution,
-            "hexes": hexes,
-            "meta": {
-                "window": {
-                    "start": triggered_at_after.isoformat() if triggered_at_after else None,
-                    "end": triggered_at_before.isoformat() if triggered_at_before else None,
-                },
+    payload: dict = {
+        "constellation_id": constellation_id,
+        "h3_resolution": h3_resolution,
+        "hexes": hexes,
+        "meta": {
+            "window": {
+                "start": triggered_at_after.isoformat() if triggered_at_after else None,
+                "end": triggered_at_before.isoformat() if triggered_at_before else None,
             },
-        }
-    )
+        },
+    }
+    if include_targets:
+        payload["targets"] = aggregate_reach_rows_to_constellation_targets(rows)
+        payload["feeders"] = constellation_feeder_markers(constellation_id)
+
+    return Response(payload)
 
 
 @api_view(["GET"])

--- a/docs/features/traceroute/coverage.md
+++ b/docs/features/traceroute/coverage.md
@@ -106,6 +106,11 @@ Implementation:
 - `constellation_id` (filter to feeders in this constellation; targets are
   *not* filtered, by design — we want to see how far into other regions a
   constellation's feeders reach)
+- `target_strategy_tokens` (optional list of strings, e.g. ``intra_zone``,
+  ``dx_across``, ``legacy``): when provided, only traceroutes whose
+  ``AutoTraceRoute.target_strategy`` matches one of the tokens are counted.
+  ``legacy`` matches null or explicit legacy strategy (same semantics as the
+  traceroute list ``target_strategy`` query param).
 
 Both view functions are thin wrappers over this helper.
 
@@ -130,6 +135,7 @@ Implemented in **`Meshflow/traceroute/views.py::feeder_reach()`**.
 | `feeder_id` | yes | integer | Meshtastic node id of a `ManagedNode`. 400 if missing or non-integer; 404 if not found. |
 | `triggered_at_after` | no | ISO 8601 datetime | Start of window (inclusive). |
 | `triggered_at_before` | no | ISO 8601 datetime | End of window (inclusive). |
+| `target_strategy` | no | comma-separated strings | Same tokens as the traceroute list filter (`intra_zone`, `dx_across`, `dx_same_side`, `legacy`). When omitted, all strategies count. |
 
 **Response shape** (full schema: `FeederReach` in `openapi.yaml`)
 
@@ -181,6 +187,8 @@ Implemented in **`Meshflow/traceroute/views.py::constellation_coverage()`**.
 | `triggered_at_after` | no | ISO 8601 datetime | |
 | `triggered_at_before` | no | ISO 8601 datetime | |
 | `h3_resolution` | no | integer | Default 6. Clamped to `[0, 15]`. |
+| `target_strategy` | no | comma-separated strings | Restrict rows to these selection strategies before binning (same semantics as `feeder-reach`). |
+| `include_targets` | no | boolean-ish | When `1`, `true`, `yes`, or `on`, the response also includes `targets` (per-target aggregates across all feeders) and `feeders` (all managed nodes in the constellation with a map position). Omit or false for the original hex-only payload. |
 
 **Aggregation**
 
@@ -231,6 +239,16 @@ for full numbers.
 }
 ```
 
+When `include_targets=1`, two extra top-level arrays are present:
+
+- **`targets`**: one object per distinct target node reached in the window,
+  with summed `attempts` / `successes` across every feeder in the constellation
+  and `contributing_feeders` (distinct feeder count that attempted that target).
+- **`feeders`**: one object per `ManagedNode` in the constellation that has a
+  resolvable position (`default_location_*` or linked `ObservedNode.latest_status`),
+  regardless of whether it appears in the window's traceroute rows — so the map
+  can always show infrastructure.
+
 ---
 
 ## Frontend rendering
@@ -264,9 +282,10 @@ a metric question comes back. Source files live in
 ### Constellation page → `ConstellationCoveragePage`
 
 - `useConstellationCoverage(constellationId, window, h3Resolution)` fetches
-  one `ConstellationCoverage` payload.
+  one `ConstellationCoverage` payload (optionally with `include_targets=1` for
+  per-target dots and managed-node markers).
 - `ConstellationCoverageMap` renders a single `H3HexagonLayer` over the
-  server-binned hexes.
+  server-binned hexes, and when included, dots plus feeder icon markers.
 - Toolbar: constellation picker, time window, H3 resolution control,
   min-attempts input.
 - Hex-click popup shows `successes / attempts`, smoothed rate,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -144,6 +144,8 @@ components:
       description: >
         Server-side H3-binned reliability for an entire constellation. Each hex
         aggregates every (feeder, target) row whose target falls inside the cell.
+        When `include_targets=1` is passed on the request, `targets` and `feeders`
+        are also returned for dot and marker layers on the constellation map.
       required: [constellation_id, h3_resolution, hexes, meta]
       properties:
         constellation_id:
@@ -155,12 +157,58 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConstellationCoverageHex'
+        targets:
+          type: array
+          description: Present when `include_targets=1` on the request.
+          items:
+            $ref: '#/components/schemas/ConstellationCoverageTarget'
+        feeders:
+          type: array
+          description: Present when `include_targets=1` on the request.
+          items:
+            $ref: '#/components/schemas/FeederReachFeeder'
         meta:
           type: object
           required: [window]
           properties:
             window:
               $ref: '#/components/schemas/CoverageWindow'
+
+    ConstellationCoverageTarget:
+      type: object
+      description: >
+        Per-target aggregate across all feeders in the constellation for the
+        requested window (and optional strategy filter).
+      required:
+        - node_id
+        - node_id_str
+        - lat
+        - lng
+        - attempts
+        - successes
+        - contributing_feeders
+      properties:
+        node_id:
+          type: integer
+        node_id_str:
+          type: string
+        short_name:
+          type: string
+          nullable: true
+        long_name:
+          type: string
+          nullable: true
+        lat:
+          type: number
+        lng:
+          type: number
+        attempts:
+          type: integer
+        successes:
+          type: integer
+        contributing_feeders:
+          type: integer
+          description: Distinct feeder count that attempted this target.
 
     ConstellationCoverageHex:
       type: object
@@ -5095,6 +5143,14 @@ paths:
             type: string
             format: date-time
             description: Window end (triggered_at <= value, ISO 8601)
+        - name: target_strategy
+          in: query
+          required: false
+          schema:
+            type: string
+            description: >
+              Comma-separated strategy tokens (intra_zone, dx_across,
+              dx_same_side, legacy). legacy matches null or explicit legacy.
       responses:
         '200':
           description: Per-target attempt/success counts for the feeder
@@ -5145,6 +5201,22 @@ paths:
             minimum: 0
             maximum: 15
             description: H3 resolution (default 6, ~3km hex edge).
+        - name: target_strategy
+          in: query
+          required: false
+          schema:
+            type: string
+            description: >
+              Comma-separated strategy tokens; same semantics as feeder-reach.
+        - name: include_targets
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: ['1', 'true', 'yes', 'on']
+            description: >
+              When set, response includes `targets` and `feeders` arrays for
+              constellation map dots and managed-node markers.
       responses:
         '200':
           description: H3-binned reliability cells for the constellation


### PR DESCRIPTION
## Summary

- Constellation coverage endpoint returns explicit **targets** and **feeders** metadata alongside hex aggregates.
- **`target_strategy`** query support filters which traceroute strategies contribute to reach / coverage (wired through `compute_reach`).
- **`include_targets`** (and related OpenAPI) documents the expanded response shape.
- Updates **traceroute coverage** docs and tests for the new behaviour.

Companion UI PR: https://github.com/pskillen/meshtastic-bot-ui/pull/207

## Testing performed

- Ran Meshflow traceroute unit tests for reach and views while developing (`Meshflow/traceroute/tests/…`).

Closes #204