### PR TITLE
feat(traceroute): automatic target reliability for auto TR selection

### DIFF
--- a/Meshflow/traceroute/reliability.py
+++ b/Meshflow/traceroute/reliability.py
@@ -1,0 +1,121 @@
+"""
+Per-source target reliability for automatic traceroute selection.
+
+Only ``trigger_type=auto`` and terminal statuses (completed, failed) are used.
+Manual, monitor, and external triggers do not affect exclusion or soft penalties.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import timedelta
+
+from django.utils import timezone
+
+from .models import AutoTraceRoute
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    return int(str(raw).strip())
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    return float(str(raw).strip())
+
+
+@dataclass(frozen=True)
+class ReliabilitySettings:
+    """Tunables for automatic target reliability (see docs/ENV_VARS.md)."""
+
+    enabled: bool
+    window_days: int
+    consecutive_fails_cooldown: int
+    soft_max: float
+    min_attempts_soft: int
+
+
+def get_reliability_settings() -> ReliabilitySettings:
+    return ReliabilitySettings(
+        enabled=_env_bool("TR_RELIABILITY_ENABLED", True),
+        window_days=_env_int("TR_RELIABILITY_WINDOW_DAYS", 14),
+        consecutive_fails_cooldown=_env_int("TR_RELIABILITY_CONSECUTIVE_FAILS", 4),
+        soft_max=_env_float("TR_RELIABILITY_SOFT_MAX", 100.0),
+        min_attempts_soft=_env_int("TR_RELIABILITY_MIN_ATTEMPTS_SOFT", 3),
+    )
+
+
+def load_source_target_reliability(
+    managed_node,
+) -> tuple[set[int], dict[int, float]]:
+    """
+    Return (hard_cooldown_target_node_ids, soft_penalty_by_target_node_id).
+
+    Hard cooldown: at least ``consecutive_fails_cooldown`` consecutive automatic
+    failures for this (source, target) pair, with no more recent success in the
+    reliability window (most-recent-first streak).
+
+    Soft penalty: up to ``soft_max`` times (failed / attempts) in the window,
+    when ``attempts >= min_attempts_soft``, using the same completed/failed auto
+    rows (same order as for consecutive counting).
+    """
+    s = get_reliability_settings()
+    if not s.enabled:
+        return set(), {}
+    if s.consecutive_fails_cooldown <= 0 and s.soft_max <= 0.0:
+        return set(), {}
+
+    cutoff = timezone.now() - timedelta(days=s.window_days)
+    rows = list(
+        AutoTraceRoute.objects.filter(
+            source_node=managed_node,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+            triggered_at__gte=cutoff,
+            status__in=(AutoTraceRoute.STATUS_COMPLETED, AutoTraceRoute.STATUS_FAILED),
+        )
+        .order_by("target_node__node_id", "-triggered_at")
+        .values("target_node__node_id", "status")
+    )
+
+    by_target: dict[int, list[str]] = defaultdict(list)
+    for r in rows:
+        by_target[r["target_node__node_id"]].append(r["status"])
+
+    hard: set[int] = set()
+    soft: dict[int, float] = {}
+
+    for tid, statuses in by_target.items():
+        consec = 0
+        for st in statuses:
+            if st == AutoTraceRoute.STATUS_FAILED:
+                consec += 1
+            else:
+                break
+        if s.consecutive_fails_cooldown > 0 and consec >= s.consecutive_fails_cooldown:
+            hard.add(tid)
+            continue
+
+        n = len(statuses)
+        if n < s.min_attempts_soft or s.soft_max <= 0.0:
+            continue
+        failed = sum(1 for x in statuses if x == AutoTraceRoute.STATUS_FAILED)
+        if failed == 0:
+            continue
+        ratio = failed / float(n)
+        soft[tid] = s.soft_max * ratio
+
+    return hard, soft

--- a/Meshflow/traceroute/target_selection.py
+++ b/Meshflow/traceroute/target_selection.py
@@ -21,6 +21,7 @@ from nodes.models import ManagedNode, ObservedNode
 from nodes.positioning import managed_node_lat_lon
 
 from .models import AutoTraceRoute
+from .reliability import load_source_target_reliability
 
 
 def _get_last_traced_by_source(managed_node: ManagedNode) -> dict[int, float]:
@@ -56,8 +57,13 @@ def _iter_scored_candidates(
     last_traced_hours: dict[int, float],
     managed_node_ids: set[int],
     suppressed: list[int],
+    *,
+    hard_cooldown: set[int] | None = None,
+    soft_penalty: dict[int, float] | None = None,
 ):
     """Yield (score, ObservedNode) where higher score is better (legacy-style)."""
+    hard = hard_cooldown or set()
+    soft = soft_penalty or {}
     source_pos = managed_node_lat_lon(managed_node)
     if not source_pos:
         return
@@ -76,12 +82,15 @@ def _iter_scored_candidates(
     )
 
     for obs in candidates:
+        if obs.node_id in hard:
+            continue
         lat = obs.latest_status.latitude
         lon = obs.latest_status.longitude
         dist = haversine_km(source_pos[0], source_pos[1], lat, lon)
         hours_since = last_traced_hours.get(obs.node_id)
         demerit = _demerit_hours(hours_since)
-        score = dist - demerit
+        sp = soft.get(obs.node_id, 0.0)
+        score = dist - demerit - sp
         yield score, obs
 
 
@@ -109,7 +118,9 @@ def pick_traceroute_target(
     Pick one target ObservedNode for a ManagedNode.
 
     ``strategy``:
-        ``None`` / ``legacy`` — original periphery-first + recency demerit (existing behaviour).
+        ``None`` / ``legacy`` — periphery-first, recency demerit, and automatic
+        reliability soft penalty / hard cooldown from recent auto traceroutes
+        (meshflow-api#211).
         ``intra_zone`` / ``dx_across`` / ``dx_same_side`` — hypothesis-driven selectors (#176).
     """
     strat = strategy
@@ -119,6 +130,7 @@ def pick_traceroute_target(
     last_traced_hours = _get_last_traced_by_source(managed_node)
     managed_node_ids = set(ManagedNode.objects.values_list("node_id", flat=True))
     suppressed = list(suppressed_observed_node_ids())
+    hard_cooldown, soft_penalty = load_source_target_reliability(managed_node)
 
     if strat is None:
         return _pick_legacy(
@@ -128,6 +140,8 @@ def pick_traceroute_target(
             managed_node_ids,
             suppressed,
             slot,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
 
     if strat == AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE:
@@ -138,6 +152,8 @@ def pick_traceroute_target(
             managed_node_ids,
             suppressed,
             slot,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
     if strat == AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS:
         return _pick_dx(
@@ -148,6 +164,8 @@ def pick_traceroute_target(
             suppressed,
             slot,
             across=True,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
     if strat == AutoTraceRoute.TARGET_STRATEGY_DX_SAME_SIDE:
         return _pick_dx(
@@ -158,6 +176,8 @@ def pick_traceroute_target(
             suppressed,
             slot,
             across=False,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
 
     return _pick_legacy(
@@ -167,6 +187,8 @@ def pick_traceroute_target(
         managed_node_ids,
         suppressed,
         slot,
+        hard_cooldown=hard_cooldown,
+        soft_penalty=soft_penalty,
     )
 
 
@@ -177,6 +199,9 @@ def _pick_legacy(
     managed_node_ids,
     suppressed,
     slot,
+    *,
+    hard_cooldown: set[int] | None = None,
+    soft_penalty: dict[int, float] | None = None,
 ):
     scored = list(
         _iter_scored_candidates(
@@ -185,6 +210,8 @@ def _pick_legacy(
             last_traced_hours,
             managed_node_ids,
             suppressed,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
     )
     scored.sort(key=lambda x: -x[0])
@@ -206,6 +233,9 @@ def _pick_intra_zone(
     managed_node_ids,
     suppressed,
     slot,
+    *,
+    hard_cooldown: set[int] | None = None,
+    soft_penalty: dict[int, float] | None = None,
 ):
     constellation = managed_node.constellation
     env = get_constellation_envelope(constellation) if constellation else None
@@ -220,12 +250,14 @@ def _pick_intra_zone(
     r_km = env["radius_km"]
 
     inside: list[tuple[float, ObservedNode]] = []
-    for score, obs in _iter_scored_candidates(
+    for _score, obs in _iter_scored_candidates(
         managed_node,
         last_heard_within_hours,
         last_traced_hours,
         managed_node_ids,
         suppressed,
+        hard_cooldown=hard_cooldown,
+        soft_penalty=soft_penalty,
     ):
         lat = obs.latest_status.latitude
         lon = obs.latest_status.longitude
@@ -240,11 +272,13 @@ def _pick_intra_zone(
     dists = [d for d, _ in inside]
     med = float(median(dists))
     scored = []
+    soft = soft_penalty or {}
     for d_src, obs in inside:
         hours_since = last_traced_hours.get(obs.node_id)
         demerit = _demerit_hours(hours_since)
         base = -abs(d_src - med)
-        total = base - demerit
+        sp = soft.get(obs.node_id, 0.0)
+        total = base - demerit - sp
         scored.append((total, obs))
     scored.sort(key=lambda x: -x[0])
     top20 = [obs for _, obs in scored[:20]]
@@ -260,6 +294,8 @@ def _pick_dx(
     slot,
     *,
     across: bool,
+    hard_cooldown: set[int] | None = None,
+    soft_penalty: dict[int, float] | None = None,
 ):
     constellation = managed_node.constellation
     source_pos = managed_node_lat_lon(managed_node)
@@ -293,6 +329,8 @@ def _pick_dx(
             br_src,
             half_w,
             across=across,
+            hard_cooldown=hard_cooldown,
+            soft_penalty=soft_penalty,
         )
         if ranked:
             return _deterministic_pick(managed_node, ranked[:20], slot or strategy_key)
@@ -311,6 +349,8 @@ def _dx_candidate_rank(
     half_window,
     *,
     across,
+    hard_cooldown: set[int] | None = None,
+    soft_penalty: dict[int, float] | None = None,
 ) -> list[ObservedNode]:
     """Return ObservedNodes sorted best-first for current half_window (periphery + bearing)."""
     source_pos = managed_node_lat_lon(managed_node)
@@ -323,6 +363,8 @@ def _dx_candidate_rank(
                 last_traced_hours,
                 managed_node_ids,
                 suppressed,
+                hard_cooldown=hard_cooldown,
+                soft_penalty=soft_penalty,
             )
         )
         scored.sort(key=lambda x: -x[0])
@@ -338,6 +380,8 @@ def _dx_candidate_rank(
         last_traced_hours,
         managed_node_ids,
         suppressed,
+        hard_cooldown=hard_cooldown,
+        soft_penalty=soft_penalty,
     ):
         lat = obs.latest_status.latitude
         lon = obs.latest_status.longitude

--- a/Meshflow/traceroute/tests/test_reliability.py
+++ b/Meshflow/traceroute/tests/test_reliability.py
@@ -1,0 +1,155 @@
+"""Automatic traceroute target reliability (meshflow-api#211)."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from nodes.models import NodeLatestStatus
+from traceroute.models import AutoTraceRoute
+from traceroute.reliability import get_reliability_settings, load_source_target_reliability
+from traceroute.target_selection import pick_traceroute_target
+
+
+@pytest.mark.django_db
+def test_load_reliability_hard_cooldown_consecutive_auto_fails(
+    create_managed_node,
+    create_observed_node,
+    monkeypatch,
+):
+    """Repeated automatic failures to the same target exclude it from the pool."""
+    monkeypatch.setenv("TR_RELIABILITY_CONSECUTIVE_FAILS", "2")
+    assert get_reliability_settings().consecutive_fails_cooldown == 2
+
+    source = create_managed_node(
+        allow_auto_traceroute=True,
+        default_location_latitude=55.0,
+        default_location_longitude=-3.5,
+        node_id=0xE1000001,
+    )
+    bad = create_observed_node(
+        node_id=0xE10000AA,
+        node_id_str=meshtastic_id_to_hex(0xE10000AA),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=bad, latitude=55.6, longitude=-3.5)
+    good = create_observed_node(
+        node_id=0xE10000BB,
+        node_id_str=meshtastic_id_to_hex(0xE10000BB),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=good, latitude=55.1, longitude=-3.5)
+
+    now = timezone.now()
+    for i in range(2):
+        AutoTraceRoute.objects.create(
+            source_node=source,
+            target_node=bad,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+            status=AutoTraceRoute.STATUS_FAILED,
+            triggered_at=now - timedelta(minutes=i),
+            completed_at=now - timedelta(minutes=i),
+        )
+
+    hard, _soft = load_source_target_reliability(source)
+    assert bad.node_id in hard
+
+    picked = pick_traceroute_target(source, slot="test_reliability_hard")
+    assert picked is not None
+    assert picked.node_id == good.node_id
+
+
+@pytest.mark.django_db
+def test_load_reliability_ignores_non_auto_triggers(
+    create_managed_node,
+    create_observed_node,
+    monkeypatch,
+):
+    monkeypatch.setenv("TR_RELIABILITY_CONSECUTIVE_FAILS", "2")
+    source = create_managed_node(
+        allow_auto_traceroute=True,
+        default_location_latitude=56.0,
+        default_location_longitude=-3.0,
+        node_id=0xE2000001,
+    )
+    target = create_observed_node(
+        node_id=0xE20000AA,
+        node_id_str=meshtastic_id_to_hex(0xE20000AA),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=target, latitude=56.8, longitude=-3.0)
+    other = create_observed_node(
+        node_id=0xE20000BB,
+        node_id_str=meshtastic_id_to_hex(0xE20000BB),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=other, latitude=56.1, longitude=-3.0)
+
+    now = timezone.now()
+    for i in range(2):
+        AutoTraceRoute.objects.create(
+            source_node=source,
+            target_node=target,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_USER,
+            status=AutoTraceRoute.STATUS_FAILED,
+            triggered_at=now - timedelta(minutes=i),
+            completed_at=now - timedelta(minutes=i),
+        )
+
+    hard, _ = load_source_target_reliability(source)
+    assert target.node_id not in hard
+    assert hard == set()
+
+
+@pytest.mark.django_db
+def test_load_reliability_streak_broken_by_recent_success(
+    create_managed_node,
+    create_observed_node,
+    monkeypatch,
+):
+    """A completed auto traceroute after failures resets consecutive-fail counting."""
+    monkeypatch.setenv("TR_RELIABILITY_CONSECUTIVE_FAILS", "2")
+    source = create_managed_node(
+        allow_auto_traceroute=True,
+        default_location_latitude=57.0,
+        default_location_longitude=-3.0,
+        node_id=0xE3000001,
+    )
+    t = create_observed_node(
+        node_id=0xE30000AA,
+        node_id_str=meshtastic_id_to_hex(0xE30000AA),
+        last_heard=timezone.now(),
+    )
+    NodeLatestStatus.objects.create(node=t, latitude=57.3, longitude=-3.0)
+
+    now = timezone.now()
+    AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=t,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+        status=AutoTraceRoute.STATUS_FAILED,
+        triggered_at=now - timedelta(hours=3),
+        completed_at=now - timedelta(hours=3),
+    )
+    AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=t,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        triggered_at=now - timedelta(hours=2),
+        completed_at=now - timedelta(hours=2),
+    )
+    AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=t,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_AUTO,
+        status=AutoTraceRoute.STATUS_FAILED,
+        triggered_at=now - timedelta(hours=1),
+        completed_at=now - timedelta(hours=1),
+    )
+
+    hard, _ = load_source_target_reliability(source)
+    assert t.node_id not in hard

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -127,6 +127,20 @@ See **[docs/features/rf_propagation/README.md](features/rf_propagation/README.md
 
 ---
 
+## 11. Traceroute target reliability (auto selection)
+
+Tunables for [automatic target selection reliability](../features/traceroute/algorithms.md#automatic-reliability). Only `trigger_type=auto` completed/failed `AutoTraceRoute` rows in the lookback window are used.
+
+| Variable | Default | Description | Allowable Values |
+|----------|---------|-------------|------------------|
+| `TR_RELIABILITY_ENABLED` | `true` (on) | When false, disables soft penalty and hard cooldown. | `1`, `0`, `true`, `false`, `yes`, `no`, `on`, `off` (empty = default) |
+| `TR_RELIABILITY_WINDOW_DAYS` | `14` | Lookback for reliability evidence and ordering of attempts. | Integer (string) |
+| `TR_RELIABILITY_CONSECUTIVE_FAILS` | `4` | Minimum **consecutive** recent automatic failures (newest first) to hard-cooldown a (source, target) pair. Set to `0` to disable hard cooldown. | Integer (string) |
+| `TR_RELIABILITY_SOFT_MAX` | `100` | Maximum soft penalty (same scale as distance/recency demerit) applied as this times `(failed/attempts)` when enough attempts exist. Set to `0` to disable soft penalty. | Float (string) |
+| `TR_RELIABILITY_MIN_ATTEMPTS_SOFT` | `3` | Minimum completed or failed auto attempts in the window before applying the soft ratio penalty. | Integer (string) |
+
+---
+
 # Details
 
 ## 1. General Application
@@ -182,6 +196,13 @@ See **[docs/features/rf_propagation/README.md](features/rf_propagation/README.md
 - **RF_PROPAGATION_DEFAULT_RADIUS_M**, **RF_PROPAGATION_COLORMAP**, **RF_PROPAGATION_HIGH_RESOLUTION**, **RF_PROPAGATION_MIN_DBM**, **RF_PROPAGATION_MAX_DBM**, **RF_PROPAGATION_SIGNAL_THRESHOLD_DBM**: Tunables folded into `build_request` and the render input hash.
 - **RF_PROPAGATION_NODATA_RGB** / **RF_PROPAGATION_NODATA_TOLERANCE**: PNG post-processing for Leaflet overlays.
 - **RF_PROPAGATION_POLL_MAX_SECONDS**, **RF_PROPAGATION_READY_RETENTION**: Worker behaviour.
+
+## 11. Traceroute target reliability
+
+- **TR_RELIABILITY_ENABLED**: Master switch for automatic target reliability in `traceroute.target_selection`.
+- **TR_RELIABILITY_WINDOW_DAYS**: How far back to read `AutoTraceRoute` rows for a given managed source.
+- **TR_RELIABILITY_CONSECUTIVE_FAILS**: Streak of automatic failures (after the most recent attempt) required to exclude the target for that source. `0` disables exclusion.
+- **TR_RELIABILITY_SOFT_MAX** / **TR_RELIABILITY_MIN_ATTEMPTS_SOFT**: Soft deprioritisation of targets with a poor success ratio without excluding them.
 
 ---
 

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -58,12 +58,13 @@ Late responses: if a TR was marked `failed` (timeout) but the response arrives l
 
 Auto-scheduler and permission checks share one notion of a **live** source node (`ManagedNodeStatus.is_sending_data`, refreshed from `PacketObservation.upload_time` on a beat schedule). Canonical implementation: **`nodes.managed_node_liveness`** (`eligible_auto_traceroute_sources_queryset`, etc.). **`traceroute.source_eligibility`** re-exports the same API for existing imports.
 
-**Target selection** for auto TR: `traceroute.target_selection.pick_traceroute_target` uses **`common.geo.haversine_km`** and **`nodes.positioning.managed_node_lat_lon`**.
+**Target selection** for auto TR: `traceroute.target_selection.pick_traceroute_target` uses **`common.geo.haversine_km`**, **`nodes.positioning.managed_node_lat_lon`**, and optional automatic reliability (soft penalty and hard cooldown from recent `AutoTraceRoute` rows with `trigger_type=auto`; see [Algorithms](algorithms.md) and [ENV_VARS.md](../../ENV_VARS.md) §11).
 
 **Manual trigger rate limit**: **`traceroute.trigger_intervals.MANUAL_TRIGGER_MIN_INTERVAL_SEC`**. Mesh monitoring (future Celery) can use **`MONITORING_TRIGGER_MIN_INTERVAL_SEC`** for a shorter default.
 
 ## Related Documentation
 
+- [Algorithms](algorithms.md) – Source, strategy, and target selection (including auto reliability)
 - [Permissions](permissions.md) – Canonical rules for who may view and trigger traceroutes
 - [Flow](flow.md) – End-to-end lifecycle from trigger to completion
 - [Heatmap](heatmap.md) – Neo4j schema, heatmap-edges API, visualization

--- a/docs/features/traceroute/algorithms.md
+++ b/docs/features/traceroute/algorithms.md
@@ -1,0 +1,93 @@
+# Traceroute selection algorithms
+
+This document describes the design of Meshflow automatic traceroute **source** selection, **strategy** rotation, and **target** selection, including automatic reliability signals. Implementation lives under `Meshflow/traceroute/`.
+
+See also [Environment variables](../../ENV_VARS.md) §11 for tunables.
+
+---
+
+## Scheduler flow
+
+On each automatic scheduling tick the system:
+
+1. Orders **eligible managed sources** (feeders) with a pluggable policy.
+2. For each source in order, tries **target strategies** from least-recently-used to oldest.
+3. For the first strategy that yields a target, creates an `AutoTraceRoute` and sends the command.
+4. If no hypothesis strategy finds a target, falls back to **legacy** target selection.
+
+Manual and **monitor** traceroutes are out of scope for automatic reliability: only `trigger_type=auto` terminal rows inform cooldowns and soft penalties.
+
+---
+
+## Source selection
+
+**Intent:** choose which managed node should originate the next automatic traceroute.
+
+**Inputs:** `allow_auto_traceroute`, managed-node liveness (recent ingestion), usable position, and `AutoTraceRoute` history for ordering.
+
+### Shared eligibility
+
+A source must be live, allowed for auto traceroute, and have coordinates (default location or linked observed position) so geographic target strategies can run.
+
+### Algorithms
+
+| Name | Behaviour | Trade-off |
+|------|-----------|-----------|
+| **Random** | Shuffle eligible sources. | Simple; no fairness. |
+| **Least recently used (LRU)** | Prefer the source whose last `AutoTraceRoute` is oldest; never-used first. | Fair across feeders; dense constellations with many feeders get more total share. |
+| **Stratified LRU** | Order constellations by oldest cluster-wide activity, then LRU within each. | Fairer across regions; more complex. |
+
+Environment: `AUTO_TR_SOURCE_SELECTION_ALGO` (`least_recently_used`, `random`, `stratified_lru`).
+
+---
+
+## Strategy rotation
+
+**Intent:** rotate which geographic “question” each feeder tests: intra-zone, DX across, DX same side.
+
+**Mechanism:** Redis-backed least-recently-used per `(feeder, strategy)` with a stable tie order. A strategy is recorded as run only when a traceroute is actually created.
+
+**Applicable strategies:** `intra_zone` requires a constellation envelope. Without it, only `dx_across` and `dx_same_side` apply. `legacy` is not part of rotation; it is a fallback from `pick_traceroute_target`.
+
+---
+
+## Target selection
+
+**Intent:** pick an `ObservedNode` target that matches the strategy’s geometry and is not a poor use of scheduler budget given recent automatic outcomes.
+
+**Shared pipeline:**
+
+1. Build the **base pool:** recently heard, positioned, not the source, not any managed infrastructure `node_id`, not mesh-monitoring suppressed.
+2. Apply **strategy geometry** (legacy distance bias, intra envelope, DX bearing window).
+3. Compute **strategy score** (e.g. distance for legacy, median distance for intra).
+4. Subtract **recency demerit** (same source→target traced recently).
+5. Subtract **reliability soft penalty** from recent automatic completed/failed history.
+6. **Hard-exclude** targets in automatic cooldown (consecutive automatic failures).
+7. Sort, take the top *N*, then **deterministic pick** from that shortlist (stable, avoids always picking rank 1).
+
+### Strategies
+
+- **Legacy:** Prefer more distant candidates (periphery bias), minus recency and reliability.
+- **Intra zone:** Only targets inside the constellation envelope; prefer distances near the **median** distance from the source to in-envelope nodes (avoids always picking the hub or a single outlier).
+- **DX across / same side:** Only outside the envelope; filter by **bearing** from the constellation centroid (opposite side vs same side as the source). **Widens** the bearing window in steps until some candidates exist. If geometry is unavailable, falls back to legacy-style scoring for that attempt.
+
+### Automatic reliability
+
+**Evidence:** `AutoTraceRoute` rows with `trigger_type=auto` and `status` in `completed` or `failed` within a configurable lookback window. User, monitor, and external triggers are ignored for suppression.
+
+**Per source–target pair:**
+
+- **Soft penalty:** `TR_RELIABILITY_SOFT_MAX * (failed / attempts)` when `attempts >= TR_RELIABILITY_MIN_ATTEMPTS_SOFT`, using the same ordered history. Reduces score without removing the target.
+- **Hard cooldown:** if the most recent automatic attempts, newest first, are **consecutive failures** and the run length is at least `TR_RELIABILITY_CONSECUTIVE_FAILS`, the target is excluded for this source until a success occurs or the window/attempt pattern changes. A more recent `completed` row in the same window breaks the streak (only trailing failures count).
+
+Tunables: `TR_RELIABILITY_ENABLED`, `TR_RELIABILITY_WINDOW_DAYS`, `TR_RELIABILITY_CONSECUTIVE_FAILS`, `TR_RELIABILITY_SOFT_MAX`, `TR_RELIABILITY_MIN_ATTEMPTS_SOFT` (see [ENV_VARS.md](../../ENV_VARS.md)).
+
+**Design note:** the first version scopes signals to the **source–target** pair. A global per-target penalty across all feeders is reserved for a future iteration if needed.
+
+---
+
+## Non-goals
+
+- Replacing **manual** target choice.
+- Suppressing **monitoring** / watch-list verification traceroutes via the same automatic reliability rules.
+- Using coverage API aggregates as the scheduler’s primary state; selection reads `AutoTraceRoute` directly.


### PR DESCRIPTION
# Summary

Automatic traceroute target selection now deprioritises and temporarily excludes targets that have repeatedly **failed** recent **automatic** (`trigger_type=auto`) attempts from the same managed source, while leaving manual and monitor triggers out of the reliability evidence (meshflow-api#211, meshflow-api#210).

- New `traceroute.reliability` loads per–(source, target) soft penalty and hard cooldown from `AutoTraceRoute` history (configurable window; default consecutive-fail threshold 4, soft max 100, min 3 attempts for soft ratio).
- `target_selection` applies soft penalty and filters hard-cooled targets for legacy, intra-zone, and DX strategies; env tunables documented in `docs/ENV_VARS.md` §11.
- Added `docs/features/traceroute/algorithms.md` and linked it from the traceroute feature README.

## Testing performed

- `python -m pytest traceroute/tests/ -q`
- `black` / `isort` / `flake8` on new/changed traceroute Python files

Closes #211
Closes #210