### PR TITLE
feat(dx-monitoring): staff DX event API and node exclusion

### DIFF
--- a/Meshflow/Meshflow/urls.py
+++ b/Meshflow/Meshflow/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
                 path("stats/", include("stats.urls")),
                 path("traceroutes/", include("traceroute.urls")),
                 path("monitoring/", include("mesh_monitoring.urls")),
+                path("dx/", include("dx_monitoring.urls")),
                 path("messages/", include("text_messages.urls")),
                 # JWT Token endpoints
                 path("token/", CustomTokenObtainPairView.as_view(), name="token_obtain_pair"),

--- a/Meshflow/dx_monitoring/serializers.py
+++ b/Meshflow/dx_monitoring/serializers.py
@@ -1,0 +1,113 @@
+"""Serializers for DX monitoring visibility API."""
+
+from rest_framework import serializers
+
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from constellations.models import Constellation
+from dx_monitoring.models import DxEvent, DxEventObservation, DxNodeMetadata
+from nodes.models import ManagedNode, ObservedNode
+
+
+class ConstellationMinimalSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Constellation
+        fields = ("id", "name")
+
+
+class DxManagedNodeMinimalSerializer(serializers.ModelSerializer):
+    node_id_str = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ManagedNode
+        fields = ("internal_id", "node_id", "node_id_str", "name")
+
+    def get_node_id_str(self, obj: ManagedNode) -> str:
+        return meshtastic_id_to_hex(obj.node_id)
+
+
+class DxDestinationSerializer(serializers.ModelSerializer):
+    """Observed destination node with nested DX metadata (exclusion flags)."""
+
+    dx_metadata = serializers.SerializerMethodField()
+
+    class Meta:
+        model = ObservedNode
+        fields = ("internal_id", "node_id", "node_id_str", "short_name", "long_name", "dx_metadata")
+
+    def get_dx_metadata(self, obj: ObservedNode) -> dict:
+        try:
+            m: DxNodeMetadata = obj.dx_metadata
+        except DxNodeMetadata.DoesNotExist:
+            return {
+                "exclude_from_detection": False,
+                "exclude_notes": "",
+                "updated_at": None,
+            }
+        return {
+            "exclude_from_detection": m.exclude_from_detection,
+            "exclude_notes": m.exclude_notes,
+            "updated_at": m.updated_at,
+        }
+
+
+class DxEventObservationSerializer(serializers.ModelSerializer):
+    observer = DxManagedNodeMinimalSerializer(read_only=True)
+
+    class Meta:
+        model = DxEventObservation
+        fields = (
+            "id",
+            "observed_at",
+            "distance_km",
+            "metadata",
+            "observer",
+            "raw_packet",
+            "packet_observation",
+        )
+
+
+class DxEventListSerializer(serializers.ModelSerializer):
+    constellation = ConstellationMinimalSerializer(read_only=True)
+    destination = DxDestinationSerializer(read_only=True)
+    last_observer = DxManagedNodeMinimalSerializer(read_only=True, allow_null=True)
+    evidence_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = DxEvent
+        fields = (
+            "id",
+            "constellation",
+            "destination",
+            "reason_code",
+            "state",
+            "first_observed_at",
+            "last_observed_at",
+            "active_until",
+            "observation_count",
+            "last_observer",
+            "best_distance_km",
+            "last_distance_km",
+            "metadata",
+            "evidence_count",
+        )
+
+
+class DxEventDetailSerializer(DxEventListSerializer):
+    observations = DxEventObservationSerializer(many=True, read_only=True)
+
+    class Meta(DxEventListSerializer.Meta):
+        fields = DxEventListSerializer.Meta.fields + ("observations",)
+
+
+class DxNodeExclusionRequestSerializer(serializers.Serializer):
+    node_id = serializers.IntegerField(min_value=1)
+    exclude_from_detection = serializers.BooleanField()
+    exclude_notes = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class DxNodeExclusionResponseSerializer(serializers.Serializer):
+    node_id = serializers.IntegerField()
+    node_id_str = serializers.CharField()
+    exclude_from_detection = serializers.BooleanField()
+    exclude_notes = serializers.CharField()
+    updated_at = serializers.DateTimeField(allow_null=True)

--- a/Meshflow/dx_monitoring/tests/test_dx_api.py
+++ b/Meshflow/dx_monitoring/tests/test_dx_api.py
@@ -1,0 +1,224 @@
+"""Tests for DX monitoring visibility API."""
+
+from datetime import timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import constellations.tests.conftest  # noqa: F401
+import nodes.tests.conftest  # noqa: F401
+import packets.tests.conftest  # noqa: F401
+import users.tests.conftest  # noqa: F401
+from dx_monitoring.models import DxEvent, DxEventObservation, DxEventState, DxNodeMetadata, DxReasonCode
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_dx_events_list_forbidden_for_non_staff(api_client, create_user, create_constellation, create_observed_node):
+    user = create_user(is_staff=False)
+    api_client.force_authenticate(user=user)
+    c = create_constellation()
+    dest = create_observed_node(node_id=0xABCD0001)
+    now = timezone.now()
+    DxEvent.objects.create(
+        constellation=c,
+        destination=dest,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+    )
+    url = reverse("dxevent-list")
+    r = api_client.get(url)
+    assert r.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_dx_events_list_staff_ok(api_client, create_user, create_constellation, create_observed_node):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    c = create_constellation()
+    dest = create_observed_node(node_id=0xABCD0002)
+    now = timezone.now()
+    ev = DxEvent.objects.create(
+        constellation=c,
+        destination=dest,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+    )
+    url = reverse("dxevent-list")
+    r = api_client.get(url)
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["count"] == 1
+    row = r.data["results"][0]
+    assert row["id"] == str(ev.id)
+    assert row["reason_code"] == DxReasonCode.NEW_DISTANT_NODE
+    assert row["destination"]["node_id"] == dest.node_id
+    assert row["destination"]["dx_metadata"]["exclude_from_detection"] is False
+    assert row["evidence_count"] == 0
+
+
+@pytest.mark.django_db
+def test_dx_events_filter_reason_and_destination(api_client, create_user, create_constellation, create_observed_node):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    c = create_constellation()
+    d1 = create_observed_node(node_id=0x11111101)
+    d2 = create_observed_node(node_id=0x22222202)
+    now = timezone.now()
+    DxEvent.objects.create(
+        constellation=c,
+        destination=d1,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+    )
+    DxEvent.objects.create(
+        constellation=c,
+        destination=d2,
+        reason_code=DxReasonCode.RETURNED_DX_NODE,
+        state=DxEventState.CLOSED,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now - timedelta(hours=1),
+    )
+    url = reverse("dxevent-list")
+    r = api_client.get(url, {"reason_code": DxReasonCode.RETURNED_DX_NODE})
+    assert r.data["count"] == 1
+    assert r.data["results"][0]["destination"]["node_id"] == d2.node_id
+
+    r2 = api_client.get(url, {"destination_node_id": d1.node_id})
+    assert r2.data["count"] == 1
+    assert r2.data["results"][0]["reason_code"] == DxReasonCode.NEW_DISTANT_NODE
+
+
+@pytest.mark.django_db
+def test_dx_event_detail_includes_observations(
+    api_client,
+    create_user,
+    create_constellation,
+    create_observed_node,
+    create_managed_node,
+    create_packet_observation,
+    create_node_info_packet,
+):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    observer = create_managed_node()
+    c = create_constellation()
+    dest = create_observed_node(node_id=0x33333303)
+    now = timezone.now()
+    ev = DxEvent.objects.create(
+        constellation=c,
+        destination=dest,
+        reason_code=DxReasonCode.DISTANT_OBSERVATION,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+        last_observer=observer,
+    )
+    pkt = create_node_info_packet(packet_id=42, from_int=dest.node_id, from_str=dest.node_id_str)
+    obs_po = create_packet_observation(packet=pkt, observer=observer)
+    DxEventObservation.objects.create(
+        event=ev,
+        raw_packet=pkt,
+        packet_observation=obs_po,
+        observer=observer,
+        observed_at=now,
+        distance_km=123.4,
+        metadata={"k": "v"},
+    )
+
+    url = reverse("dxevent-detail", kwargs={"pk": str(ev.id)})
+    r = api_client.get(url)
+    assert r.status_code == status.HTTP_200_OK
+    assert len(r.data["observations"]) == 1
+    o0 = r.data["observations"][0]
+    assert o0["distance_km"] == 123.4
+    assert str(o0["raw_packet"]) == str(pkt.id)
+    assert o0["observer"]["node_id"] == observer.node_id
+
+
+@pytest.mark.django_db
+def test_dx_node_exclusion_post_staff(api_client, create_user, create_observed_node):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    dest = create_observed_node(node_id=0x44444404)
+    url = reverse("dx-node-exclusion")
+    r = api_client.post(
+        url,
+        {"node_id": dest.node_id, "exclude_from_detection": True, "exclude_notes": "test mobile"},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["exclude_from_detection"] is True
+    assert r.data["exclude_notes"] == "test mobile"
+    meta = DxNodeMetadata.objects.get(observed_node=dest)
+    assert meta.exclude_from_detection is True
+
+
+@pytest.mark.django_db
+def test_dx_node_exclusion_forbidden_non_staff(api_client, create_user, create_observed_node):
+    user = create_user(is_staff=False)
+    api_client.force_authenticate(user=user)
+    dest = create_observed_node(node_id=0x55555505)
+    url = reverse("dx-node-exclusion")
+    r = api_client.post(
+        url,
+        {"node_id": dest.node_id, "exclude_from_detection": True},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_dx_node_exclusion_unknown_node(api_client, create_user):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    url = reverse("dx-node-exclusion")
+    r = api_client.post(
+        url,
+        {"node_id": 999999999999, "exclude_from_detection": True},
+        format="json",
+    )
+    assert r.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
+def test_dx_event_list_shows_exclusion_on_destination(
+    api_client, create_user, create_constellation, create_observed_node
+):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    c = create_constellation()
+    dest = create_observed_node(node_id=0x66666606)
+    DxNodeMetadata.objects.create(observed_node=dest, exclude_from_detection=True, exclude_notes="n")
+    now = timezone.now()
+    DxEvent.objects.create(
+        constellation=c,
+        destination=dest,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+    )
+    url = reverse("dxevent-list")
+    r = api_client.get(url)
+    assert r.data["results"][0]["destination"]["dx_metadata"]["exclude_from_detection"] is True
+    assert r.data["results"][0]["destination"]["dx_metadata"]["exclude_notes"] == "n"

--- a/Meshflow/dx_monitoring/urls.py
+++ b/Meshflow/dx_monitoring/urls.py
@@ -1,0 +1,18 @@
+from django.urls import include, path
+
+from rest_framework.routers import DefaultRouter
+
+from dx_monitoring.views import DxEventViewSet, DxNodeExclusionByNodeIdView, DxNodeExclusionView
+
+router = DefaultRouter()
+router.register(r"events", DxEventViewSet, basename="dxevent")
+
+urlpatterns = [
+    path("", include(router.urls)),
+    path("nodes/exclusion/", DxNodeExclusionView.as_view(), name="dx-node-exclusion"),
+    path(
+        "nodes/by-node-id/<int:node_id>/exclusion/",
+        DxNodeExclusionByNodeIdView.as_view(),
+        name="dx-node-exclusion-by-node-id",
+    ),
+]

--- a/Meshflow/dx_monitoring/views.py
+++ b/Meshflow/dx_monitoring/views.py
@@ -1,0 +1,194 @@
+"""Read-only DX event API and staff node exclusion for DX detection."""
+
+from django.db.models import Count, Prefetch
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from rest_framework import permissions, status, views, viewsets
+from rest_framework.response import Response
+
+from dx_monitoring.models import DxEvent, DxEventObservation, DxEventState, DxNodeMetadata
+from dx_monitoring.serializers import (
+    DxEventDetailSerializer,
+    DxEventListSerializer,
+    DxNodeExclusionRequestSerializer,
+    DxNodeExclusionResponseSerializer,
+)
+from nodes.models import ObservedNode
+
+
+def _parse_dt(raw: str):
+    dt = parse_datetime(raw)
+    if dt is None:
+        return None
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.get_current_timezone())
+    return dt
+
+
+class DxEventViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Staff-only read API for DX detection events.
+
+    List: GET /api/dx/events/
+    Detail: GET /api/dx/events/{uuid}/
+    """
+
+    permission_classes = [permissions.IsAdminUser]
+    lookup_field = "pk"
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return DxEventDetailSerializer
+        return DxEventListSerializer
+
+    def get_queryset(self):
+        qs = (
+            DxEvent.objects.all()
+            .select_related("constellation", "destination", "destination__dx_metadata", "last_observer")
+            .annotate(evidence_count=Count("observations", distinct=True))
+            .order_by("-last_observed_at")
+        )
+        if self.action == "retrieve":
+            qs = qs.prefetch_related(
+                Prefetch(
+                    "observations",
+                    queryset=DxEventObservation.objects.select_related(
+                        "raw_packet",
+                        "packet_observation",
+                        "observer",
+                    ).order_by("-observed_at"),
+                )
+            )
+        params = self.request.query_params
+
+        if state := params.get("state"):
+            qs = qs.filter(state=state)
+        if reason := params.get("reason_code"):
+            qs = qs.filter(reason_code=reason)
+        if cid := params.get("constellation"):
+            try:
+                qs = qs.filter(constellation_id=int(cid))
+            except ValueError:
+                qs = qs.none()
+        if raw := params.get("destination_node_id"):
+            try:
+                qs = qs.filter(destination__node_id=int(raw))
+            except ValueError:
+                qs = qs.none()
+        if raw := params.get("last_observer_id"):
+            qs = qs.filter(last_observer_id=raw)
+
+        if params.get("active_now") in ("1", "true", "True", "yes"):
+            now = timezone.now()
+            qs = qs.filter(state=DxEventState.ACTIVE, active_until__gte=now)
+
+        if raw := params.get("last_observed_after"):
+            dt = _parse_dt(raw)
+            if dt:
+                qs = qs.filter(last_observed_at__gte=dt)
+        if raw := params.get("last_observed_before"):
+            dt = _parse_dt(raw)
+            if dt:
+                qs = qs.filter(last_observed_at__lte=dt)
+        if raw := params.get("first_observed_after"):
+            dt = _parse_dt(raw)
+            if dt:
+                qs = qs.filter(first_observed_at__gte=dt)
+        if raw := params.get("first_observed_before"):
+            dt = _parse_dt(raw)
+            if dt:
+                qs = qs.filter(first_observed_at__lte=dt)
+
+        if params.get("recent_only") in ("1", "true", "True", "yes"):
+            raw_days = params.get("recent_days", "7")
+            try:
+                days = max(1, min(int(raw_days), 90))
+            except ValueError:
+                days = 7
+            cutoff = timezone.now() - timezone.timedelta(days=days)
+            qs = qs.filter(last_observed_at__gte=cutoff)
+
+        return qs
+
+
+class DxNodeExclusionView(views.APIView):
+    """
+    Create or update DxNodeMetadata for an observed node (by Meshtastic node_id).
+
+    POST /api/dx/nodes/exclusion/
+    Staff only.
+    """
+
+    permission_classes = [permissions.IsAdminUser]
+
+    def post(self, request):
+        ser = DxNodeExclusionRequestSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        node_id = ser.validated_data["node_id"]
+        exclude = ser.validated_data["exclude_from_detection"]
+        notes = ser.validated_data.get("exclude_notes") or ""
+
+        observed = ObservedNode.objects.filter(node_id=node_id).order_by("-last_heard", "-created_at").first()
+        if observed is None:
+            return Response(
+                {"detail": "No observed node found for this node_id."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        meta, _ = DxNodeMetadata.objects.get_or_create(observed_node=observed)
+        meta.exclude_from_detection = exclude
+        meta.exclude_notes = notes
+        meta.save()
+
+        out = DxNodeExclusionResponseSerializer(
+            {
+                "node_id": observed.node_id,
+                "node_id_str": observed.node_id_str,
+                "exclude_from_detection": meta.exclude_from_detection,
+                "exclude_notes": meta.exclude_notes,
+                "updated_at": meta.updated_at,
+            }
+        )
+        return Response(out.data, status=status.HTTP_200_OK)
+
+
+def _resolve_observed_by_node_id(node_id: int) -> ObservedNode | None:
+    return ObservedNode.objects.filter(node_id=node_id).order_by("-last_heard", "-created_at").first()
+
+
+class DxNodeExclusionByNodeIdView(views.APIView):
+    """
+    GET current exclusion flags for an observed node by Meshtastic node_id.
+
+    GET /api/dx/nodes/by-node-id/{node_id}/exclusion/
+    Staff only.
+    """
+
+    permission_classes = [permissions.IsAdminUser]
+
+    def get(self, request, node_id: int):
+        observed = _resolve_observed_by_node_id(node_id)
+        if observed is None:
+            return Response(
+                {"detail": "No observed node found for this node_id."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        meta = DxNodeMetadata.objects.filter(observed_node=observed).first()
+        if meta is None:
+            payload = {
+                "node_id": observed.node_id,
+                "node_id_str": observed.node_id_str,
+                "exclude_from_detection": False,
+                "exclude_notes": "",
+                "updated_at": None,
+            }
+        else:
+            payload = {
+                "node_id": observed.node_id,
+                "node_id_str": observed.node_id_str,
+                "exclude_from_detection": meta.exclude_from_detection,
+                "exclude_notes": meta.exclude_notes,
+                "updated_at": meta.updated_at,
+            }
+        return Response(DxNodeExclusionResponseSerializer(payload).data)

--- a/deployment/portainer/docker-compose.portainer.yaml
+++ b/deployment/portainer/docker-compose.portainer.yaml
@@ -121,6 +121,10 @@ services:
 
       # Discord notifications
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN}
+
+      # DX event detection
+      DX_MONITORING_DETECTION_ENABLED: true
+
     ports:
       - "${API_EXT_PORT}:8000"
     volumes:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,6 +26,8 @@ tags:
     description: Traceroute history and manual triggering
   - name: Mesh Monitoring
     description: User watches on observed nodes for silence detection and offline verification
+  - name: DX Monitoring
+    description: Staff-only DX detection event visibility and per-node exclusion metadata
 
 components:
   parameters:
@@ -2367,6 +2369,160 @@ components:
       properties:
         detail:
           type: string
+
+    DxConstellationMinimal:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+
+    DxManagedNodeMinimal:
+      type: object
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id:
+          type: integer
+        node_id_str:
+          type: string
+        name:
+          type: string
+
+    DxNodeMetadataPublic:
+      type: object
+      description: Per-destination DX tuning flags (subset exposed to the visibility API).
+      properties:
+        exclude_from_detection:
+          type: boolean
+        exclude_notes:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    DxDestinationNode:
+      type: object
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id:
+          type: integer
+        node_id_str:
+          type: string
+        short_name:
+          type: string
+        long_name:
+          type: string
+        dx_metadata:
+          $ref: '#/components/schemas/DxNodeMetadataPublic'
+
+    DxEventObservation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        observed_at:
+          type: string
+          format: date-time
+        distance_km:
+          type: number
+          nullable: true
+        metadata:
+          type: object
+        observer:
+          $ref: '#/components/schemas/DxManagedNodeMinimal'
+        raw_packet:
+          type: string
+          format: uuid
+        packet_observation:
+          type: integer
+
+    DxEventList:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        constellation:
+          $ref: '#/components/schemas/DxConstellationMinimal'
+        destination:
+          $ref: '#/components/schemas/DxDestinationNode'
+        reason_code:
+          type: string
+          enum: [new_distant_node, returned_dx_node, distant_observation]
+        state:
+          type: string
+          enum: [active, closed]
+        first_observed_at:
+          type: string
+          format: date-time
+        last_observed_at:
+          type: string
+          format: date-time
+        active_until:
+          type: string
+          format: date-time
+        observation_count:
+          type: integer
+        last_observer:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/DxManagedNodeMinimal'
+        best_distance_km:
+          type: number
+          nullable: true
+        last_distance_km:
+          type: number
+          nullable: true
+        metadata:
+          type: object
+        evidence_count:
+          type: integer
+
+    DxEventDetail:
+      allOf:
+        - $ref: '#/components/schemas/DxEventList'
+        - type: object
+          properties:
+            observations:
+              type: array
+              items:
+                $ref: '#/components/schemas/DxEventObservation'
+
+    DxNodeExclusionRequest:
+      type: object
+      required: [node_id, exclude_from_detection]
+      properties:
+        node_id:
+          type: integer
+          description: Meshtastic node id of the observed destination node.
+        exclude_from_detection:
+          type: boolean
+        exclude_notes:
+          type: string
+          default: ''
+
+    DxNodeExclusionResponse:
+      type: object
+      properties:
+        node_id:
+          type: integer
+        node_id_str:
+          type: string
+        exclude_from_detection:
+          type: boolean
+        exclude_notes:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
 
 
 paths:
@@ -5594,6 +5750,180 @@ paths:
           description: Unauthorized
         '404':
           description: Not found
+
+  /dx/events/:
+    get:
+      summary: List DX detection events
+      description: >
+        Staff-only. Paginated list of DX events with filters for operational review.
+      tags: [DX Monitoring]
+      security:
+        - BearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PaginationPage'
+        - $ref: '#/components/parameters/PaginationPageSize'
+        - name: state
+          in: query
+          schema:
+            type: string
+            enum: [active, closed]
+        - name: reason_code
+          in: query
+          schema:
+            type: string
+            enum: [new_distant_node, returned_dx_node, distant_observation]
+        - name: constellation
+          in: query
+          schema:
+            type: integer
+        - name: destination_node_id
+          in: query
+          schema:
+            type: integer
+        - name: last_observer_id
+          in: query
+          description: ManagedNode internal UUID
+          schema:
+            type: string
+            format: uuid
+        - name: active_now
+          in: query
+          description: When true, only events that are active and not past active_until.
+          schema:
+            type: boolean
+        - name: recent_only
+          in: query
+          description: When true, restrict to last_observed_at within recent_days (default 7, max 90).
+          schema:
+            type: boolean
+        - name: recent_days
+          in: query
+          schema:
+            type: integer
+            default: 7
+        - name: last_observed_after
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: last_observed_before
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: first_observed_after
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: first_observed_before
+          in: query
+          schema:
+            type: string
+            format: date-time
+      responses:
+        '200':
+          description: Paginated DX events
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      results:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/DxEventList'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden (not staff)
+
+  /dx/events/{id}/:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      summary: Get DX event detail with evidence rows
+      tags: [DX Monitoring]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: DX event with nested observations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DxEventDetail'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden (not staff)
+        '404':
+          description: Not found
+
+  /dx/nodes/exclusion/:
+    post:
+      summary: Set DX exclusion metadata for an observed node
+      description: >
+        Staff-only. Creates or updates DxNodeMetadata for the most recently heard ObservedNode
+        matching the given Meshtastic node_id.
+      tags: [DX Monitoring]
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DxNodeExclusionRequest'
+      responses:
+        '200':
+          description: Updated exclusion flags
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DxNodeExclusionResponse'
+        '400':
+          description: Validation error
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden (not staff)
+        '404':
+          description: No observed node for node_id
+
+  /dx/nodes/by-node-id/{node_id}/exclusion/:
+    parameters:
+      - name: node_id
+        in: path
+        required: true
+        schema:
+          type: integer
+    get:
+      summary: Read DX exclusion metadata for an observed node
+      description: Staff-only. Resolves the same ObservedNode row as the POST exclusion endpoint.
+      tags: [DX Monitoring]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Current exclusion flags
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DxNodeExclusionResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden (not staff)
+        '404':
+          description: No observed node for node_id
 
   /nodes/claims/mine/:
     get:


### PR DESCRIPTION
# Summary

Adds staff-only REST endpoints under `/api/dx/` for Phase 6a operational visibility: paginated DX event list and detail (with evidence rows and nested destination `DxNodeMetadata`), filters for state, reason, time windows, constellation, destination and observer, plus `POST /api/dx/nodes/exclusion/` to set `exclude_from_detection` / notes on `DxNodeMetadata` by Meshtastic `node_id`. OpenAPI documents the contract.

Related to DX Monitoring epic #217. Closes #222.

## Testing performed

- `python -m pytest Meshflow/dx_monitoring/tests/test_dx_api.py -v`
- `black`, `isort`, and `flake8` on `Meshflow/dx_monitoring/`