### PR TITLE
feat(traceroute): use ManagedNodeStatus for feeder eligibility

### DIFF
--- a/Meshflow/constellations/geometry.py
+++ b/Meshflow/constellations/geometry.py
@@ -11,7 +11,7 @@ from django.core.cache import cache
 from common.geo import haversine_km
 from nodes.models import ManagedNode, ObservedNode
 
-ENVELOPE_CACHE_PREFIX = "tr:envelope:v1"
+ENVELOPE_CACHE_PREFIX = "tr:envelope:v2"
 ENVELOPE_TTL_SECONDS = 600
 
 # Source farther than this fraction of envelope radius counts as "perimeter" feeder
@@ -57,9 +57,9 @@ def managed_node_position_lat_lon(managed_node: ManagedNode) -> tuple[float, flo
 
 
 def constellation_centroid(constellation) -> tuple[float, float] | None:
-    """Mean of ManagedNode positions (with coordinates) in this constellation."""
+    """Mean of positions for managed nodes that are actively feeding (ManagedNodeStatus)."""
     positions: list[tuple[float, float]] = []
-    for mn in ManagedNode.objects.filter(constellation=constellation).iterator():
+    for mn in ManagedNode.objects.filter(constellation=constellation, status__is_sending_data=True).iterator():
         p = managed_node_position_lat_lon(mn)
         if p:
             positions.append(p)
@@ -73,12 +73,13 @@ def constellation_centroid(constellation) -> tuple[float, float] | None:
 
 def _compute_envelope_circle(constellation) -> dict[str, Any] | None:
     """
-    Circular envelope: centroid + p90 distance from centroid to managed-node positions.
+    Circular envelope: centroid + p90 distance from centroid to managed-node positions
+    for nodes that are actively feeding (ManagedNodeStatus.is_sending_data).
 
     Returns ``None`` when fewer than three managed nodes have coordinates (undefined).
     """
     positions: list[tuple[float, float]] = []
-    for mn in ManagedNode.objects.filter(constellation=constellation).iterator():
+    for mn in ManagedNode.objects.filter(constellation=constellation, status__is_sending_data=True).iterator():
         p = managed_node_position_lat_lon(mn)
         if p:
             positions.append(p)

--- a/Meshflow/constellations/tests/test_geometry.py
+++ b/Meshflow/constellations/tests/test_geometry.py
@@ -4,6 +4,7 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 from constellations.geometry import (
+    _compute_envelope_circle,
     bearing_difference_deg,
     constellation_centroid,
     initial_bearing_deg,
@@ -13,7 +14,7 @@ from constellations.models import Constellation
 
 
 @pytest.mark.django_db
-def test_constellation_centroid_mean(create_user, create_managed_node):
+def test_constellation_centroid_mean(create_user, create_managed_node, mark_constellation_managed_nodes_feeding):
     user = create_user()
     c = Constellation.objects.create(name="G", created_by=user)
     create_managed_node(
@@ -28,10 +29,45 @@ def test_constellation_centroid_mean(create_user, create_managed_node):
         default_location_longitude=2.0,
         node_id=2,
     )
+    mark_constellation_managed_nodes_feeding(c)
     cc = constellation_centroid(c)
     assert cc is not None
     assert abs(cc[0] - 1.0) < 1e-9
     assert abs(cc[1] - 1.0) < 1e-9
+
+
+@pytest.mark.django_db
+def test_envelope_circle_counts_only_actively_feeding_managed_nodes(
+    create_user, create_managed_node, mark_managed_node_feeding
+):
+    user = create_user()
+    c = Constellation.objects.create(name="Env", created_by=user)
+    a = create_managed_node(
+        constellation=c,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.25,
+        node_id=10,
+    )
+    b = create_managed_node(
+        constellation=c,
+        default_location_latitude=55.03,
+        default_location_longitude=-4.25,
+        node_id=11,
+    )
+    d = create_managed_node(
+        constellation=c,
+        default_location_latitude=55.02,
+        default_location_longitude=-4.22,
+        node_id=12,
+    )
+    mark_managed_node_feeding(a, sending=True)
+    mark_managed_node_feeding(b, sending=True)
+    assert _compute_envelope_circle(c) is None
+
+    mark_managed_node_feeding(d, sending=True)
+    env = _compute_envelope_circle(c)
+    assert env is not None
+    assert env["n_managed_positions"] == 3
 
 
 def test_bearing_and_octant():

--- a/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
@@ -14,6 +14,7 @@ from mesh_monitoring.constants import notify_verification_start_enabled, verific
 from mesh_monitoring.models import NodePresence
 from mesh_monitoring.tasks import process_node_watch_presence, send_monitoring_traceroute_command
 from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
+from nodes.tasks import update_managed_node_statuses
 
 
 def test_notify_verification_start_enabled_default_true_when_unset(monkeypatch):
@@ -63,6 +64,7 @@ def test_verification_start_notify_happy_path(
         default_location_longitude=2.0,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     channel_layer = MagicMock()
 
@@ -115,6 +117,7 @@ def test_verification_start_notify_skipped_when_flag_off(
         default_location_longitude=2.0,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     channel_layer = MagicMock()
 
@@ -164,6 +167,7 @@ def test_verification_start_notify_respects_cooldown(
         default_location_longitude=2.0,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     channel_layer = MagicMock()
 

--- a/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
+++ b/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
@@ -14,6 +14,7 @@ from mesh_monitoring.services import monitoring_traceroute_succeeded_since, on_m
 from mesh_monitoring.tasks import process_node_watch_presence, send_monitoring_traceroute_command
 from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 from nodes.models import NodeLatestStatus
+from nodes.tasks import update_managed_node_statuses
 from traceroute.models import AutoTraceRoute
 
 
@@ -41,6 +42,7 @@ def test_process_node_watch_presence_starts_verification_and_creates_monitor_tr(
         default_location_longitude=2.1,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     channel_layer = MagicMock()
 
@@ -155,6 +157,7 @@ def test_dispatch_zero_sources_sets_last_zero_sources_at(
         default_location_longitude=2.1,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     with patch("mesh_monitoring.tasks.select_monitoring_sources", return_value=[]):
         process_node_watch_presence()
@@ -265,6 +268,7 @@ def test_process_node_watch_presence_offline_confirm_sets_is_offline(
         default_location_longitude=2.1,
     )
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     monkeypatch.setattr(
         "mesh_monitoring.tasks.verification_window_seconds",

--- a/Meshflow/mesh_monitoring/tests/test_selection.py
+++ b/Meshflow/mesh_monitoring/tests/test_selection.py
@@ -1,0 +1,126 @@
+"""Unit tests for mesh_monitoring.selection (monitoring traceroute sources)."""
+
+from django.utils import timezone
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from mesh_monitoring.selection import select_monitoring_sources
+from nodes.models import NodeLatestStatus
+
+
+@pytest.mark.django_db
+def test_select_monitoring_sources_orders_by_distance(
+    create_observed_node,
+    create_managed_node,
+    mark_managed_node_feeding,
+):
+    target = create_observed_node(node_id=0xE1000001)
+    NodeLatestStatus.objects.create(node=target, latitude=48.0, longitude=2.0)
+
+    far = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE1000010,
+        default_location_latitude=48.9,
+        default_location_longitude=2.0,
+    )
+    near = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE1000011,
+        default_location_latitude=48.02,
+        default_location_longitude=2.02,
+    )
+    mark_managed_node_feeding(far, sending=True)
+    mark_managed_node_feeding(near, sending=True)
+
+    picks = select_monitoring_sources(target, max_sources=3)
+    assert [mn.node_id for mn in picks[:2]] == [near.node_id, far.node_id]
+
+
+@pytest.mark.django_db
+def test_select_monitoring_sources_excludes_managed_node_same_mesh_id_as_target(
+    create_observed_node,
+    create_managed_node,
+    mark_managed_node_feeding,
+):
+    mesh_id = 0xE2000001
+    target = create_observed_node(node_id=mesh_id)
+    NodeLatestStatus.objects.create(node=target, latitude=50.0, longitude=0.0)
+
+    same_radio = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=mesh_id,
+        default_location_latitude=50.01,
+        default_location_longitude=0.01,
+    )
+    helper = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE2000099,
+        default_location_latitude=50.5,
+        default_location_longitude=0.5,
+    )
+    mark_managed_node_feeding(same_radio, sending=True)
+    mark_managed_node_feeding(helper, sending=True)
+
+    picks = select_monitoring_sources(target, max_sources=3)
+    assert all(mn.node_id != mesh_id for mn in picks)
+    assert picks[0].node_id == helper.node_id
+
+
+@pytest.mark.django_db
+def test_select_monitoring_sources_omits_non_feeding_managed_nodes(
+    create_observed_node,
+    create_managed_node,
+    mark_managed_node_feeding,
+):
+    target = create_observed_node(node_id=0xE3000001)
+    NodeLatestStatus.objects.create(node=target, latitude=51.0, longitude=1.0)
+
+    stale = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE3000010,
+        default_location_latitude=51.01,
+        default_location_longitude=1.01,
+    )
+    mark_managed_node_feeding(stale, sending=False)
+
+    fresh = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE3000011,
+        default_location_latitude=51.02,
+        default_location_longitude=1.02,
+    )
+    mark_managed_node_feeding(fresh, sending=True)
+
+    picks = select_monitoring_sources(target, max_sources=3)
+    assert picks == [fresh]
+
+
+@pytest.mark.django_db
+def test_select_monitoring_sources_respects_spacing_cooldown(
+    create_observed_node,
+    create_managed_node,
+    mark_managed_node_feeding,
+):
+    from traceroute.models import AutoTraceRoute
+
+    target = create_observed_node(node_id=0xE4000001)
+    NodeLatestStatus.objects.create(node=target, latitude=49.0, longitude=1.5)
+
+    mn = create_managed_node(
+        allow_auto_traceroute=True,
+        node_id=0xE4000010,
+        default_location_latitude=49.01,
+        default_location_longitude=1.51,
+    )
+    mark_managed_node_feeding(mn, sending=True)
+
+    AutoTraceRoute.objects.create(
+        source_node=mn,
+        target_node=target,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+        status=AutoTraceRoute.STATUS_SENT,
+        triggered_at=timezone.now(),
+    )
+
+    assert select_monitoring_sources(target, max_sources=3) == []

--- a/Meshflow/nodes/managed_node_liveness.py
+++ b/Meshflow/nodes/managed_node_liveness.py
@@ -22,13 +22,10 @@ def eligible_auto_traceroute_sources_queryset():
     ManagedNodeStatus.is_sending_data (refreshed periodically; same recency window as
     schedule_traceroute_source_recency_seconds in nodes.tasks.update_managed_node_statuses).
     """
-    return (
-        ManagedNode.objects.filter(
-            allow_auto_traceroute=True,
-            status__is_sending_data=True,
-        )
-        .select_related("constellation", "status")
-    )
+    return ManagedNode.objects.filter(
+        allow_auto_traceroute=True,
+        status__is_sending_data=True,
+    ).select_related("constellation", "status")
 
 
 def is_managed_node_eligible_traceroute_source(managed_node: ManagedNode) -> bool:

--- a/Meshflow/nodes/managed_node_liveness.py
+++ b/Meshflow/nodes/managed_node_liveness.py
@@ -1,13 +1,8 @@
 """Managed-node eligibility based on recent packet ingestion (traceroute sources, monitoring)."""
 
 import os
-from datetime import timedelta
-
-from django.db.models import Exists, OuterRef
-from django.utils import timezone
 
 from nodes.models import ManagedNode
-from packets.models import PacketObservation
 
 DEFAULT_SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS = 600
 
@@ -23,19 +18,16 @@ def schedule_traceroute_source_recency_seconds() -> int:
 
 def eligible_auto_traceroute_sources_queryset():
     """
-    ManagedNodes that may run auto traceroutes: allow_auto_traceroute and at least one
-    PacketObservation as observer with upload_time within the recency window.
+    ManagedNodes that may run auto traceroutes: allow_auto_traceroute and denormalized
+    ManagedNodeStatus.is_sending_data (refreshed periodically; same recency window as
+    schedule_traceroute_source_recency_seconds in nodes.tasks.update_managed_node_statuses).
     """
-    cutoff = timezone.now() - timedelta(seconds=schedule_traceroute_source_recency_seconds())
-    recent_observation = PacketObservation.objects.filter(
-        observer_id=OuterRef("pk"),
-        upload_time__gte=cutoff,
-    )
     return (
-        ManagedNode.objects.filter(allow_auto_traceroute=True)
-        .annotate(_has_recent_ingestion=Exists(recent_observation))
-        .filter(_has_recent_ingestion=True)
-        .select_related("constellation")
+        ManagedNode.objects.filter(
+            allow_auto_traceroute=True,
+            status__is_sending_data=True,
+        )
+        .select_related("constellation", "status")
     )
 
 

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -1,9 +1,10 @@
 import pytest
+from django.utils import timezone
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import MessageChannel
 from constellations.tests.conftest import create_constellation  # noqa: F401
-from nodes.models import ManagedNode, NodeAPIKey, NodeAuth, ObservedNode
+from nodes.models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, ObservedNode
 from users.tests.conftest import create_user  # noqa: F401
 
 
@@ -96,3 +97,31 @@ def create_node_auth(create_node_api_key, create_managed_node):
         return NodeAuth.objects.create(**kwargs)
 
     return make_node_auth
+
+
+@pytest.fixture
+def mark_managed_node_feeding():
+    """Set denormalized feeder snapshot without going through packet ingestion."""
+
+    def _mark(managed_node: ManagedNode, *, sending: bool = True, last_at=None):
+        ts = last_at if last_at is not None else (timezone.now() if sending else None)
+        ManagedNodeStatus.objects.update_or_create(
+            node=managed_node,
+            defaults={
+                "last_packet_ingested_at": ts,
+                "is_sending_data": sending,
+            },
+        )
+
+    return _mark
+
+
+@pytest.fixture
+def mark_constellation_managed_nodes_feeding(mark_managed_node_feeding):
+    """Mark every managed node in a constellation as actively feeding."""
+
+    def _mark(constellation):
+        for mn in ManagedNode.objects.filter(constellation=constellation):
+            mark_managed_node_feeding(mn, sending=True)
+
+    return _mark

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 from django.utils import timezone
+
+import pytest
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import MessageChannel

--- a/Meshflow/nodes/tests/test_managed_node_liveness.py
+++ b/Meshflow/nodes/tests/test_managed_node_liveness.py
@@ -1,0 +1,54 @@
+"""Tests for managed-node traceroute source eligibility (ManagedNodeStatus-backed)."""
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from nodes.managed_node_liveness import (
+    eligible_auto_traceroute_sources_queryset,
+    is_managed_node_eligible_traceroute_source,
+)
+from nodes.models import ManagedNodeStatus
+
+
+@pytest.mark.django_db
+def test_eligible_sources_requires_sending_status_and_allow_auto(
+    create_managed_node,
+    mark_managed_node_feeding,
+):
+    mn_ok = create_managed_node(allow_auto_traceroute=True, node_id=0xA1000001)
+    mark_managed_node_feeding(mn_ok, sending=True)
+
+    mn_disallowed = create_managed_node(allow_auto_traceroute=False, node_id=0xA1000002)
+    mark_managed_node_feeding(mn_disallowed, sending=True)
+
+    mn_stale = create_managed_node(allow_auto_traceroute=True, node_id=0xA1000003)
+    mark_managed_node_feeding(mn_stale, sending=False)
+
+    mn_no_row = create_managed_node(allow_auto_traceroute=True, node_id=0xA1000004)
+
+    ids = set(eligible_auto_traceroute_sources_queryset().values_list("pk", flat=True))
+    assert ids == {mn_ok.pk}
+    assert is_managed_node_eligible_traceroute_source(mn_ok) is True
+    assert is_managed_node_eligible_traceroute_source(mn_disallowed) is False
+    assert is_managed_node_eligible_traceroute_source(mn_stale) is False
+    assert is_managed_node_eligible_traceroute_source(mn_no_row) is False
+
+
+@pytest.mark.django_db
+def test_eligible_sources_select_related_status(create_managed_node, mark_managed_node_feeding):
+    mn = create_managed_node(allow_auto_traceroute=True)
+    mark_managed_node_feeding(mn, sending=True)
+    mn_fetched = eligible_auto_traceroute_sources_queryset().get(pk=mn.pk)
+    assert mn_fetched.status.is_sending_data is True
+
+
+@pytest.mark.django_db
+def test_refresh_task_aligns_with_eligibility(monkeypatch, create_managed_node, create_packet_observation):
+    monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
+    from nodes.tasks import update_managed_node_statuses
+
+    mn = create_managed_node(allow_auto_traceroute=True)
+    create_packet_observation(observer=mn)
+    update_managed_node_statuses()
+    assert ManagedNodeStatus.objects.get(node=mn).is_sending_data is True
+    assert eligible_auto_traceroute_sources_queryset().filter(pk=mn.pk).exists()

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -7,6 +7,7 @@ from rest_framework.test import APIClient
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import NodeLatestStatus
+from nodes.tasks import update_managed_node_statuses
 
 
 @pytest.mark.django_db
@@ -62,6 +63,7 @@ def test_managed_nodes_status_fields_only_returned_with_include_status(
     observation = create_packet_observation(observer=managed)
     observation.upload_time = now
     observation.save(update_fields=["upload_time"])
+    update_managed_node_statuses()
 
     list_url = reverse("managed-nodes-list")
     response_without_status = client.get(list_url)

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -8,7 +8,6 @@ from django.db.models import (
     Case,
     Count,
     DateTimeField,
-    Exists,
     IntegerField,
     OuterRef,
     Q,
@@ -30,12 +29,12 @@ from rest_framework.views import APIView
 from common.mesh_node_helpers import meshtastic_hex_to_int
 from constellations.models import ConstellationUserMembership
 from nodes.constants import INFRASTRUCTURE_ROLES
-from nodes.managed_node_liveness import schedule_traceroute_source_recency_seconds
 from nodes.models import (
     DeviceMetrics,
     EnvironmentExposure,
     EnvironmentMetrics,
     ManagedNode,
+    ManagedNodeStatus,
     NodeAPIKey,
     NodeAuth,
     NodeLatestStatus,
@@ -1012,12 +1011,16 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
         now = timezone.now()
         hour_cutoff = now - timedelta(hours=1)
         day_cutoff = now - timedelta(hours=24)
-        recent_cutoff = now - timedelta(seconds=schedule_traceroute_source_recency_seconds())
 
         packet_observation_qs = PacketObservation.objects.filter(observer_id=OuterRef("pk"))
         observed_node_qs = ObservedNode.objects.filter(node_id=OuterRef("node_id"))
 
-        last_packet_subquery = packet_observation_qs.order_by("-upload_time").values("upload_time")[:1]
+        status_qs = ManagedNodeStatus.objects.filter(node_id=OuterRef("pk"))
+        last_packet_subquery = status_qs.values("last_packet_ingested_at")[:1]
+        is_sending_subquery = Subquery(
+            status_qs.values("is_sending_data")[:1],
+            output_field=BooleanField(),
+        )
         packets_last_hour_subquery = (
             packet_observation_qs.filter(upload_time__gte=hour_cutoff)
             .values("observer")
@@ -1030,7 +1033,6 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
             .annotate(c=Count("id"))
             .values("c")[:1]
         )
-        eligible_observation_exists = Exists(packet_observation_qs.filter(upload_time__gte=recent_cutoff))
 
         return queryset.annotate(
             last_packet_ingested_at=Subquery(last_packet_subquery, output_field=DateTimeField()),
@@ -1044,7 +1046,7 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
             ),
             radio_last_heard=Subquery(observed_node_qs.values("last_heard")[:1], output_field=DateTimeField()),
             is_eligible_traceroute_source=Case(
-                When(allow_auto_traceroute=True, then=eligible_observation_exists),
+                When(allow_auto_traceroute=True, then=Coalesce(is_sending_subquery, Value(False))),
                 default=Value(False),
                 output_field=BooleanField(),
             ),

--- a/Meshflow/traceroute/tests/test_geo_classification.py
+++ b/Meshflow/traceroute/tests/test_geo_classification.py
@@ -22,7 +22,9 @@ def _clear_constellation_envelope_cache():
 
 
 @pytest.mark.django_db
-def test_geo_classification_envelope_and_selector_params_perimeter_feeder(create_user, create_managed_node):
+def test_geo_classification_envelope_and_selector_params_perimeter_feeder(
+    create_user, create_managed_node, mark_constellation_managed_nodes_feeding
+):
     user = create_user()
     c1 = create_managed_node(
         owner=user,
@@ -52,6 +54,7 @@ def test_geo_classification_envelope_and_selector_params_perimeter_feeder(create
         default_location_longitude=-4.25,
     )
 
+    mark_constellation_managed_nodes_feeding(c1)
     geo = build_geo_classification(feeder)
 
     assert geo["tier"] == "perimeter"
@@ -72,7 +75,9 @@ def test_geo_classification_envelope_and_selector_params_perimeter_feeder(create
 
 
 @pytest.mark.django_db
-def test_geo_classification_internal_feeder_still_has_envelope(create_user, create_managed_node):
+def test_geo_classification_internal_feeder_still_has_envelope(
+    create_user, create_managed_node, mark_constellation_managed_nodes_feeding
+):
     user = create_user()
     c1 = create_managed_node(
         owner=user,
@@ -103,6 +108,7 @@ def test_geo_classification_internal_feeder_still_has_envelope(create_user, crea
         default_location_longitude=-4.24,
     )
 
+    mark_constellation_managed_nodes_feeding(c1)
     geo = build_geo_classification(feeder)
     assert geo["tier"] == "internal"
     assert geo["envelope"] is not None
@@ -110,7 +116,9 @@ def test_geo_classification_internal_feeder_still_has_envelope(create_user, crea
 
 
 @pytest.mark.django_db
-def test_geo_classification_no_envelope_two_nodes_source_bearing_from_centroid(create_user, create_managed_node):
+def test_geo_classification_no_envelope_two_nodes_source_bearing_from_centroid(
+    create_user, create_managed_node, mark_constellation_managed_nodes_feeding
+):
     """Envelope needs ≥3 positioned managed nodes; centroid still exists for two."""
     user = create_user()
     c1 = create_managed_node(
@@ -127,6 +135,7 @@ def test_geo_classification_no_envelope_two_nodes_source_bearing_from_centroid(c
         default_location_longitude=-4.25,
     )
 
+    mark_constellation_managed_nodes_feeding(c1)
     geo = build_geo_classification(feeder)
     assert geo["envelope"] is None
     assert geo["selection_centroid"] is not None

--- a/Meshflow/traceroute/tests/test_schedule_traceroutes.py
+++ b/Meshflow/traceroute/tests/test_schedule_traceroutes.py
@@ -9,6 +9,7 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
+from nodes.tasks import update_managed_node_statuses
 from traceroute.models import AutoTraceRoute
 from traceroute.tasks import schedule_traceroutes
 
@@ -29,6 +30,7 @@ def test_schedule_traceroutes_excludes_stale_observation(monkeypatch, create_man
     obs = create_packet_observation(observer=mn)
     obs.upload_time = timezone.now() - timedelta(seconds=700)
     obs.save(update_fields=["upload_time"])
+    update_managed_node_statuses()
 
     assert schedule_traceroutes() == {"created": 0}
     assert AutoTraceRoute.objects.count() == 0
@@ -44,6 +46,7 @@ def test_schedule_traceroutes_creates_when_recent_observation(
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
     mn = create_managed_node(allow_auto_traceroute=True)
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
     target = create_observed_node(node_id=111222333)
 
     channel_layer = MagicMock()

--- a/Meshflow/traceroute/tests/test_source_selection.py
+++ b/Meshflow/traceroute/tests/test_source_selection.py
@@ -8,6 +8,7 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
+from nodes.tasks import update_managed_node_statuses
 from traceroute.models import AutoTraceRoute
 from traceroute.source_selection import (
     SOURCE_SELECTORS,
@@ -30,6 +31,7 @@ def test_select_lru_prefers_never_used_feeder(
     b = create_managed_node(allow_auto_traceroute=True, node_id=0xA0000002)
     create_packet_observation(observer=a)
     create_packet_observation(observer=b)
+    update_managed_node_statuses()
     tgt = create_observed_node(node_id=501)
     AutoTraceRoute.objects.create(
         source_node=a,
@@ -52,6 +54,7 @@ def test_unknown_algo_falls_back_to_default(monkeypatch, create_managed_node, cr
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
     mn = create_managed_node(allow_auto_traceroute=True)
     create_packet_observation(observer=mn)
+    update_managed_node_statuses()
 
     assert SOURCE_SELECTORS["least_recently_used"] is not None
     picked = select_traceroute_source()

--- a/Meshflow/traceroute/tests/test_strategy_rotation.py
+++ b/Meshflow/traceroute/tests/test_strategy_rotation.py
@@ -43,7 +43,7 @@ def test_pick_strategy_rotates_cold_cache(create_user, create_managed_node):
 
 @pytest.mark.django_db
 def test_applicable_strategies_includes_intra_for_internal_feeder_when_envelope_exists(
-    create_user, create_managed_node
+    create_user, create_managed_node, mark_constellation_managed_nodes_feeding
 ):
     """Internal (near-centroid) feeders still get intra_zone if the constellation envelope is defined."""
     user = create_user()
@@ -74,6 +74,7 @@ def test_applicable_strategies_includes_intra_for_internal_feeder_when_envelope_
         default_location_latitude=55.015,
         default_location_longitude=-4.24,
     )
+    mark_constellation_managed_nodes_feeding(c1)
     strat = applicable_strategies(internal_feeder)
     assert AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE in strat
     assert AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS in strat

--- a/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
+++ b/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
@@ -1,0 +1,74 @@
+"""Target selection excludes mesh IDs that belong to any ManagedNode."""
+
+from django.utils import timezone
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from nodes.models import NodeLatestStatus, ObservedNode
+from traceroute.target_selection import pick_traceroute_target
+
+
+@pytest.mark.django_db
+def test_pick_traceroute_target_excludes_observed_node_whose_mesh_id_is_managed(
+    create_managed_node,
+    create_observed_node,
+):
+    """Any ObservedNode whose node_id matches a ManagedNode cannot be an auto target."""
+    source = create_managed_node(
+        allow_auto_traceroute=True,
+        default_location_latitude=51.0,
+        default_location_longitude=-0.1,
+        node_id=0xD1000001,
+    )
+    other_mn = create_managed_node(node_id=0xD1000002)
+    on_mesh_id = other_mn.node_id
+    victim = create_observed_node(
+        node_id=on_mesh_id,
+        node_id_str=meshtastic_id_to_hex(on_mesh_id),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=victim, latitude=51.01, longitude=-0.11)
+
+    free = create_observed_node(
+        node_id=0xD1000099,
+        node_id_str=meshtastic_id_to_hex(0xD1000099),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=free, latitude=51.02, longitude=-0.12)
+
+    picked = pick_traceroute_target(source)
+    assert picked is not None
+    assert picked.node_id != victim.node_id
+    assert picked.node_id == free.node_id
+
+
+@pytest.mark.django_db
+def test_managed_node_mesh_id_excluded_even_without_managednodestatus_row(create_managed_node, create_observed_node):
+    """Placeholder managed nodes still occupy their mesh ID in the exclusion set."""
+    source = create_managed_node(
+        allow_auto_traceroute=True,
+        default_location_latitude=52.0,
+        default_location_longitude=1.0,
+        node_id=0xD2000001,
+    )
+    create_managed_node(node_id=0xD2000002)
+
+    victim = create_observed_node(
+        node_id=0xD2000002,
+        node_id_str=meshtastic_id_to_hex(0xD2000002),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=victim, latitude=52.01, longitude=1.01)
+
+    free = create_observed_node(
+        node_id=0xD2000099,
+        node_id_str=meshtastic_id_to_hex(0xD2000099),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=free, latitude=52.02, longitude=1.02)
+
+    picked = pick_traceroute_target(source)
+    assert picked is not None
+    assert picked.node_id == free.node_id

--- a/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
+++ b/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
@@ -6,7 +6,7 @@ import pytest
 
 import nodes.tests.conftest  # noqa: F401
 from common.mesh_node_helpers import meshtastic_id_to_hex
-from nodes.models import NodeLatestStatus, ObservedNode
+from nodes.models import NodeLatestStatus
 from traceroute.target_selection import pick_traceroute_target
 
 

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -14,6 +14,7 @@ import nodes.tests.conftest  # noqa: F401 - load fixtures
 import packets.tests.conftest  # noqa: F401 - load fixtures
 import users.tests.conftest  # noqa: F401 - load fixtures
 from constellations.models import ConstellationUserMembership, MessageChannel
+from nodes.tasks import update_managed_node_statuses
 from packets.models import PacketObservation
 from traceroute.models import AutoTraceRoute
 
@@ -28,7 +29,7 @@ def add_traceroute_source_ingestion(create_raw_packet):
             name=f"tr-ingest-{observer.internal_id}",
             constellation=observer.constellation,
         )
-        return PacketObservation.objects.create(
+        obs = PacketObservation.objects.create(
             packet=packet,
             observer=observer,
             channel=channel,
@@ -40,6 +41,8 @@ def add_traceroute_source_ingestion(create_raw_packet):
             upload_time=timezone.now(),
             relay_node=None,
         )
+        update_managed_node_statuses()
+        return obs
 
     return _add
 
@@ -371,7 +374,7 @@ class TestTracerouteTriggerableNodes:
         assert node["position"] == {"latitude": 51.5, "longitude": -0.12}
 
     def test_triggerable_nodes_excludes_without_recent_ingestion(self, api_client, staff_user, create_managed_node):
-        """Nodes with allow_auto_traceroute but no recent PacketObservation as observer are omitted."""
+        """Nodes with allow_auto_traceroute but no active ManagedNodeStatus feeding snapshot are omitted."""
         mn = create_managed_node(allow_auto_traceroute=True)
         api_client.force_authenticate(user=staff_user)
         resp = api_client.get("/api/traceroutes/triggerable-nodes/")
@@ -601,7 +604,7 @@ class TestTracerouteTrigger:
         create_managed_node,
         create_observed_node,
     ):
-        """Trigger returns 400 when source has permission but no recent ingestion as observer."""
+        """Trigger returns 400 when source has permission but ManagedNodeStatus is not actively feeding."""
         membership = ConstellationUserMembership.objects.filter(user=editor_user, role="editor").first()
         constellation = membership.constellation
         creator = constellation.created_by

--- a/docs/RECENCY.md
+++ b/docs/RECENCY.md
@@ -25,7 +25,9 @@ When you change any threshold in code, **update this file in the same PR**.
   in `packets/services/base.py` at ingest. It is the canonical "mesh heard"
   time.
 - `PacketObservation.upload_time` (feeder upload) is the canonical
-  "feeder heard" time for managed nodes and traceroute source eligibility.
+  "feeder heard" time for managed nodes. Traceroute **source eligibility** and
+  constellation **coverage geometry** read the denormalized snapshot
+  `ManagedNodeStatus` (refreshed periodically from packet observations).
 
 ---
 
@@ -37,7 +39,7 @@ source of truth for defaults.
 | Env var | Default | Purpose |
 | --- | --- | --- |
 | `PACKET_DEDUP_WINDOW_MINUTES` | `10` (min) | Packet dedup window vs `first_reported_time` |
-| `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS` | `600` (s) | Managed feeder liveness + TR source eligibility |
+| `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS` | `600` (s) | Managed feeder snapshot (`ManagedNodeStatus`) + TR source eligibility window |
 | `FAILED_TR_TIMEOUT_SECONDS` | `180` (s) | Mark stuck `AutoTraceRoute` as `failed` |
 | `STALE_TR_TIMEOUT_SECONDS` | `180` (s) | Match inbound TR response packet to an `AutoTraceRoute` |
 | `ONLINE_NODE_WINDOW_HOURS` | `2` (h) | `online_nodes` stats snapshot window |
@@ -61,12 +63,14 @@ Implemented in
 
 | Signal | Field | Fresh if | Controlled by |
 | --- | --- | --- | --- |
-| Feeder | `PacketObservation.upload_time` | within **`SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`** (default **600 s / 10 min**) | env |
+| Feeder (TR sources / monitoring) | `ManagedNodeStatus.is_sending_data` | `True` when `last_packet_ingested_at` is within **`SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`** (default **600 s / 10 min**) | env + periodic `nodes.tasks.update_managed_node_statuses` |
 | Radio / mesh | `ObservedNode.last_heard` (or `ManagedNode.radio_last_heard` proxy) | within **2 h** (aligned with `online_nodes` window) | code |
 
-`eligible_auto_traceroute_sources_queryset()` uses the same feeder cutoff;
-this is the **one place** that decides whether a managed node is eligible to
-originate a traceroute.
+`eligible_auto_traceroute_sources_queryset()` requires `allow_auto_traceroute`
+and `status.is_sending_data`; the status row is derived from recent
+`PacketObservation.upload_time` by the refresh task (same cutoff as the env
+var above). This is the **canonical** rule for whether a managed node may
+originate an auto or monitoring traceroute.
 
 ### Managed-node API annotations
 
@@ -76,8 +80,8 @@ In `ManagedNodeViewSet` (see `Meshflow/nodes/views.py`):
 | --- | --- | --- |
 | `packets_last_hour` | **1 h** | `PacketObservation.upload_time` |
 | `packets_last_24h` | **24 h** | `PacketObservation.upload_time` |
-| `last_packet_ingested_at` | latest `upload_time` | `PacketObservation` |
-| `is_eligible_traceroute_source` | feeder window above | `managed_node_liveness` |
+| `last_packet_ingested_at` | snapshot | `ManagedNodeStatus.last_packet_ingested_at` |
+| `is_eligible_traceroute_source` | `allow_auto_traceroute` and `status.is_sending_data` | `ManagedNodeStatus` |
 
 ### Managed-node status denormalization (`ManagedNodeStatus`)
 
@@ -93,8 +97,9 @@ liveness; that remains `ObservedNode.last_heard`.
 
 The Celery task `nodes.tasks.update_managed_node_statuses` runs on a **5-minute**
 `django_celery_beat` interval (see `nodes` migration `0032_add_update_managed_node_statuses_periodic_task`).
-API list/detail annotations may still compute status on the fly until follow-up work
-switches consumers to this table.
+Managed-node `include=status` responses use this snapshot for ingest time and
+traceroute-source eligibility; packet-count fields remain live aggregates over
+`PacketObservation`.
 
 ### `ObservedNodeViewSet.recent_counts`
 

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -56,7 +56,7 @@ Late responses: if a TR was marked `failed` (timeout) but the response arrives l
 
 ## Code map (shared helpers)
 
-Auto-scheduler and permission checks share one notion of a **live** source node (recent packet ingestion as observer). Canonical implementation: **`nodes.managed_node_liveness`** (`eligible_auto_traceroute_sources_queryset`, etc.). **`traceroute.source_eligibility`** re-exports the same API for existing imports.
+Auto-scheduler and permission checks share one notion of a **live** source node (`ManagedNodeStatus.is_sending_data`, refreshed from `PacketObservation.upload_time` on a beat schedule). Canonical implementation: **`nodes.managed_node_liveness`** (`eligible_auto_traceroute_sources_queryset`, etc.). **`traceroute.source_eligibility`** re-exports the same API for existing imports.
 
 **Target selection** for auto TR: `traceroute.target_selection.pick_traceroute_target` uses **`common.geo.haversine_km`** and **`nodes.positioning.managed_node_lat_lon`**.
 

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -8,18 +8,18 @@ Who can trigger traceroutes and from which nodes:
 
 | Role | Can trigger from |
 |------|------------------|
-| System admin (`is_staff`) | ManagedNodes with `allow_auto_traceroute=True` and recent ingestion as `PacketObservation.observer` |
+| System admin (`is_staff`) | ManagedNodes with `allow_auto_traceroute=True` and `ManagedNodeStatus.is_sending_data` (feeder snapshot) |
 | Constellation admin/editor | Same eligibility, in constellations where user has admin/editor role |
 | ManagedNode owner | Same eligibility for nodes they own |
 | All authenticated | View traceroute list, detail, heatmap |
 
-The UI fetches `GET /api/traceroutes/triggerable-nodes/` to list sources that are both permitted and recently ingesting (same rule as the Celery scheduler: **`nodes.managed_node_liveness`**, exposed via **`traceroute.source_eligibility`** for traceroute code). The trigger view validates eligibility, `user_can_trigger_from_node(user, source_node)`, and rate limits before sending the command.
+The UI fetches `GET /api/traceroutes/triggerable-nodes/` to list sources that are both permitted and actively feeding per **`ManagedNodeStatus`** (same rule as the Celery scheduler: **`nodes.managed_node_liveness`**, exposed via **`traceroute.source_eligibility`** for traceroute code). The trigger view validates eligibility, `user_can_trigger_from_node(user, source_node)`, and rate limits before sending the command.
 
 ## 1. Trigger
 
-**Manual**: User calls `POST /api/traceroutes/trigger/` with `managed_node_id` and optional `target_node_id`. Source must match the same eligibility as auto-schedule (recent ingestion window `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`). Requires permission as above. Rate limit: **`traceroute.trigger_intervals.MANUAL_TRIGGER_MIN_INTERVAL_SEC`** (default 60s) per source node.
+**Manual**: User calls `POST /api/traceroutes/trigger/` with `managed_node_id` and optional `target_node_id`. Source must match the same eligibility as auto-schedule (`ManagedNodeStatus` / `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS` window). Requires permission as above. Rate limit: **`traceroute.trigger_intervals.MANUAL_TRIGGER_MIN_INTERVAL_SEC`** (default 60s) per source node.
 
-**Automatic**: Celery task `schedule_traceroutes` runs periodically. Picks one random ManagedNode with `allow_auto_traceroute=True` **and** recent packet ingestion as `PacketObservation.observer` (within `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`, default 600s; see **`nodes.managed_node_liveness`**), uses **`pick_traceroute_target()`** to select a target (geography via **`common.geo.haversine_km`** and **`nodes.positioning.managed_node_lat_lon`**, prioritises periphery and less-recently-traced nodes), creates `AutoTraceRoute` with `trigger_type=auto`. **`pick_traceroute_target()`** excludes observed nodes that have **`mesh_monitoring.NodePresence`** with active verification or offline confirmed.
+**Automatic**: Celery task `schedule_traceroutes` runs periodically. Picks one eligible ManagedNode with `allow_auto_traceroute=True` **and** `ManagedNodeStatus.is_sending_data` (same recency window as `SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS`, default 600s; see **`nodes.managed_node_liveness`**), uses **`pick_traceroute_target()`** to select a target (geography via **`common.geo.haversine_km`** and **`nodes.positioning.managed_node_lat_lon`**, prioritises periphery and less-recently-traced nodes), creates `AutoTraceRoute` with `trigger_type=auto`. **`pick_traceroute_target()`** excludes observed nodes that have **`mesh_monitoring.NodePresence`** with active verification or offline confirmed.
 
 **Mesh monitoring**: Celery task **`mesh_monitoring.tasks.process_node_watch_presence`** (beat, default every 60s) creates `AutoTraceRoute` rows with `trigger_type=monitor` and `trigger_source=mesh_monitoring` for watched nodes that are silent past their effective threshold; commands use the same WebSocket path as above. See [mesh monitoring](../mesh-monitoring/README.md).
 

--- a/docs/features/traceroute/permissions.md
+++ b/docs/features/traceroute/permissions.md
@@ -39,7 +39,7 @@ contract; update the code (or this document) until they agree.
 "Eligibility" for a source node means:
 
 - `allow_auto_traceroute=True`, and
-- The node has reported packets recently enough to be considered live — see
+- `ManagedNodeStatus.is_sending_data` is true (feeder snapshot; refreshed from packet observations) — see
   `eligible_auto_traceroute_sources_queryset` in
   [`Meshflow/traceroute/source_eligibility.py`](../../../Meshflow/traceroute/source_eligibility.py)
   and its canonical definition in `nodes.managed_node_liveness`.


### PR DESCRIPTION
# Summary

- Traceroute **source eligibility** (`eligible_auto_traceroute_sources_queryset`, monitoring `select_monitoring_sources`) now uses **`ManagedNodeStatus.is_sending_data`** plus `allow_auto_traceroute`, instead of live `PacketObservation` `Exists` queries.
- **`ManagedNodeViewSet` `include=status`**: `last_packet_ingested_at` and `is_eligible_traceroute_source` come from **`ManagedNodeStatus`**; `packets_last_hour` / `packets_last_24h` remain live counts from `PacketObservation`.
- Constellation **centroid** and **circular envelope** (`constellation_centroid`, `_compute_envelope_circle`) only include managed nodes with **`status__is_sending_data=True`**. Envelope cache prefix bumped to **`tr:envelope:v2`** to avoid stale geometry.
- Tests: `nodes/tests/test_managed_node_liveness.py`, `mesh_monitoring/tests/test_selection.py`, `traceroute/tests/test_target_selection_managed_nodes.py`; fixtures `mark_managed_node_feeding` / `mark_constellation_managed_nodes_feeding`; sync **`update_managed_node_statuses()`** where tests relied on packet observations alone.
- Docs: `docs/RECENCY.md`, traceroute feature docs (`README`, `flow`, `permissions`).

**Operational note:** Eligibility for sources can lag real ingestion by up to the **`update_managed_node_statuses`** beat interval (default 5 minutes), in addition to the recency window.

Closes #212

## Testing performed

- Not run locally (no Django venv in this environment). 