### PR TITLE
feat(dx-monitoring): expose DX traceroute exploration on event API

### DIFF
--- a/Meshflow/dx_monitoring/serializers.py
+++ b/Meshflow/dx_monitoring/serializers.py
@@ -1,11 +1,14 @@
 """Serializers for DX monitoring visibility API."""
 
+from collections import Counter
+
 from rest_framework import serializers
 
 from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import Constellation
-from dx_monitoring.models import DxEvent, DxEventObservation, DxNodeMetadata
+from dx_monitoring.models import DxEvent, DxEventObservation, DxEventTraceroute, DxNodeMetadata
 from nodes.models import ManagedNode, ObservedNode
+from traceroute.models import AutoTraceRoute
 
 
 class ConstellationMinimalSerializer(serializers.ModelSerializer):
@@ -66,11 +69,87 @@ class DxEventObservationSerializer(serializers.ModelSerializer):
         )
 
 
+class DxObservedNodeHopSerializer(serializers.ModelSerializer):
+    """Destination (or hop target) without nested dx_metadata — used on exploration rows."""
+
+    class Meta:
+        model = ObservedNode
+        fields = ("internal_id", "node_id", "node_id_str", "short_name", "long_name")
+
+
+class DxAutoTracerouteExplorationSerializer(serializers.ModelSerializer):
+    """Queued or completed AutoTraceRoute row when present on a DX exploration attempt."""
+
+    trigger_type_label = serializers.SerializerMethodField()
+
+    class Meta:
+        model = AutoTraceRoute
+        fields = (
+            "id",
+            "status",
+            "trigger_type",
+            "trigger_type_label",
+            "trigger_source",
+            "triggered_at",
+            "earliest_send_at",
+            "dispatched_at",
+            "completed_at",
+            "error_message",
+        )
+
+    def get_trigger_type_label(self, obj: AutoTraceRoute) -> str:
+        labels = {
+            int(AutoTraceRoute.TRIGGER_TYPE_USER): "User",
+            int(AutoTraceRoute.TRIGGER_TYPE_EXTERNAL): "External",
+            int(AutoTraceRoute.TRIGGER_TYPE_MONITORING): "Monitoring",
+            int(AutoTraceRoute.TRIGGER_TYPE_NODE_WATCH): "Node watch",
+            int(AutoTraceRoute.TRIGGER_TYPE_DX_WATCH): "DX Watch",
+            int(AutoTraceRoute.TRIGGER_TYPE_NEW_NODE_BASELINE): "New node baseline",
+        }
+        return labels.get(int(obj.trigger_type), str(obj.trigger_type))
+
+
+class DxEventTracerouteExplorationSerializer(serializers.ModelSerializer):
+    """One DX exploration attempt: DX_WATCH queue, skip outcome, or linked new-node baseline."""
+
+    auto_traceroute = DxAutoTracerouteExplorationSerializer(read_only=True, allow_null=True)
+    source_node = DxManagedNodeMinimalSerializer(read_only=True, allow_null=True)
+    destination = serializers.SerializerMethodField()
+    link_kind = serializers.SerializerMethodField()
+
+    class Meta:
+        model = DxEventTraceroute
+        fields = (
+            "id",
+            "outcome",
+            "skip_reason",
+            "metadata",
+            "link_kind",
+            "created_at",
+            "updated_at",
+            "source_node",
+            "destination",
+            "auto_traceroute",
+        )
+
+    def get_link_kind(self, obj: DxEventTraceroute) -> str:
+        meta = obj.metadata or {}
+        return str(meta.get("link_kind") or "")
+
+    def get_destination(self, obj: DxEventTraceroute) -> dict:
+        if obj.auto_traceroute_id:
+            dest = obj.auto_traceroute.target_node
+        else:
+            dest = obj.event.destination
+        return DxObservedNodeHopSerializer(dest, context=self.context).data
+
+
 class DxEventListSerializer(serializers.ModelSerializer):
     constellation = ConstellationMinimalSerializer(read_only=True)
     destination = DxDestinationSerializer(read_only=True)
     last_observer = DxManagedNodeMinimalSerializer(read_only=True, allow_null=True)
     evidence_count = serializers.IntegerField(read_only=True)
+    exploration_attempt_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = DxEvent
@@ -89,14 +168,34 @@ class DxEventListSerializer(serializers.ModelSerializer):
             "last_distance_km",
             "metadata",
             "evidence_count",
+            "exploration_attempt_count",
         )
 
 
 class DxEventDetailSerializer(DxEventListSerializer):
     observations = DxEventObservationSerializer(many=True, read_only=True)
+    traceroute_explorations = DxEventTracerouteExplorationSerializer(many=True, read_only=True)
+    exploration_summary = serializers.SerializerMethodField()
 
     class Meta(DxEventListSerializer.Meta):
-        fields = DxEventListSerializer.Meta.fields + ("observations",)
+        fields = DxEventListSerializer.Meta.fields + (
+            "observations",
+            "traceroute_explorations",
+            "exploration_summary",
+        )
+
+    def get_exploration_summary(self, obj: DxEvent) -> dict:
+        rows = list(obj.traceroute_explorations.all())
+        by_outcome = Counter((r.outcome or "") for r in rows)
+        baseline_rows = sum(1 for r in rows if (r.metadata or {}).get("link_kind") == "new_node_baseline")
+        return {
+            "total": len(rows),
+            "pending": int(by_outcome.get("pending", 0)),
+            "completed": int(by_outcome.get("completed", 0)),
+            "failed": int(by_outcome.get("failed", 0)),
+            "skipped": int(by_outcome.get("skipped", 0)),
+            "baseline_linked_rows": baseline_rows,
+        }
 
 
 class DxNodeExclusionRequestSerializer(serializers.Serializer):

--- a/Meshflow/dx_monitoring/tests/test_dx_api.py
+++ b/Meshflow/dx_monitoring/tests/test_dx_api.py
@@ -10,10 +10,21 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 import constellations.tests.conftest  # noqa: F401
+import dx_monitoring.tests.conftest  # noqa: F401
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
 import users.tests.conftest  # noqa: F401
-from dx_monitoring.models import DxEvent, DxEventObservation, DxEventState, DxNodeMetadata, DxReasonCode
+from dx_monitoring.models import (
+    DxEvent,
+    DxEventObservation,
+    DxEventState,
+    DxEventTraceroute,
+    DxEventTracerouteOutcome,
+    DxEventTracerouteSkipReason,
+    DxNodeMetadata,
+    DxReasonCode,
+)
+from traceroute.models import AutoTraceRoute
 
 
 @pytest.fixture
@@ -68,6 +79,7 @@ def test_dx_events_list_staff_ok(api_client, create_user, create_constellation, 
     assert row["destination"]["node_id"] == dest.node_id
     assert row["destination"]["dx_metadata"]["exclude_from_detection"] is False
     assert row["evidence_count"] == 0
+    assert row["exploration_attempt_count"] == 0
 
 
 @pytest.mark.django_db
@@ -152,6 +164,90 @@ def test_dx_event_detail_includes_observations(
     assert o0["distance_km"] == 123.4
     assert str(o0["raw_packet"]) == str(pkt.id)
     assert o0["observer"]["node_id"] == observer.node_id
+
+
+@pytest.mark.django_db
+def test_dx_event_detail_includes_traceroute_explorations(
+    api_client,
+    create_user,
+    create_constellation,
+    create_observed_node,
+    create_managed_node,
+    create_auto_traceroute,
+):
+    staff = create_user(is_staff=True)
+    api_client.force_authenticate(user=staff)
+    source = create_managed_node()
+    c = create_constellation()
+    dest = create_observed_node(node_id=0x77777707)
+    now = timezone.now()
+    ev = DxEvent.objects.create(
+        constellation=c,
+        destination=dest,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        state=DxEventState.ACTIVE,
+        first_observed_at=now,
+        last_observed_at=now,
+        active_until=now + timedelta(hours=1),
+    )
+    tr = create_auto_traceroute(
+        source_node=source,
+        target_node=dest,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_DX_WATCH,
+        status=AutoTraceRoute.STATUS_PENDING,
+        triggered_by=None,
+    )
+    DxEventTraceroute.objects.create(
+        event=ev,
+        auto_traceroute=tr,
+        source_node=source,
+        outcome=DxEventTracerouteOutcome.PENDING,
+        metadata={"link_kind": "dx_watch"},
+    )
+    DxEventTraceroute.objects.create(
+        event=ev,
+        auto_traceroute=None,
+        source_node=None,
+        outcome=DxEventTracerouteOutcome.SKIPPED,
+        skip_reason=DxEventTracerouteSkipReason.NO_ELIGIBLE_SOURCE,
+        metadata={},
+    )
+    baseline_tr = create_auto_traceroute(
+        source_node=source,
+        target_node=dest,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_NEW_NODE_BASELINE,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+        triggered_by=None,
+        route=[{"node_id": 1, "snr": 0.0}],
+    )
+    DxEventTraceroute.objects.create(
+        event=ev,
+        auto_traceroute=baseline_tr,
+        source_node=source,
+        outcome=DxEventTracerouteOutcome.COMPLETED,
+        metadata={"link_kind": "new_node_baseline", "route_hops": 1},
+    )
+
+    url = reverse("dxevent-detail", kwargs={"pk": str(ev.id)})
+    r = api_client.get(url)
+    assert r.status_code == status.HTTP_200_OK
+    assert r.data["exploration_summary"]["total"] == 3
+    assert r.data["exploration_summary"]["pending"] == 1
+    assert r.data["exploration_summary"]["skipped"] == 1
+    assert r.data["exploration_summary"]["completed"] == 1
+    assert r.data["exploration_summary"]["baseline_linked_rows"] == 1
+
+    ex = {row["outcome"]: row for row in r.data["traceroute_explorations"]}
+    assert ex["pending"]["link_kind"] == "dx_watch"
+    assert ex["pending"]["auto_traceroute"]["trigger_type"] == AutoTraceRoute.TRIGGER_TYPE_DX_WATCH
+    assert ex["pending"]["destination"]["node_id"] == dest.node_id
+    assert ex["skipped"]["skip_reason"] == DxEventTracerouteSkipReason.NO_ELIGIBLE_SOURCE
+    assert ex["skipped"]["auto_traceroute"] is None
+    assert ex["completed"]["auto_traceroute"]["trigger_type"] == AutoTraceRoute.TRIGGER_TYPE_NEW_NODE_BASELINE
+
+    r_list = api_client.get(reverse("dxevent-list"))
+    row = next(x for x in r_list.data["results"] if x["id"] == str(ev.id))
+    assert row["exploration_attempt_count"] == 3
 
 
 @pytest.mark.django_db

--- a/Meshflow/dx_monitoring/views.py
+++ b/Meshflow/dx_monitoring/views.py
@@ -1,13 +1,14 @@
 """Read-only DX event API and staff node exclusion for DX detection."""
 
-from django.db.models import Count, Prefetch
+from django.db.models import Count, IntegerField, OuterRef, Prefetch, Subquery, Value
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 from rest_framework import permissions, status, views, viewsets
 from rest_framework.response import Response
 
-from dx_monitoring.models import DxEvent, DxEventObservation, DxEventState, DxNodeMetadata
+from dx_monitoring.models import DxEvent, DxEventObservation, DxEventState, DxEventTraceroute, DxNodeMetadata
 from dx_monitoring.serializers import (
     DxEventDetailSerializer,
     DxEventListSerializer,
@@ -24,6 +25,14 @@ def _parse_dt(raw: str):
     if timezone.is_naive(dt):
         dt = timezone.make_aware(dt, timezone.get_current_timezone())
     return dt
+
+
+_exploration_attempt_count_sq = (
+    DxEventTraceroute.objects.filter(event_id=OuterRef("pk"))
+    .values("event_id")
+    .annotate(_c=Count("id"))
+    .values("_c")[:1]
+)
 
 
 class DxEventViewSet(viewsets.ReadOnlyModelViewSet):
@@ -46,7 +55,13 @@ class DxEventViewSet(viewsets.ReadOnlyModelViewSet):
         qs = (
             DxEvent.objects.all()
             .select_related("constellation", "destination", "destination__dx_metadata", "last_observer")
-            .annotate(evidence_count=Count("observations", distinct=True))
+            .annotate(
+                evidence_count=Count("observations", distinct=True),
+                exploration_attempt_count=Coalesce(
+                    Subquery(_exploration_attempt_count_sq, output_field=IntegerField()),
+                    Value(0),
+                ),
+            )
             .order_by("-last_observed_at")
         )
         if self.action == "retrieve":
@@ -58,7 +73,16 @@ class DxEventViewSet(viewsets.ReadOnlyModelViewSet):
                         "packet_observation",
                         "observer",
                     ).order_by("-observed_at"),
-                )
+                ),
+                Prefetch(
+                    "traceroute_explorations",
+                    queryset=DxEventTraceroute.objects.select_related(
+                        "source_node",
+                        "event__destination",
+                        "auto_traceroute",
+                        "auto_traceroute__target_node",
+                    ).order_by("-created_at"),
+                ),
             )
         params = self.request.query_params
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2444,6 +2444,105 @@ components:
         packet_observation:
           type: integer
 
+    DxObservedNodeHop:
+      type: object
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id:
+          type: integer
+        node_id_str:
+          type: string
+        short_name:
+          type: string
+        long_name:
+          type: string
+
+    DxAutoTracerouteExploration:
+      type: object
+      properties:
+        id:
+          type: integer
+        status:
+          type: string
+          enum: [pending, sent, completed, failed]
+        trigger_type:
+          type: integer
+        trigger_type_label:
+          type: string
+        trigger_source:
+          type: string
+          nullable: true
+        triggered_at:
+          type: string
+          format: date-time
+        earliest_send_at:
+          type: string
+          format: date-time
+        dispatched_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+
+    DxEventTracerouteExploration:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        outcome:
+          type: string
+          enum: [pending, completed, failed, skipped]
+        skip_reason:
+          type: string
+          description: Set when outcome is skipped (DX gating / dedupe / cooldown).
+        metadata:
+          type: object
+        link_kind:
+          type: string
+          description: From metadata; dx_watch or new_node_baseline when set.
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        source_node:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/DxManagedNodeMinimal'
+        destination:
+          $ref: '#/components/schemas/DxObservedNodeHop'
+        auto_traceroute:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/DxAutoTracerouteExploration'
+
+    DxExplorationSummary:
+      type: object
+      properties:
+        total:
+          type: integer
+        pending:
+          type: integer
+        completed:
+          type: integer
+        failed:
+          type: integer
+        skipped:
+          type: integer
+        baseline_linked_rows:
+          type: integer
+          description: Count of exploration rows tied to a new-node baseline traceroute.
+
     DxEventList:
       type: object
       properties:
@@ -2456,7 +2555,7 @@ components:
           $ref: '#/components/schemas/DxDestinationNode'
         reason_code:
           type: string
-          enum: [new_distant_node, returned_dx_node, distant_observation]
+          enum: [new_distant_node, returned_dx_node, distant_observation, traceroute_distant_hop]
         state:
           type: string
           enum: [active, closed]
@@ -2485,6 +2584,9 @@ components:
           type: object
         evidence_count:
           type: integer
+        exploration_attempt_count:
+          type: integer
+          description: Number of DX exploration attempt rows (queued, linked baseline, or skipped).
 
     DxEventDetail:
       allOf:
@@ -2495,6 +2597,12 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/DxEventObservation'
+            traceroute_explorations:
+              type: array
+              items:
+                $ref: '#/components/schemas/DxEventTracerouteExploration'
+            exploration_summary:
+              $ref: '#/components/schemas/DxExplorationSummary'
 
     DxNodeExclusionRequest:
       type: object
@@ -5789,7 +5897,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: [new_distant_node, returned_dx_node, distant_observation]
+            enum: [new_distant_node, returned_dx_node, distant_observation, traceroute_distant_hop]
         - name: constellation
           in: query
           schema:


### PR DESCRIPTION
# Summary

Adds the DX monitoring read-contract needed by the Phase 6b UI so staff can inspect how each DX event was explored with traceroutes.

- Adds nested `traceroute_explorations` and `exploration_summary` to DX event detail responses.
- Adds `exploration_attempt_count` to DX event list responses.
- Documents the new response shape in `openapi.yaml` and covers baseline-linked, queued, completed, and skipped rows in API tests.

Tracking ticket: pskillen/meshtastic-bot-ui#231
Parent epic: pskillen/meshflow-api#217

## Testing performed

- `python -m pytest dx_monitoring/tests/test_dx_api.py -v --tb=short`
- `black dx_monitoring/models.py dx_monitoring/serializers.py dx_monitoring/views.py dx_monitoring/tests/test_dx_api.py`
- `isort dx_monitoring/models.py dx_monitoring/serializers.py dx_monitoring/views.py dx_monitoring/tests/test_dx_api.py`
- `flake8 dx_monitoring/models.py dx_monitoring/serializers.py dx_monitoring/views.py dx_monitoring/tests/test_dx_api.py`