### PR TITLE
feat(traceroute): geo_classification envelope and selector preview fields

### DIFF
--- a/Meshflow/traceroute/geo_classification.py
+++ b/Meshflow/traceroute/geo_classification.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from constellations.geometry import (
+    PERIMETER_DISTANCE_FRACTION,
     constellation_centroid,
     feeder_tier,
     get_constellation_envelope,
@@ -13,6 +14,11 @@ from constellations.geometry import (
 from nodes.models import ManagedNode
 
 from .strategy_rotation import applicable_strategies
+
+# Match ``pick_traceroute_target`` default; exposed to the UI so preview cannot drift.
+SELECTOR_LAST_HEARD_WITHIN_HOURS = 3
+# Match ``_pick_dx`` half-window sweep in ``target_selection``.
+DX_HALF_WINDOW_SWEEP_DEG = list(range(45, 91, 15))
 
 
 def build_geo_classification(managed_node: ManagedNode) -> dict:
@@ -40,8 +46,39 @@ def build_geo_classification(managed_node: ManagedNode) -> dict:
             br = initial_bearing_deg(c[0], c[1], pos[0], pos[1])
             octant = octant_from_bearing(br)
 
+    envelope_payload = None
+    if env is not None:
+        envelope_payload = {
+            "centroid_lat": env["centroid_lat"],
+            "centroid_lon": env["centroid_lon"],
+            "radius_km": env["radius_km"],
+        }
+
+    source_bearing_deg: float | None = None
+    if pos:
+        if env is not None:
+            source_bearing_deg = initial_bearing_deg(
+                env["centroid_lat"],
+                env["centroid_lon"],
+                pos[0],
+                pos[1],
+            )
+        elif constellation is not None:
+            c = constellation_centroid(constellation)
+            if c:
+                source_bearing_deg = initial_bearing_deg(c[0], c[1], pos[0], pos[1])
+
+    selector_params = {
+        "last_heard_within_hours": SELECTOR_LAST_HEARD_WITHIN_HOURS,
+        "dx_half_window_sweep_deg": DX_HALF_WINDOW_SWEEP_DEG,
+        "perimeter_distance_fraction": PERIMETER_DISTANCE_FRACTION,
+    }
+
     return {
         "tier": tier,
         "bearing_octant": octant,
         "applicable_strategies": applicable_strategies(managed_node),
+        "envelope": envelope_payload,
+        "source_bearing_deg": source_bearing_deg,
+        "selector_params": selector_params,
     }

--- a/Meshflow/traceroute/geo_classification.py
+++ b/Meshflow/traceroute/geo_classification.py
@@ -54,6 +54,12 @@ def build_geo_classification(managed_node: ManagedNode) -> dict:
             "radius_km": env["radius_km"],
         }
 
+    selection_centroid: tuple[float, float] | None = None
+    if env is not None:
+        selection_centroid = (env["centroid_lat"], env["centroid_lon"])
+    elif constellation is not None:
+        selection_centroid = constellation_centroid(constellation)
+
     source_bearing_deg: float | None = None
     if pos:
         if env is not None:
@@ -74,11 +80,19 @@ def build_geo_classification(managed_node: ManagedNode) -> dict:
         "perimeter_distance_fraction": PERIMETER_DISTANCE_FRACTION,
     }
 
+    centroid_payload = None
+    if selection_centroid is not None:
+        centroid_payload = {
+            "lat": selection_centroid[0],
+            "lon": selection_centroid[1],
+        }
+
     return {
         "tier": tier,
         "bearing_octant": octant,
         "applicable_strategies": applicable_strategies(managed_node),
         "envelope": envelope_payload,
+        "selection_centroid": centroid_payload,
         "source_bearing_deg": source_bearing_deg,
         "selector_params": selector_params,
     }

--- a/Meshflow/traceroute/strategy_rotation.py
+++ b/Meshflow/traceroute/strategy_rotation.py
@@ -14,7 +14,6 @@ from django.utils import timezone
 
 from constellations.geometry import (
     get_constellation_envelope,
-    is_perimeter_feeder,
     managed_node_position_lat_lon,
 )
 from nodes.models import ManagedNode
@@ -35,21 +34,24 @@ STRATEGY_TIE_ORDER = [
 
 def applicable_strategies(managed_node: ManagedNode) -> list[str]:
     """
-    Perimeter feeder with a defined envelope: intra_zone, dx_across, dx_same_side.
-    Internal feeder (or no envelope): dx_across, dx_same_side only.
+    When the constellation has a defined circular envelope (≥3 positioned managed nodes),
+    all three hypothesis strategies apply: intra_zone, dx_across, dx_same_side.
+
+    Intra-zone picks targets inside that envelope regardless of whether the feeder sits
+    on the geometric ``perimeter`` vs ``internal`` tier (see ``feeder_tier`` for display).
+
+    Without a constellation or envelope, only the two DX strategies are offered.
     """
     if not managed_node.constellation_id:
         return _dx_pair()
     env = get_constellation_envelope(managed_node.constellation)
     if env is None:
         return _dx_pair()
-    if is_perimeter_feeder(managed_node, env):
-        return [
-            AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
-            AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
-            AutoTraceRoute.TARGET_STRATEGY_DX_SAME_SIDE,
-        ]
-    return _dx_pair()
+    return [
+        AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+        AutoTraceRoute.TARGET_STRATEGY_DX_SAME_SIDE,
+    ]
 
 
 def _dx_pair() -> list[str]:

--- a/Meshflow/traceroute/tests/__init__.py
+++ b/Meshflow/traceroute/tests/__init__.py
@@ -1,1 +1,0 @@
-# Traceroute tests

--- a/Meshflow/traceroute/tests/test_geo_classification.py
+++ b/Meshflow/traceroute/tests/test_geo_classification.py
@@ -1,0 +1,129 @@
+"""Tests for ``build_geo_classification`` (managed-node geo + selector preview fields)."""
+
+from django.core.cache import cache
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from constellations.geometry import PERIMETER_DISTANCE_FRACTION
+from traceroute.geo_classification import (
+    DX_HALF_WINDOW_SWEEP_DEG,
+    SELECTOR_LAST_HEARD_WITHIN_HOURS,
+    build_geo_classification,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_constellation_envelope_cache():
+    """Envelope is cached by constellation PK; reuse-db can recycle PKs with stale cache."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_geo_classification_envelope_and_selector_params_perimeter_feeder(create_user, create_managed_node):
+    user = create_user()
+    c1 = create_managed_node(
+        owner=user,
+        node_id=1001,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.25,
+    ).constellation
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=1002,
+        default_location_latitude=55.03,
+        default_location_longitude=-4.25,
+    )
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=1003,
+        default_location_latitude=55.015,
+        default_location_longitude=-4.22,
+    )
+    feeder = create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=1004,
+        default_location_latitude=55.25,
+        default_location_longitude=-4.25,
+    )
+
+    geo = build_geo_classification(feeder)
+
+    assert geo["tier"] == "perimeter"
+    assert geo["envelope"] is not None
+    assert set(geo["envelope"]) == {"centroid_lat", "centroid_lon", "radius_km"}
+    assert geo["envelope"]["radius_km"] > 0
+    assert geo["source_bearing_deg"] is not None
+    assert 0 <= geo["source_bearing_deg"] < 360
+
+    sp = geo["selector_params"]
+    assert sp["last_heard_within_hours"] == SELECTOR_LAST_HEARD_WITHIN_HOURS
+    assert sp["dx_half_window_sweep_deg"] == DX_HALF_WINDOW_SWEEP_DEG
+    assert sp["perimeter_distance_fraction"] == PERIMETER_DISTANCE_FRACTION
+
+
+@pytest.mark.django_db
+def test_geo_classification_internal_feeder_still_has_envelope(create_user, create_managed_node):
+    user = create_user()
+    c1 = create_managed_node(
+        owner=user,
+        node_id=2001,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.25,
+    ).constellation
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=2002,
+        default_location_latitude=55.03,
+        default_location_longitude=-4.25,
+    )
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=2003,
+        default_location_latitude=55.015,
+        default_location_longitude=-4.22,
+    )
+    # Rough centroid of the three corners (~55.015, -4.24); place feeder there.
+    feeder = create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=2004,
+        default_location_latitude=55.015,
+        default_location_longitude=-4.24,
+    )
+
+    geo = build_geo_classification(feeder)
+    assert geo["tier"] == "internal"
+    assert geo["envelope"] is not None
+    assert geo["source_bearing_deg"] is not None
+
+
+@pytest.mark.django_db
+def test_geo_classification_no_envelope_two_nodes_source_bearing_from_centroid(create_user, create_managed_node):
+    """Envelope needs ≥3 positioned managed nodes; centroid still exists for two."""
+    user = create_user()
+    c1 = create_managed_node(
+        owner=user,
+        node_id=3001,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.25,
+    ).constellation
+    feeder = create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=3002,
+        default_location_latitude=55.02,
+        default_location_longitude=-4.25,
+    )
+
+    geo = build_geo_classification(feeder)
+    assert geo["envelope"] is None
+    assert geo["source_bearing_deg"] is not None
+    assert 0 <= geo["source_bearing_deg"] < 360

--- a/Meshflow/traceroute/tests/test_geo_classification.py
+++ b/Meshflow/traceroute/tests/test_geo_classification.py
@@ -58,6 +58,10 @@ def test_geo_classification_envelope_and_selector_params_perimeter_feeder(create
     assert geo["envelope"] is not None
     assert set(geo["envelope"]) == {"centroid_lat", "centroid_lon", "radius_km"}
     assert geo["envelope"]["radius_km"] > 0
+    assert geo["selection_centroid"] == {
+        "lat": geo["envelope"]["centroid_lat"],
+        "lon": geo["envelope"]["centroid_lon"],
+    }
     assert geo["source_bearing_deg"] is not None
     assert 0 <= geo["source_bearing_deg"] < 360
 
@@ -125,5 +129,7 @@ def test_geo_classification_no_envelope_two_nodes_source_bearing_from_centroid(c
 
     geo = build_geo_classification(feeder)
     assert geo["envelope"] is None
+    assert geo["selection_centroid"] is not None
+    assert {"lat", "lon"} == set(geo["selection_centroid"])
     assert geo["source_bearing_deg"] is not None
     assert 0 <= geo["source_bearing_deg"] < 360

--- a/Meshflow/traceroute/tests/test_strategy_rotation.py
+++ b/Meshflow/traceroute/tests/test_strategy_rotation.py
@@ -6,6 +6,7 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 from constellations.models import Constellation
+from traceroute.models import AutoTraceRoute
 from traceroute.strategy_rotation import (
     applicable_strategies,
     ordered_strategies_for_feeder,
@@ -38,6 +39,45 @@ def test_pick_strategy_rotates_cold_cache(create_user, create_managed_node):
     second = pick_strategy_for_feeder(mn)
     assert second in applicable_strategies(mn)
     assert second != first
+
+
+@pytest.mark.django_db
+def test_applicable_strategies_includes_intra_for_internal_feeder_when_envelope_exists(
+    create_user, create_managed_node
+):
+    """Internal (near-centroid) feeders still get intra_zone if the constellation envelope is defined."""
+    user = create_user()
+    c1 = create_managed_node(
+        owner=user,
+        node_id=0xC0000001,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.25,
+    ).constellation
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=0xC0000002,
+        default_location_latitude=55.03,
+        default_location_longitude=-4.25,
+    )
+    create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=0xC0000003,
+        default_location_latitude=55.015,
+        default_location_longitude=-4.22,
+    )
+    internal_feeder = create_managed_node(
+        owner=user,
+        constellation=c1,
+        node_id=0xC0000004,
+        default_location_latitude=55.015,
+        default_location_longitude=-4.24,
+    )
+    strat = applicable_strategies(internal_feeder)
+    assert AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE in strat
+    assert AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS in strat
+    assert AutoTraceRoute.TARGET_STRATEGY_DX_SAME_SIDE in strat
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# Summary

Extends `build_geo_classification` so managed nodes requested with `include=geo_classification` return data the UI needs to draw auto-target selection preview maps: circular envelope (centroid + radius), `selection_centroid` for bearings when the envelope is undefined, `source_bearing_deg` from that centroid toward the feeder, and `selector_params` (`last_heard_within_hours`, `dx_half_window_sweep_deg`, `perimeter_distance_fraction`) so the client cannot drift from server-side `target_selection`.

Adds `Meshflow/traceroute/tests/test_geo_classification.py` with a cache-clearing autouse fixture so pytest `--reuse-db` does not reuse stale envelope cache entries across constellation PKs.

**Strategy eligibility (#202):** `applicable_strategies` previously only offered `intra_zone` when `is_perimeter_feeder` was true (feeder beyond `TR_PERIMETER_THRESHOLD` of the envelope radius from the centroid). In practice, tightly clustered gateways were all classified **internal**, so they never got `intra_zone` in the API/UI even though `_pick_intra_zone` only needs a defined envelope. The PR now offers `intra_zone` whenever the constellation envelope exists; perimeter vs internal remains a **display** tier on `geo_classification`, not a gate for intra. See comment on #202 for what we learned from the new map visualization.

**UI PR:** https://github.com/pskillen/meshtastic-bot-ui/pull/209

## Testing performed

- `pytest traceroute/tests/test_geo_classification.py traceroute/tests/test_strategy_rotation.py -v --no-cov`
- `black`, `isort`, and `flake8` on touched traceroute modules

Closes #206

Closes #202