### PR TITLE
docs: document RF maps and traceroute ownership

### DIFF
--- a/docs/features/rf_propagation/README.md
+++ b/docs/features/rf_propagation/README.md
@@ -1,58 +1,80 @@
-# RF propagation renders
+# RF propagation
 
 Owners of observed nodes can request a predicted RF coverage map for their
-hardware, rendered as a Leaflet PNG overlay. This document covers how the
-pipeline fits together in production.
+hardware. Meshflow stores RF profile settings, queues a render through Celery,
+calls the Meshtastic Site Planner Docker image, converts the returned GeoTIFF
+to a browser asset, and displays it over the normal map.
+
+## Docs
+
+- [pipeline.md](pipeline.md) - queue admission, deduplication, Celery pickup,
+  and the handoff to the Site Planner Docker image.
+- [rendering.md](rendering.md) - render inputs, Site Planner output,
+  GeoTIFF-to-PNG conversion, asset storage, cache keys, and retention.
+- [geo-rendering.md](geo-rendering.md) - geospatial bounds, raster display,
+  Leaflet overlay placement, and alignment investigation notes.
+- [privacy.md](privacy.md) - private-coordinate threat model, leak surfaces,
+  candidate mitigations, and expected tests.
 
 ## Architecture
 
 ```mermaid
 sequenceDiagram
     participant UI
-    participant API as api (Django)
-    participant Q as Redis (DB 1)<br/>rf_renders queue
+    participant API as api Django
+    participant Q as Redis DB 1 Celery broker
     participant W as celery-rf-worker
-    participant E as rf-propagation<br/>(Site Planner)
+    participant E as rf-propagation Site Planner
     participant FS as rf_assets volume
 
-    UI->>API: POST /rf-propagation/recompute/
-    API->>API: hash profile &amp; dedup (cache / in-flight)
-    API->>Q: enqueue render task (rf_renders)
-    API-->>UI: 201 { status: pending, input_hash }
-
-    W->>Q: BRPOP rf_renders
-    W->>E: POST /predict (lat, lon, frequency_mhz, …)
-    E-->>W: 200 { task_id }
-    loop poll until done
-        W->>E: GET /status/{task_id}
-        E-->>W: { status }
-    end
-    W->>E: GET /result/{task_id}
+    UI->>API: POST rf-propagation/recompute
+    API->>API: validate profile, hash, dedupe
+    API->>Q: enqueue render task
+    API-->>UI: render row
+    W->>Q: consume render task
+    W->>E: POST /predict
+    E-->>W: task_id
+    W->>E: poll /status then GET /result
     E-->>W: GeoTIFF bytes
-    W->>W: GeoTIFF → PNG
-    W->>FS: write {hash}.png
-    W->>API: UPDATE render row status=ready, bounds, asset_filename
-
-    UI->>API: GET /rf-propagation/ (polling, 5s)
-    API-->>UI: { status: ready, asset_url, bounds }
-    UI->>FS: GET {asset_url} (public PNG)
+    W->>W: GeoTIFF to PNG and bounds
+    W->>FS: write hash.png
+    W->>API: mark render ready
+    UI->>API: poll rf-propagation
+    API-->>UI: asset_url and bounds
 ```
 
-Three containers collaborate on every render:
+## Main components
 
-- **api** accepts the request and holds the `NodeRfProfile` /
-  `NodeRfPropagationRender` rows. See `nodes/views.py::rf_propagation_recompute`.
-- **celery-rf-worker** consumes the dedicated `rf_renders` queue and drives
-  one render to completion. See `rf_propagation/tasks.py`.
-- **rf-propagation** (image `ghcr.io/pskillen/meshflow-rf-propagation`) is
-  an external FastAPI service that wraps SPLAT! and returns a GeoTIFF.
+- `NodeRfProfile` stores RF render inputs for an `ObservedNode`, including
+  private RF coordinates and radio parameters.
+- `NodeRfPropagationRender` stores one render attempt, status, cache hash,
+  asset filename, bounds, errors, and completion time.
+- `rf_propagation.payload` builds the Site Planner request body.
+- `rf_propagation.hashing` computes the cache key from normalized profile
+  fields, render version, and render tunables.
+- `rf_propagation.tasks.render_rf_propagation` drives the engine roundtrip and
+  writes the generated asset.
+- `rf_propagation.image` decodes the GeoTIFF, extracts bounds, applies
+  transparency, and writes PNG bytes.
+- `meshtastic-bot-ui` displays ready renders with a Leaflet image overlay.
+
+## Runtime services
+
+Three containers collaborate on a render:
+
+- `api` accepts requests and owns database state.
+- `celery-rf-worker` consumes RF render tasks from the Celery broker.
+- `rf-propagation` runs the Site Planner FastAPI service and SPLAT!.
+
+Redis is shared across services with logical database partitioning. Channels
+uses DB 0, Celery uses DB 1, Django cache uses DB 2, and Site Planner uses DB 3
+for its own task state.
 
 ## Engine dependency
 
-The engine is pulled (not built) from GHCR; the source lives in the
-`meshflow-rf-propagation` repository. Local stacks default to the
-`latest-dev` tag; Portainer stacks pin an explicit `RF_PROPAGATION_TAG`
-in `.env.portainer.*`.
+The engine image is published from `meshflow-rf-propagation` and pulled from
+GHCR. Local stacks default to `latest-dev`; Portainer stacks pin an explicit
+`RF_PROPAGATION_TAG`.
 
 Smoke-test the engine without the UI:
 
@@ -64,168 +86,25 @@ docker compose exec api curl -sf http://rf-propagation:8080/docs >/dev/null && e
 docker compose exec api curl -sf http://site-planner:8080/docs >/dev/null && echo ok
 ```
 
-## Redis layout
+## Operational notes
 
-Redis is shared across services with logical database partitioning — see
-[docs/REDIS.md](../../REDIS.md). In short: Channels on DB 0, Celery broker
-on DB 1, Django cache on DB 2, and the Site Planner engine on **DB 3**
-for its own task state.
-
-## Hashing and cache strategy
-
-`rf_propagation.hashing.compute_input_hash` produces a SHA256 digest over:
-
-- The rounded RF profile fields (lat/lng to 6 dp, metres to 2 dp, dB to
-  1 dp, frequency to 3 dp).
-- `antenna_pattern`, azimuth, beamwidth (captured even though Site Planner
-  currently ignores them — future engines may use them).
-- `render_version` from `settings.RF_PROPAGATION_RENDER_VERSION`.
-- Engine tunables from ``rf_propagation.payload.hash_extras_from_payload``
-  (`radius_m`, `colormap`, `high_resolution`, `min_dbm`, `max_dbm`,
-  `signal_threshold`) so changing any of the related environment variables
-  invalidates existing renders.
-
-The hash doubles as the on-disk filename (`{hash}.png`). Two nodes with
-identical RF profiles therefore share a PNG.
-
-### Single-inflight dedup
-
-`rf_propagation_recompute` will:
-
-1. Reuse a `ready` render with a matching hash (no new row, no engine
-   call) whose asset still exists on disk.
-2. Otherwise return any `pending`/`running` row that already exists for
-   the same node without enqueueing another task.
-3. Otherwise create a fresh `pending` row and `.delay()` the render task.
-
-### Cancelling / dismissing a render
-
-There are two flavours of "stop" for non-`ready` rows, both scoped to a
-single node and both requiring the same permission as `recompute`:
-
-- **`POST .../rf-propagation/cancel/`** — audit-preserving. Flips any
-  `pending`/`running` rows to `failed` with
-  `error_message="Cancelled by user"` and stamps `completed_at`. The
-  row stays in the database so operators can see _why_ a render was
-  aborted. `failed` rows are untouched (nothing to cancel).
-- **`POST .../rf-propagation/dismiss/`** — destructive. Deletes every
-  non-`ready` row for the node (`pending`, `running`, **and**
-  `failed`). Returns `{ "deleted": <count> }`. Use this from the UI
-  when the operator clicks "Cancel" (while in flight) or "Dismiss"
-  (on a failed row) — the end state is the same: the row is gone and
-  the next recompute starts from a clean slate.
-
-The worker is resilient to both: it performs three checks and treats
-"row gone" (`DoesNotExist`) and "row in terminal state" the same way
-— log and bail without writing:
-
-1. On task pickup — skip if the row is already terminal (cancel) or
-   missing (dismiss).
-2. Just before the engine call — avoids the expensive roundtrip.
-3. After the engine returns and the PNG is on disk — the worker
-   refuses to revive a cancelled/dismissed row. The PNG stays on disk
-   (it is content-addressed, so retention will reap it if nothing
-   else references the hash).
-
-There is no way to interrupt a running `/predict` call on the engine
-side, so a cancel/dismiss during engine polling will still let the
-current engine request finish; the worker just won't mark the row
-`ready`.
-
-Typical flows:
-
-- Render is stuck in `pending` (e.g. worker was down, engine URL was
-  misconfigured) → operator hits **dismiss** and then **recompute**.
-- Engine returns a permanent `422` for an unfixable profile → row
-  lands in `failed` → operator fixes the profile, clicks **dismiss**
-  on the error card, then **recompute**.
-
-### Bumping `render_version`
-
-Any time the render recipe changes (colormap, colour scale, default
-radius, radio climate, post-processing) bump
-`RF_PROPAGATION_RENDER_VERSION` so the next request per node produces a
-fresh cache entry instead of reusing a stale PNG. The old PNG files are
-cleaned up lazily by the retention rule below.
-
-## Retention
-
-On every successful render, the task keeps the **3 most recent** ready
-renders per node (configurable via `RF_PROPAGATION_READY_RETENTION`) and
-deletes any older ready rows plus their PNG files. `failed` rows older
-than 7 days are also pruned per node.
-
-## PNG overlay transparency
-
-After GeoTIFF→PNG, pixels within **`RF_PROPAGATION_NODATA_TOLERANCE`**
-of **`RF_PROPAGATION_NODATA_RGB`** (comma-separated `R,G,B`, default
-`0,0,0`) are written with alpha 0 so the Leaflet basemap shows through
-outside the tinted coverage.
-
-After that, **pixel aspect correction** adjusts the raster width/height so
-each pixel matches the relative east–west vs north–south metres implied by the
-bbox centre latitude (Leaflet stretches the PNG onto Web Mercator). This avoids
-coverage patterns looking vertically squashed when SPLAT emits equal pixels per
-degree on both axes.
-
-### Tuning (radius, palette, resolution)
-
-- **`RF_PROPAGATION_DEFAULT_RADIUS_M`** — hint for how far SPLAT!/SRTM tries to extend the scene (actual bounds still come from the GeoTIFF tags). Larger values cost more compute and disk.
-- **`RF_PROPAGATION_COLORMAP`** — matplotlib colormap name forwarded to Site Planner (`plasma` default; invalid names fall back with a WARN log).
-- **`RF_PROPAGATION_HIGH_RESOLUTION`** — toggles SPLAT!'s finer SRTM sampling (`true` ⇒ ~9× more pixels vs standard). Keep `false` unless you explicitly need sharper terrain.
-- **`RF_PROPAGATION_MIN_DBM`**, **`RF_PROPAGATION_MAX_DBM`**, **`RF_PROPAGATION_SIGNAL_THRESHOLD_DBM`** — SPLAT palette span and contour threshold.
-
-All tunables participate in ``compute_input_hash`` (via ``hash_extras_from_payload``) so operators get a fresh cache row when ops change defaults.
-
-## Environment variables
-
-| Variable | Default | Where used | Notes |
-| --- | --- | --- | --- |
-| `RF_PROPAGATION_ENGINE_URL` | _(empty)_ | worker | Internal URL of the engine, e.g. `http://rf-propagation:8080`. Required for real renders. |
-| `RF_PROPAGATION_ASSET_DIR` | `/var/meshflow/generated-assets/rf-propagation` | api + worker | Mounted from the `rf_assets` named volume; must be shared between `api` and `celery-rf-worker`. |
-| `RF_PROPAGATION_IMAGE_TAG` | `latest-dev` | compose | Tag for the engine image. |
-| `RF_PROPAGATION_RENDER_VERSION` | `4` | api + worker | Bump to invalidate all cached renders. |
-| `RF_PROPAGATION_NODATA_RGB` | `0,0,0` | api + worker | RGB colour treated as transparent background in the PNG overlay. |
-| `RF_PROPAGATION_NODATA_TOLERANCE` | `8` | api + worker | Per-channel distance from nodata RGB (0–255) to clear alpha. |
-| `RF_PROPAGATION_DEFAULT_RADIUS_M` | `50000` | api + worker | Hint passed to the engine; actual rendered bounds come from the GeoTIFF's georef tags. |
-| `RF_PROPAGATION_COLORMAP` | `plasma` | api + worker | Validated matplotlib name; forwarded to Site Planner. |
-| `RF_PROPAGATION_HIGH_RESOLUTION` | `false` | api + worker | Finer SRTM sampling (larger rasters). Boolean-ish (`1`/`true`/…). |
-| `RF_PROPAGATION_MIN_DBM` | `-130` | api + worker | Colour scale minimum (dBm). |
-| `RF_PROPAGATION_MAX_DBM` | `-50` | api + worker | Colour scale maximum (dBm). |
-| `RF_PROPAGATION_SIGNAL_THRESHOLD_DBM` | `-110` | api + worker | SPLAT signal threshold (dBm). |
-| `RF_PROPAGATION_POLL_MAX_SECONDS` | `300` | worker | Cap on cumulative polling before the render is marked failed. |
-| `RF_PROPAGATION_READY_RETENTION` | `3` | worker | Number of `ready` renders kept per node. |
+- A stuck `pending` render usually means the RF worker is not consuming the
+  queue or the engine URL is wrong.
+- A failed row exposes `error_message` and can be dismissed before retrying.
+- Force fresh output by bumping `RF_PROPAGATION_RENDER_VERSION` or changing RF
+  profile inputs.
+- `RF_PROPAGATION_READY_RETENTION` controls how many ready rows are kept per
+  node.
+- Update [docs/ENV_VARS.md](../../ENV_VARS.md) when adding or changing RF
+  propagation environment variables.
 
 ## Known limitations
 
-- **Directional antennas**: Site Planner's current model is omni-only.
-  The UI still collects azimuth/beamwidth so we can render directional
-  predictions once the engine supports them; for now we log a WARN and
-  render an omni coverage map. Azimuth/beamwidth are still folded into
-  the hash, so an operator toggling between omni and directional gets a
-  fresh cache entry.
-- **SRTM coverage**: The default engine image ships UK SRTM tiles.
-  Requests for nodes outside the shipped coverage fail with an
-  `engine task … reported status=failed` and are surfaced on the row's
-  `error_message`.
-- **Pillow first, tifffile fallback**: some non-baseline GeoTIFFs trip
-  Pillow. The converter falls back to `tifffile`; adding `rasterio`
-  later would only be necessary if we see unreadable variants in
-  production.
-- **Bounds come from the GeoTIFF**: the stored `bounds_*` fields are read
-  from `ModelTiepointTag` + `ModelPixelScaleTag` on the engine's GeoTIFF
-  so the Leaflet `imageOverlay` lines up with the actual rendered
-  extent. If both tags are missing we fall back to a `±radius/111320°`
-  bbox centred on the profile lat/lng and log a warning.
-
-## Operational runbook
-
-- **Stuck render?** Check the row: `status`, `error_message`, and
-  `completed_at`. A pending row with no matching celery log usually
-  means the queue is unconsumed — check `celery-rf-worker` logs.
-- **Force re-render**: bump `RF_PROPAGATION_RENDER_VERSION` or PATCH the
-  profile to invalidate the hash.
-- **Purge disk**: `RF_PROPAGATION_READY_RETENTION=0` will GC on the next
-  render; otherwise `ls $RF_PROPAGATION_ASSET_DIR` and remove by hand.
-- **Engine upgrade**: bump `RF_PROPAGATION_IMAGE_TAG` in the env file
-  and redeploy only the `rf-propagation`/`site-planner` service.
+- Directional antennas are captured in Meshflow but Site Planner currently
+  renders omni coverage only.
+- The default engine image ships UK SRTM tiles; renders outside coverage may
+  fail.
+- Current display uses a PNG plus bounds rather than rendering the original
+  GeoTIFF directly.
+- Private-coordinate renders need a stricter public response contract before
+  exact georeferencing can be treated as safe for broad access.

--- a/docs/features/rf_propagation/geo-rendering.md
+++ b/docs/features/rf_propagation/geo-rendering.md
@@ -1,0 +1,143 @@
+# RF propagation geospatial display
+
+This document explains how RF propagation render output is positioned on a
+geographic map. It includes the geospatial parts of image generation because
+the display can only be correct if the rendered raster and exposed bounds use
+the same coordinate model.
+
+For queueing details, see [pipeline.md](pipeline.md). For image conversion and
+storage, see [rendering.md](rendering.md). For private-coordinate risk, see
+[privacy.md](privacy.md).
+
+## Current display contract
+
+The API exposes a ready render as:
+
+```json
+{
+  "status": "ready",
+  "input_hash": "...",
+  "asset_url": "https://.../{hash}.png",
+  "bounds": {
+    "west": -4.5,
+    "south": 55.0,
+    "east": -4.0,
+    "north": 55.5
+  },
+  "created_at": "...",
+  "completed_at": "..."
+}
+```
+
+The frontend treats `asset_url` as a plain image and `bounds` as the WGS84
+extent of that image.
+
+In `meshtastic-bot-ui`,
+`src/components/nodes/RfPropagationMap.tsx` converts API order
+`west/south/east/north` into Leaflet image overlay order:
+
+```text
+[[south, west], [north, east]]
+```
+
+It then calls:
+
+```text
+L.imageOverlay(assetUrl, [[south, west], [north, east]])
+```
+
+## Geospatial source of truth
+
+The source of truth for display bounds should be the rendered raster's own
+georeferencing, not the requested radius.
+
+The pipeline is:
+
+```mermaid
+flowchart TD
+  profile["NodeRfProfile true RF coords"] --> payload["Site Planner payload"]
+  payload --> splat["SPLAT render"]
+  splat --> ppm["output.ppm coverage image"]
+  splat --> kml["output.kml LatLonBox"]
+  ppm --> geotiff["GeoTIFF EPSG 4326"]
+  kml --> geotiff
+  geotiff --> tags["ModelTiepointTag and ModelPixelScaleTag"]
+  tags --> bounds["API bounds west south east north"]
+  geotiff --> png["Meshflow PNG asset"]
+  png --> leaflet["Leaflet imageOverlay"]
+  bounds --> leaflet
+```
+
+Site Planner derives the GeoTIFF extent from SPLAT's KML `LatLonBox`. Meshflow
+then extracts bounds from the GeoTIFF tags and stores them on
+`NodeRfPropagationRender`.
+
+This matters because SPLAT/Site Planner may render an extent that differs from
+the naive request radius. The request radius is a hint for the engine; it is not
+the display contract.
+
+## Coordinate systems in play
+
+- Site Planner emits a GeoTIFF in `EPSG:4326`.
+- Meshflow stores bounds as WGS84 longitude/latitude degrees.
+- Leaflet's default map display is Web Mercator (`EPSG:3857`).
+- `L.imageOverlay` accepts lat/lng corner bounds, then Leaflet projects those
+  corners into its map CRS and stretches the image between them.
+
+That means a PNG overlay is not the same thing as rendering the GeoTIFF as a
+geospatial raster. Once Meshflow converts the GeoTIFF into a plain PNG, the
+frontend no longer has the original raster transform, CRS, pixel scale, nodata
+value, or colormap metadata. It only has the image pixels and outer bounds.
+
+## Current API-side geometry changes
+
+Before writing the PNG, Meshflow currently applies pixel aspect correction in
+`rf_propagation.image._maybe_resample_pixel_aspect_for_web_mercator()`.
+
+The correction compares:
+
+- source image aspect ratio, `width / height`
+- approximate ground-distance aspect ratio,
+  `(lng_span * cos(center_lat)) / lat_span`
+
+If they differ by more than two percent, the converter resizes the bitmap.
+The stored API bounds are still the GeoTIFF-derived bounds.
+
+This is a critical detail for alignment work: resizing a georeferenced raster
+as a plain bitmap can change where internal terrain features fall within the
+same outer bounds. Any alignment investigation should compare:
+
+1. The raw engine GeoTIFF.
+2. The PNG with aspect correction enabled.
+3. The PNG with aspect correction disabled.
+4. A frontend that renders the GeoTIFF directly with a geospatial raster layer.
+
+## Frontend fitting vs overlay placement
+
+`RfPropagationMap.tsx` has two separate responsibilities:
+
+- Place the image with `L.imageOverlay(assetUrl, bounds)`.
+- Fit the map viewport so the user can see a useful area.
+
+The viewport fitting code may cap the viewed diameter for large render bounds.
+That changes what part of the overlay is visible initially, but it should not
+change overlay placement. Alignment bugs should therefore focus first on the
+asset pixels and bounds, not on `fitBoundsForPropagation()`.
+
+## Recommended investigation path
+
+When debugging misalignment, start from the most geospatially complete artifact
+and move outward:
+
+1. Inspect the raw Site Planner GeoTIFF: CRS, transform, bounds, dimensions,
+   nodata, and visual alignment in a geospatial viewer.
+2. Compare GeoTIFF bounds with the API's stored `bounds_*` values.
+3. Compare the raw GeoTIFF dimensions with the served PNG dimensions.
+4. Disable API pixel aspect correction in a local probe and compare alignment.
+5. Compare `L.imageOverlay` with direct GeoTIFF rendering, such as
+   `georaster-layer-for-leaflet`.
+
+If the GeoTIFF aligns but the PNG overlay does not, the likely fault is in the
+API conversion or frontend display strategy. If the GeoTIFF is already offset,
+the fault is earlier in Site Planner's SPLAT output, KML `LatLonBox`, or terrain
+tile conversion.

--- a/docs/features/rf_propagation/pipeline.md
+++ b/docs/features/rf_propagation/pipeline.md
@@ -1,0 +1,135 @@
+# RF propagation queue pipeline
+
+This document covers the pipeline from a user requesting an RF propagation
+render up to the point where Meshflow sends a prediction request to the
+Meshtastic Site Planner engine. For image conversion and display details, see
+[rendering.md](rendering.md) and [geo-rendering.md](geo-rendering.md).
+
+## Components
+
+```mermaid
+flowchart TD
+  ui["meshtastic-bot-ui"] -->|"POST recompute"| api["api Django"]
+  api --> profile["NodeRfProfile"]
+  api --> render["NodeRfPropagationRender"]
+  api -->|"delay render_id"| celeryBroker["Redis DB 1 Celery broker"]
+  worker["celery-rf-worker"] -->|"BRPOP task"| celeryBroker
+  worker -->|"POST predict"| engine["rf-propagation Site Planner image"]
+```
+
+- `meshtastic-bot-ui` calls the observed-node RF propagation endpoints.
+- `api` owns validation, permissions, render rows, hashing, and enqueueing.
+- `Redis DB 1` is the Celery broker. It is separate from Channels, Django
+  cache, and the Site Planner engine's own Redis task state.
+- `celery-rf-worker` consumes the dedicated RF render task and performs the
+  blocking engine roundtrip.
+- `rf-propagation` is the Docker image published from
+  `ghcr.io/pskillen/meshflow-rf-propagation`. It wraps the upstream
+  Meshtastic Site Planner FastAPI service and SPLAT!.
+
+## Request entry point
+
+The UI starts or reuses a render with:
+
+```text
+POST /api/nodes/observed-nodes/{node_id}/rf-propagation/recompute/
+```
+
+The Django action is `nodes.views.ObservedNodeViewSet.rf_propagation_recompute`.
+It requires the same permission as editing the node RF profile: staff or the
+user who has claimed the observed node.
+
+The action loads `node.rf_profile`. If the profile is missing required fields
+for rendering, the API returns `400` before creating or enqueueing any render.
+
+## Payload and hash preparation
+
+The API builds the engine payload with `rf_propagation.payload.build_request`.
+The payload contains the true RF profile coordinates and radio settings needed
+by Site Planner:
+
+- `lat`, `lon`
+- `tx_height`, `tx_gain`, `tx_power`
+- `frequency_mhz`
+- `rx_height`, `rx_gain`
+- `signal_threshold`
+- `radio_climate`
+- `colormap`
+- `radius`
+- `min_dbm`, `max_dbm`
+- `high_resolution`
+
+Directional antenna fields are stored in Meshflow and included in the cache
+hash, but the current Site Planner engine renders omni coverage only.
+
+`rf_propagation.hashing.compute_input_hash` is computed before enqueueing so
+the API and worker agree on cache identity. The hash includes normalized RF
+profile values, `RF_PROPAGATION_RENDER_VERSION`, and render tunables from
+`hash_extras_from_payload`.
+
+## Deduplication before enqueue
+
+`rf_propagation_recompute` avoids unnecessary work in this order:
+
+1. If a `ready` render with the same `input_hash` has an asset still present
+   on disk, return it. If it belongs to another node with an identical RF
+   profile, create a new ready row pointing at the shared content-addressed
+   asset.
+2. If this node already has a `pending` or `running` row, return that row.
+3. Otherwise create a fresh `pending` `NodeRfPropagationRender` row and enqueue
+   `render_rf_propagation.delay(row.pk)`.
+
+The response is a serialized render row. New pending rows return `201`; reused
+in-flight rows return `200`.
+
+## Celery task pickup
+
+The queued task is `nodes.tasks.render_rf_propagation`, implemented by
+`rf_propagation.tasks.render_rf_propagation`.
+
+On pickup, the worker:
+
+1. Loads the `NodeRfPropagationRender` by id.
+2. Skips immediately if the row has vanished or is already terminal.
+3. Loads the related `ObservedNode` and `NodeRfProfile`.
+4. Rebuilds the Site Planner payload and input hash.
+5. Checks again for a ready cache hit with the same hash.
+6. Refreshes the row before the engine call so a cancel or dismiss can stop
+   work before the expensive roundtrip.
+
+Only after those checks does the worker mark the row `running`.
+
+## Passing work to Site Planner
+
+The worker reads `RF_PROPAGATION_ENGINE_URL` and creates a
+`SitePlannerClient`. In local Docker Compose the service is normally
+`http://rf-propagation:8080`; in some Portainer deployments it is named
+`site-planner`.
+
+The first engine call is:
+
+```text
+POST /predict
+```
+
+The request body is the payload built from `NodeRfProfile` and environment
+settings. At that point the Meshflow queue pipeline is complete: Site Planner
+has accepted the prediction instruction and returns an engine task id.
+
+The worker then polls `/status/{task_id}` and fetches `/result/{task_id}`.
+Those steps are covered in [rendering.md](rendering.md), because they are part
+of image generation rather than queue admission.
+
+## Cancel and dismiss behavior
+
+Meshflow cannot interrupt a Site Planner `/predict` request once it is running.
+Instead, cancel and dismiss are implemented around the `NodeRfPropagationRender`
+row:
+
+- `cancel` marks `pending` or `running` rows as `failed`.
+- `dismiss` deletes non-ready rows.
+- The worker checks for terminal or missing rows on pickup, before the engine
+  call, and after the engine returns.
+
+If a row is cancelled or dismissed while the engine is already running, the
+engine request may still complete, but the worker refuses to revive the row.

--- a/docs/features/rf_propagation/privacy.md
+++ b/docs/features/rf_propagation/privacy.md
@@ -1,0 +1,178 @@
+# RF propagation privacy
+
+RF propagation coverage maps are intended to be publicly available. Node owners
+may provide private, true radio coordinates so Meshflow can render a more
+accurate public coverage map than it could from coarse or redacted Meshtastic
+position data.
+
+The privacy requirement is to use private coordinates as an internal render
+input without exposing those coordinates, or enough derived metadata to infer
+them, through the public map.
+
+The open implementation issue is
+[meshflow-api#245](https://github.com/pskillen/meshflow-api/issues/245).
+
+## Current model
+
+`NodeRfProfile` stores RF-specific transmitter data:
+
+- `rf_latitude`
+- `rf_longitude`
+- `rf_altitude_m`
+- antenna height, gain, pattern, azimuth, and beamwidth
+- transmit power and frequency
+
+The profile serializer hides `rf_latitude`, `rf_longitude`, and
+`rf_altitude_m` unless the requester can edit the RF profile. Today that means
+staff or the user who has claimed the observed node.
+
+Render generation uses the true coordinates. The worker sends them to the Site
+Planner engine as `lat` and `lon`, receives a georeferenced GeoTIFF, converts
+it to a PNG, stores bounds on `NodeRfPropagationRender`, and returns those
+bounds to the frontend for public display.
+
+## What may leak today
+
+Even when private profile fields are hidden, a ready render can reveal
+coordinate-derived information through other surfaces:
+
+- Exact `bounds` in the public RF propagation response.
+- Visible RF patterns that can imply a transmitter origin.
+- A public immutable asset URL containing the content hash filename.
+- Repeated renders with slightly different inputs, which may allow comparison.
+- Logs, task payloads, cache rows, or debugging artifacts that include exact
+  coordinates.
+
+The PNG being low resolution is not a complete privacy control. Low resolution
+reduces visual precision, but exact georeferencing can still make the public
+overlay more revealing than intended.
+
+## Public response surface
+
+The current ready response includes:
+
+```json
+{
+  "status": "ready",
+  "input_hash": "...",
+  "asset_url": "https://.../{hash}.png",
+  "bounds": {
+    "west": -4.5,
+    "south": 55.0,
+    "east": -4.0,
+    "north": 55.5
+  }
+}
+```
+
+The asset endpoint is currently public:
+
+```text
+GET /api/nodes/observed-nodes/{node_id}/rf-propagation/asset/{filename}
+```
+
+The `node_id` path component is reserved for future validation. At present,
+the hash filename is the effective asset locator.
+
+## Privacy goals
+
+The feature should support accurate internal rendering and public map display
+without exposing private coordinates more precisely than the product intends.
+
+The public contract should define:
+
+- Who can set or update the private coordinate input.
+- Who can request recomputation of a public coverage map.
+- Whether public bounds are exact, rounded, padded, cropped, or omitted.
+- How much precision the public overlay is allowed to reveal.
+- Whether the rendered image itself needs origin masking, cropping, blurring,
+  or minimum resolution constraints.
+- Whether public filenames and response metadata can be correlated with exact
+  internal render inputs.
+
+## Candidate approaches
+
+### Rounded public bounds with adjusted raster
+
+Render internally with true coordinates, then expose display bounds snapped to a
+lower-precision grid. The image must be cropped, padded, or translated so the
+public image still lines up with the public bounds.
+
+This can support public display, but it needs careful tests. Rounding only the
+bounds without adjusting the raster will intentionally misalign the overlay.
+
+### Public derivative asset
+
+Keep the exact internal GeoTIFF/PNG as a worker-side intermediate, then generate
+a public asset with reduced precision. The public derivative could be lower
+resolution, cropped to rounded bounds, padded to a grid, and stripped of exact
+georeferencing metadata.
+
+This separates internal correctness from public presentation, but adds storage,
+retention, and cache-key complexity.
+
+### Public display after obfuscation only
+
+Until a precision-reducing derivative exists, do not expose exact render bounds
+or exact-coordinate-derived assets publicly. The public map should be generated
+only after the output has been transformed according to the documented privacy
+contract.
+
+This is conservative and avoids accidental leakage while preserving the intended
+product shape: public coverage maps.
+
+## Hash and cache considerations
+
+`input_hash` includes normalized private coordinate values. The hash is not
+reversible in the ordinary sense, but it can still be sensitive metadata:
+
+- It is stable for a given private coordinate and RF profile.
+- It is used as the public PNG filename.
+- It may allow correlation between nodes or repeated renders.
+- If an attacker can narrow the possible coordinate set enough, brute-force
+  comparisons may become more plausible.
+
+Future public contracts should avoid exposing `input_hash` unless clients need
+it. Public filenames should likely use a separate random token or public
+derivative hash rather than the internal input hash.
+
+## Logging and operations
+
+Private coordinates can also leak outside API responses. Avoid adding logs or
+debug artifacts that include:
+
+- raw Site Planner payloads
+- `rf_latitude` or `rf_longitude`
+- full GeoTIFF bounds for renders that used private coordinates
+- temporary filenames or exported samples tied to a render that used private
+  coordinates
+
+When reproducing bugs, prefer synthetic coordinates or owner-approved examples.
+If a production render must be inspected, store artifacts outside public issue
+threads and remove them when the investigation is complete.
+
+## Tests to add
+
+When the privacy contract is implemented, tests should cover:
+
+- RF profile coordinates remain hidden from unauthorized users.
+- Public RF propagation responses do not return exact private-coordinate-derived
+  bounds beyond the documented precision.
+- Public RF assets follow the chosen derivative-asset rules.
+- Public display bounds are rounded or transformed according to the documented
+  contract.
+- `input_hash` exposure matches the documented public response contract.
+
+## Interaction with alignment fixes
+
+Alignment work and privacy work are connected. The display needs accurate
+georeferencing to line up with terrain, but exact public georeferencing can
+reveal private coordinates.
+
+Any fix that changes asset format, bounds, raster transforms, or frontend
+rendering should explicitly answer:
+
+1. Which artifact is the exact internal render intermediate?
+2. Which artifact is the public coverage map?
+3. Which bounds are exact, and which bounds are public display bounds?
+4. Which metadata is safe to expose with the public map?

--- a/docs/features/rf_propagation/rendering.md
+++ b/docs/features/rf_propagation/rendering.md
@@ -1,0 +1,167 @@
+# RF propagation image rendering
+
+This document explains how Meshflow turns a queued RF propagation render into
+a stored browser asset. For queue admission and worker dispatch, see
+[pipeline.md](pipeline.md). For how the final image is placed on a map, see
+[geo-rendering.md](geo-rendering.md). For private-coordinate risk, see
+[privacy.md](privacy.md).
+
+## Render inputs
+
+The worker builds a Site Planner `CoveragePredictionRequest` from
+`NodeRfProfile` plus RF propagation settings.
+
+Profile inputs:
+
+- `rf_latitude`, `rf_longitude`
+- `rf_altitude_m` or `antenna_height_m`
+- `antenna_gain_dbi`
+- `tx_power_dbm`
+- `rf_frequency_mhz`
+- `antenna_pattern`, `antenna_azimuth_deg`, `antenna_beamwidth_deg`
+
+Runtime settings:
+
+- `RF_PROPAGATION_DEFAULT_RADIUS_M`
+- `RF_PROPAGATION_COLORMAP`
+- `RF_PROPAGATION_HIGH_RESOLUTION`
+- `RF_PROPAGATION_MIN_DBM`
+- `RF_PROPAGATION_MAX_DBM`
+- `RF_PROPAGATION_SIGNAL_THRESHOLD_DBM`
+- `RF_PROPAGATION_RENDER_VERSION`
+
+The current Site Planner engine is omni-only. Meshflow still stores directional
+antenna choices and includes them in the input hash so future engine support
+will invalidate old renders correctly.
+
+## Engine roundtrip
+
+After the worker marks a render row `running`, it calls the Site Planner
+container:
+
+```mermaid
+sequenceDiagram
+  participant W as celery-rf-worker
+  participant E as rf-propagation
+  participant R as EngineRedis
+  participant S as SPLAT
+
+  W->>E: POST /predict
+  E->>R: task status processing
+  E->>S: run SPLAT with tx.qth, splat.lrp, splat.dcf
+  S-->>E: output.ppm and output.kml
+  E->>E: PPM + KML LatLonBox to GeoTIFF
+  E->>R: store GeoTIFF bytes and completed status
+  E-->>W: task_id
+  W->>E: GET /status/{task_id}
+  W->>E: GET /result/{task_id}
+  E-->>W: GeoTIFF bytes
+```
+
+The Site Planner image is built from the `meshflow-rf-propagation` repository,
+which pins an upstream `meshtastic-site-planner` revision and applies small
+Docker/runtime patches. Inside that engine, SPLAT produces a PPM coverage image
+and KML metadata. The engine converts those into a GeoTIFF using the KML
+`LatLonBox` as the raster bounds.
+
+## GeoTIFF decoding
+
+Meshflow receives GeoTIFF bytes from `/result/{task_id}` and decodes them in
+`rf_propagation.image.geotiff_to_render_image`.
+
+The decoder tries:
+
+1. Pillow for baseline TIFFs.
+2. `tifffile` as a fallback for variants Pillow cannot decode.
+
+The output is a `RenderImage` containing:
+
+- `png_bytes`: browser-ready RGBA PNG bytes.
+- `bounds`: the WGS84 bounding box recovered from GeoTIFF georeferencing tags,
+  when available.
+
+## Bounds extraction
+
+Meshflow reads the GeoTIFF `ModelTiepointTag` and `ModelPixelScaleTag`.
+For the normal north-up case, these tags identify the raster's north-west
+origin and per-pixel degree scale.
+
+The computed bounds are:
+
+- `west = tiepoint_x - tiepoint_i * scale_x`
+- `north = tiepoint_y + tiepoint_j * scale_y`
+- `east = west + width * scale_x`
+- `south = north - height * scale_y`
+
+The worker stores those values as:
+
+- `bounds_west`
+- `bounds_south`
+- `bounds_east`
+- `bounds_north`
+
+If GeoTIFF tags are missing or invalid, the worker falls back to a coarse
+`bbox_from_center(profile.rf_latitude, profile.rf_longitude, radius)` estimate.
+That fallback should be treated as degraded output because Site Planner may
+snap the rendered extent to terrain tile or SPLAT output boundaries.
+
+## PNG conversion
+
+After decoding, the image is converted to RGBA PNG.
+
+Pixels close to the configured nodata color are made transparent:
+
+- `RF_PROPAGATION_NODATA_RGB` defaults to `0,0,0`.
+- `RF_PROPAGATION_NODATA_TOLERANCE` defaults to `8`.
+
+The intent is to let the Leaflet basemap show through where SPLAT produced
+background/no-coverage pixels.
+
+The current converter also performs pixel aspect correction in
+`_maybe_resample_pixel_aspect_for_web_mercator()`. It resizes the PNG so its
+pixel aspect approximates east-west vs north-south metres at the bounding-box
+centre latitude. This was added because Leaflet stretches the PNG over a Web
+Mercator map. It is important for alignment investigations because it changes
+the raster dimensions after the GeoTIFF georeferencing has been read.
+
+## Storage
+
+The worker writes the PNG to `RF_PROPAGATION_ASSET_DIR`, which must be mounted
+into both the API and RF worker containers.
+
+The filename is content-addressed:
+
+```text
+{input_hash}.png
+```
+
+The `NodeRfPropagationRender` row stores:
+
+- `status = ready`
+- `input_hash`
+- `asset_filename`
+- `bounds_*`
+- `completed_at`
+- empty `error_message`
+
+The API serves the file through:
+
+```text
+GET /api/nodes/observed-nodes/{node_id}/rf-propagation/asset/{filename}
+```
+
+The current asset response is public, cacheable for one year, and immutable.
+The `node_id` path component is reserved for future validation; today the hash
+filename is the only asset locator.
+
+## Retention and reuse
+
+Successful renders share assets by `input_hash`. Two nodes with identical RF
+profiles and render settings can point at the same PNG.
+
+After a successful render, retention keeps the newest
+`RF_PROPAGATION_READY_RETENTION` ready rows per node and deletes older rows and
+their unreferenced PNG files. Failed rows older than seven days are pruned.
+
+Changing render inputs or output behavior should bump
+`RF_PROPAGATION_RENDER_VERSION` so stale PNG assets are not reused.

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -15,7 +15,7 @@ The traceroute feature tracks path discovery between Meshtastic nodes on the mes
 `AutoTraceRoute.trigger_type` is stored as a **stable integer**. The REST API returns `trigger_type` (int) and `trigger_type_label` (human-readable). List filters accept comma-separated **integers** and **legacy slugs** (`auto` → Monitoring, `monitor` → Node Watch, `new_node_baseline` → New node baseline) for backwards-compatible URLs.
 
 | Value | Name | Meaning |
-|------:|------|---------|
+| ---: | --- | --- |
 | 1 | User | Manual trigger from the UI/API (`triggered_by` set). |
 | 2 | External | Response matched no local row (e.g. cross-environment ingest). |
 | 3 | Monitoring | Periodic scheduler (`trigger_source` e.g. `scheduler`); replaces historical string `auto`. |
@@ -28,7 +28,7 @@ The traceroute feature tracks path discovery between Meshtastic nodes on the mes
 ## Data Model
 
 | Field | Description |
-|-------|-------------|
+| --- | --- |
 | `source_node` | ManagedNode that sends the traceroute |
 | `target_node` | ObservedNode (destination) |
 | `trigger_type` | Integer; see table above |
@@ -42,7 +42,7 @@ The traceroute feature tracks path discovery between Meshtastic nodes on the mes
 ## API Endpoints
 
 | Endpoint | Method | Description |
-|----------|--------|-------------|
+| --- | --- | --- |
 | `/api/traceroutes/` | GET | List traceroutes (filter by managed_node, target_node, status, triggered_after, etc.) |
 | `/api/traceroutes/<pk>/` | GET | Single traceroute detail |
 | `/api/traceroutes/trigger/` | POST | Manual trigger (requires `managed_node_id`, optional `target_node_id`; user must be staff, owner of source node, or constellation admin/editor) |
@@ -55,7 +55,7 @@ The traceroute feature tracks path discovery between Meshtastic nodes on the mes
 ## Permissions
 
 | Role | Can trigger from |
-|------|------------------|
+| --- | --- |
 | System admin (`is_staff`) | Any ManagedNode with `allow_auto_traceroute=True` |
 | Constellation admin/editor | Nodes in constellations where user has admin/editor role |
 | ManagedNode owner | Nodes they own (`ManagedNode.owner == user`) |
@@ -79,6 +79,7 @@ Auto-scheduler and permission checks share one notion of a **live** source node 
 
 ## Related Documentation
 
+- [Areas of concern](areas-of-concern.md) – Ownership boundaries for core traceroute, monitoring, DX, analytics, and visualisation
 - [Algorithms](algorithms.md) – Source, strategy, and target selection (including auto reliability)
 - [Permissions](permissions.md) – Canonical rules for who may view and trigger traceroutes
 - [Flow](flow.md) – End-to-end lifecycle from trigger to completion

--- a/docs/features/traceroute/areas-of-concern.md
+++ b/docs/features/traceroute/areas-of-concern.md
@@ -1,0 +1,73 @@
+# Traceroute Areas of Concern
+
+This note records the intended ownership boundaries for traceroute-related
+behaviour. It exists because traceroute is both a mission-critical operational
+primitive and the data source for richer analytics and visualisation features.
+
+The short version:
+
+- `traceroute` owns the durable traceroute lifecycle.
+- Operational apps such as `mesh_monitoring` and `dx_monitoring` own their own
+product decisions, but request traceroutes through the core traceroute
+boundary.
+- Analytics and visualisation should move out of the core app so graph, map,
+and reporting work can evolve without increasing risk to ingestion,
+dispatch, monitoring, or DX workflows.
+
+## Functional Areas
+
+
+| Functional area                        | Final app / owner                               | Rationale                                                                                                                                                                                                                                     |
+| -------------------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core traceroute domain                 | `traceroute`                                    | `AutoTraceRoute`, `TriggerType`, status transitions, route payloads, dispatch metadata, and model constraints are the shared operational substrate. Moving the model would add migration churn without improving the boundary.                |
+| Manual traceroute API                  | `traceroute`                                    | Manual trigger, list, detail, `can_trigger`, and triggerable-node endpoints are direct operations on `AutoTraceRoute` and its permission model.                                                                                               |
+| Traceroute scheduling                  | `traceroute`                                    | Periodic mesh exploration is a generic traceroute producer. It should use the same source eligibility, target selection, strategy rotation, pending caps, and dispatch queue as other producers.                                              |
+| Dispatch queue and stale timeout       | `traceroute`                                    | Pending/sent/completed/failed lifecycle, per-source pacing, retry state, timeout handling, and WebSocket status notifications are core lifecycle concerns used by all producers.                                                              |
+| Packet completion integration          | `packets` + `traceroute`                        | `packets` owns packet parsing and ingestion. `traceroute` should own matching/finalising `AutoTraceRoute` rows and emitting lifecycle side effects through a stable service boundary.                                                         |
+| New-node baseline traceroutes          | `traceroute`                                    | A first-seen node baseline is a generic operational traceroute, not a user watch and not analytics. It establishes route evidence once per target and is reused by DX exploration dedupe logic, so it belongs with the core lifecycle.        |
+| Mesh watch and node monitoring         | `mesh_monitoring`                               | Watches, presence state, offline verification, watcher notifications, and monitoring-specific source selection are product concerns of mesh monitoring. The app should request `NODE_WATCH` traceroutes through the core traceroute boundary. |
+| DX monitoring and exploration          | `dx_monitoring`                                 | DX event detection, exploration planning, skip reasons, event linking, and DX notifications are product concerns of DX monitoring. The app should request `DX_WATCH` traceroutes through the core traceroute boundary.                        |
+| Source liveness / eligibility snapshot | `nodes` with `traceroute` compatibility exports | Managed-node liveness is fundamentally node state derived from ingestion. `traceroute.source_eligibility` may continue to re-export the canonical node helpers for compatibility.                                                             |
+| Target selection and strategy rotation | `traceroute`                                    | These decide what generic automatic traceroute to run next. They are operational scheduling concerns, even when their output later feeds analytics.                                                                                           |
+| Traceroute analytics                   | `traceroute_analytics`                          | Stats, success/failure breakdowns, top routers, by-source/by-target summaries, success-over-time, and daily `StatsSnapshot` collection are derived reporting products over `AutoTraceRoute`. They should not live in the core lifecycle app.  |
+| Reach and coverage analytics           | `traceroute_analytics`                          | Feeder reach and constellation coverage are visualisation/reporting pivots over completed/failed traceroutes. They are useful, but not required for dispatch, completion, monitoring, or DX event handling.                                   |
+| Neo4j graph export and queries         | `traceroute_analytics`                          | Neo4j is the graph/visualisation backend for heatmaps and node-link exploration. Export/query code should be decoupled from core traceroute lifecycle code.                                                                                   |
+| Heatmap and topology API payloads      | `traceroute_analytics`                          | Heatmap and topology payloads are presentation-oriented analytics APIs. Public URLs can remain under `/api/traceroutes/` for compatibility, but implementation should live outside core traceroute.                                           |
+| Observed-node traceroute links         | `nodes` route backed by `traceroute_analytics`  | The route belongs in the node-detail API surface, but the graph query implementation is traceroute analytics.                                                                                                                                 |
+| WebSocket status notifications         | `traceroute`                                    | Status notifications are lifecycle events for manual, scheduled, monitoring, DX, baseline, and external traceroutes. They must not depend on analytics.                                                                                       |
+| OpenAPI contract                       | API surface, currently `openapi.yaml`           | Public endpoint compatibility matters more than internal module layout. The refactor should preserve paths unless a separate migration plan deliberately changes them.                                                                        |
+
+
+## Dependency Rules
+
+The desired direction is a one-way dependency flow:
+
+```text
+packets / mesh_monitoring / dx_monitoring
+        -> traceroute core service boundary
+        -> optional lifecycle hooks
+        -> traceroute_analytics
+```
+
+Core `traceroute` code should not import analytics modules for normal dispatch
+or completion. If analytics needs to react to a completed traceroute, use an
+explicit hook, task, or signal-like boundary so a Neo4j/reporting failure cannot
+block mission-critical lifecycle work.
+
+Operational apps may still query `AutoTraceRoute` where that is their domain
+state, but new code should prefer core service helpers for creating,
+completing, failing, or notifying traceroutes. That keeps producer-specific
+policy in the producer app while preserving one lifecycle implementation.
+
+## Refactor Notes
+
+When splitting the code:
+
+- Keep the `AutoTraceRoute` model and migrations in `traceroute`.
+- Keep public API paths stable during the first refactor pass.
+- Add compatibility wrappers for Celery task names if existing beat rows or
+queued jobs reference old `traceroute.tasks.*` names.
+- Move analytics implementation first, then clean up compatibility wrappers
+only after deployed task/API compatibility is understood.
+- Update this document when a functional area deliberately changes owner.
+


### PR DESCRIPTION
# Summary

Documents two backend architecture areas for reviewers and future maintainers:

- Adds complete RF propagation map feature documentation covering generated assets, refresh behaviour, alignment constraints, and operational notes.
- Adds traceroute areas-of-concern documentation that records ownership boundaries between core traceroute, mesh monitoring, DX monitoring, analytics, and visualisation.

No breaking changes or manual deployment steps; this is documentation-only.

## Testing performed

- Docs-only change.
- Checked the branch is clean and contains the two docs commits intended for this PR.
- Ran editor diagnostics for the edited traceroute docs and resolved markdownlint warnings there.