### PR TITLE
refactor(traceroute): core lifecycle boundary (#247)

### DIFF
--- a/Meshflow/dx_monitoring/exploration.py
+++ b/Meshflow/dx_monitoring/exploration.py
@@ -26,9 +26,9 @@ from nodes.managed_node_liveness import (
 )
 from nodes.models import ManagedNode
 from traceroute.dispatch import TRACEROUTE_MAX_PENDING_PER_SOURCE, pending_count_for_source
+from traceroute.lifecycle import create_pending_auto_traceroute
 from traceroute.models import AutoTraceRoute
 from traceroute.source_selection import eligible_traceroute_sources_ordered
-from traceroute.ws_notify import notify_traceroute_status_changed
 
 if TYPE_CHECKING:
     pass
@@ -348,17 +348,15 @@ def plan_event_exploration(event: DxEvent) -> dict:
                 continue
 
             at_now = timezone.now()
-            auto_tr = AutoTraceRoute.objects.create(
+            auto_tr = create_pending_auto_traceroute(
                 source_node=source,
                 target_node=dest,
                 trigger_type=AutoTraceRoute.TRIGGER_TYPE_DX_WATCH,
                 triggered_by=None,
                 trigger_source=TRIGGER_SOURCE,
                 target_strategy=None,
-                status=AutoTraceRoute.STATUS_PENDING,
                 earliest_send_at=at_now,
             )
-            notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_PENDING)
             DxEventTraceroute.objects.create(
                 event=event,
                 auto_traceroute=auto_tr,

--- a/Meshflow/dx_monitoring/tests/test_exploration.py
+++ b/Meshflow/dx_monitoring/tests/test_exploration.py
@@ -216,7 +216,7 @@ def test_plan_queues_dx_watch_with_expected_fields(
         destination=dest,
         last_observer=source,
     )
-    with patch("dx_monitoring.exploration.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         plan_event_exploration(ev)
 
     tr = AutoTraceRoute.objects.get(
@@ -387,7 +387,7 @@ def test_active_events_not_due_immediately_after_plan_attempt(
 
     assert active_events_due_for_exploration().filter(pk=ev.pk).exists()
 
-    with patch("dx_monitoring.exploration.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         plan_event_exploration(ev)
 
     assert not active_events_due_for_exploration().filter(pk=ev.pk).exists()

--- a/Meshflow/mesh_monitoring/tasks.py
+++ b/Meshflow/mesh_monitoring/tasks.py
@@ -9,8 +9,8 @@ from celery import shared_task
 
 from nodes.models import ObservedNode
 from traceroute.dispatch import TRACEROUTE_MAX_PENDING_PER_SOURCE, pending_count_for_source
+from traceroute.lifecycle import create_pending_auto_traceroute
 from traceroute.models import AutoTraceRoute
-from traceroute.ws_notify import notify_traceroute_status_changed
 
 from .constants import (
     DEFAULT_OFFLINE_AFTER_SECONDS,
@@ -58,16 +58,14 @@ def _dispatch_monitoring_round(observed: ObservedNode) -> None:
                 TRACEROUTE_MAX_PENDING_PER_SOURCE,
             )
             continue
-        tr = AutoTraceRoute.objects.create(
+        create_pending_auto_traceroute(
             source_node=source,
             target_node=observed,
             trigger_type=AutoTraceRoute.TRIGGER_TYPE_NODE_WATCH,
             triggered_by=None,
             trigger_source="mesh_monitoring",
-            status=AutoTraceRoute.STATUS_PENDING,
             earliest_send_at=at,
         )
-        notify_traceroute_status_changed(tr.id, AutoTraceRoute.STATUS_PENDING)
 
 
 @shared_task

--- a/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_verification_started.py
@@ -75,7 +75,7 @@ def test_verification_start_notify_happy_path(
     with override_settings(FRONTEND_URL="https://mesh.example"):
         with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
             with patch("push_notifications.discord_audit.send_dm") as send_dm:
-                with patch("mesh_monitoring.tasks.notify_traceroute_status_changed"):
+                with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
                     with patch("traceroute.dispatch.notify_traceroute_status_changed"):
                         with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                             with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):
@@ -122,7 +122,7 @@ def test_verification_start_notify_skipped_when_flag_off(
 
     with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
         with patch("push_notifications.discord_audit.send_dm") as send_dm:
-            with patch("mesh_monitoring.tasks.notify_traceroute_status_changed"):
+            with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
                 with patch("traceroute.dispatch.notify_traceroute_status_changed"):
                     with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                         with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):
@@ -167,7 +167,7 @@ def test_verification_start_notify_respects_cooldown(
 
     with patch("mesh_monitoring.services.user_has_verified_discord_dm_target", return_value=True):
         with patch("push_notifications.discord_audit.send_dm") as send_dm:
-            with patch("mesh_monitoring.tasks.notify_traceroute_status_changed"):
+            with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
                 with patch("traceroute.dispatch.notify_traceroute_status_changed"):
                     with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                         with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):

--- a/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
+++ b/Meshflow/mesh_monitoring/tests/test_process_node_watch_presence.py
@@ -50,7 +50,7 @@ def test_process_node_watch_presence_starts_verification_and_creates_monitor_tr(
     def immediate_async_to_sync(async_func):
         return async_func
 
-    with patch("mesh_monitoring.tasks.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         with patch("traceroute.dispatch.notify_traceroute_status_changed"):
             with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                 with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):

--- a/Meshflow/packets/services/traceroute.py
+++ b/Meshflow/packets/services/traceroute.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 
 from packets.models import TraceroutePacket
 from packets.services.base import BasePacketService
+from traceroute.lifecycle import apply_auto_traceroute_completion, schedule_completed_traceroute_neo4j_export
 from traceroute.models import AutoTraceRoute
 
 logger = logging.getLogger(__name__)
@@ -68,14 +69,11 @@ class TraceroutePacketService(BasePacketService):
             snr = self.packet.snr_back[i] if i < len(self.packet.snr_back) else None
             route_back.append({"node_id": nid, "snr": snr})
 
-        auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
-        auto_tr.route = route
-        auto_tr.route_back = route_back
-        auto_tr.raw_packet = self.packet
-        auto_tr.completed_at = timezone.now()
-        auto_tr.error_message = None
-        auto_tr.save(
-            update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
+        apply_auto_traceroute_completion(
+            auto_tr,
+            route=route,
+            route_back=route_back,
+            raw_packet=self.packet,
         )
 
         from dx_monitoring.exploration import on_auto_traceroute_exploration_finished
@@ -84,12 +82,11 @@ class TraceroutePacketService(BasePacketService):
         maybe_detect_dx_from_completed_traceroute(auto_tr, self.packet, self.observation)
         on_auto_traceroute_exploration_finished(auto_tr)
 
-        # Lazy imports so tests can patch traceroute.tasks / traceroute.ws_notify / mesh_monitoring.services.
+        # Lazy imports so tests can patch traceroute.ws_notify / mesh_monitoring.services / lifecycle Neo4j hook.
         from mesh_monitoring.services import on_monitoring_traceroute_completed
-        from traceroute.tasks import push_traceroute_to_neo4j
         from traceroute.ws_notify import notify_traceroute_status_changed
 
         on_monitoring_traceroute_completed(auto_tr)
         notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
-        push_traceroute_to_neo4j.delay(auto_tr.id)
+        schedule_completed_traceroute_neo4j_export(auto_tr.id)
         logger.info("Linked TraceroutePacket %s to AutoTraceRoute %s", self.packet.id, auto_tr.id)

--- a/Meshflow/traceroute/lifecycle.py
+++ b/Meshflow/traceroute/lifecycle.py
@@ -1,0 +1,73 @@
+"""Core traceroute queueing and completion helpers (meshflow-api#247 boundary)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django.utils import timezone
+
+from traceroute.models import AutoTraceRoute
+from traceroute.ws_notify import notify_traceroute_status_changed
+
+if TYPE_CHECKING:
+    from nodes.models import ManagedNode, ObservedNode
+    from packets.models import TraceroutePacket
+
+
+def create_pending_auto_traceroute(
+    *,
+    source_node: ManagedNode,
+    target_node: ObservedNode,
+    trigger_type: int,
+    trigger_source: str | None,
+    triggered_by: Any = None,
+    target_strategy: str | None = None,
+    earliest_send_at=None,
+    notify_pending: bool = True,
+) -> AutoTraceRoute:
+    """
+    Create a queued ``AutoTraceRoute`` with shared defaults (status ``pending``).
+
+    Callers keep dedupe, caps, and source selection. Optionally emits the pending WebSocket notification.
+    """
+    if earliest_send_at is None:
+        earliest_send_at = timezone.now()
+    auto_tr = AutoTraceRoute.objects.create(
+        source_node=source_node,
+        target_node=target_node,
+        trigger_type=trigger_type,
+        triggered_by=triggered_by,
+        trigger_source=trigger_source,
+        target_strategy=target_strategy,
+        status=AutoTraceRoute.STATUS_PENDING,
+        earliest_send_at=earliest_send_at,
+    )
+    if notify_pending:
+        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_PENDING)
+    return auto_tr
+
+
+def apply_auto_traceroute_completion(
+    auto_tr: AutoTraceRoute,
+    *,
+    route: list | None,
+    route_back: list | None,
+    raw_packet: TraceroutePacket | None,
+) -> None:
+    """Persist terminal success fields for a traceroute response (no product callbacks)."""
+    auto_tr.status = AutoTraceRoute.STATUS_COMPLETED
+    auto_tr.route = route
+    auto_tr.route_back = route_back
+    auto_tr.raw_packet = raw_packet
+    auto_tr.completed_at = timezone.now()
+    auto_tr.error_message = None
+    auto_tr.save(
+        update_fields=["status", "route", "route_back", "raw_packet", "completed_at", "error_message"],
+    )
+
+
+def schedule_completed_traceroute_neo4j_export(auto_traceroute_id: int) -> None:
+    """Enqueue Neo4j edge sync for a completed row (lazy import keeps Celery wiring in one place)."""
+    from traceroute.tasks import push_traceroute_to_neo4j
+
+    push_traceroute_to_neo4j.delay(auto_traceroute_id)

--- a/Meshflow/traceroute/new_node_baseline.py
+++ b/Meshflow/traceroute/new_node_baseline.py
@@ -10,9 +10,9 @@ from django.utils import timezone
 from nodes.managed_node_liveness import is_managed_node_eligible_traceroute_source
 from nodes.models import ManagedNode, ObservedNode
 from traceroute.dispatch import TRACEROUTE_MAX_PENDING_PER_SOURCE, pending_count_for_source
+from traceroute.lifecycle import create_pending_auto_traceroute
 from traceroute.models import AutoTraceRoute
 from traceroute.source_selection import eligible_traceroute_sources_ordered
-from traceroute.ws_notify import notify_traceroute_status_changed
 
 logger = logging.getLogger(__name__)
 
@@ -78,14 +78,13 @@ def enqueue_new_node_baseline(observed_node: ObservedNode, observer: ManagedNode
     at_now = timezone.now()
     try:
         with transaction.atomic():
-            auto_tr = AutoTraceRoute.objects.create(
+            auto_tr = create_pending_auto_traceroute(
                 source_node=source,
                 target_node=observed_node,
                 trigger_type=AutoTraceRoute.TRIGGER_TYPE_NEW_NODE_BASELINE,
                 triggered_by=None,
                 trigger_source=NEW_NODE_BASELINE_TRIGGER_SOURCE,
                 target_strategy=None,
-                status=AutoTraceRoute.STATUS_PENDING,
                 earliest_send_at=at_now,
             )
     except IntegrityError:
@@ -102,5 +101,4 @@ def enqueue_new_node_baseline(observed_node: ObservedNode, observer: ManagedNode
         source.node_id_str,
         observed_node.node_id_str,
     )
-    notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_PENDING)
     return RESULT_QUEUED

--- a/Meshflow/traceroute/tasks.py
+++ b/Meshflow/traceroute/tasks.py
@@ -11,6 +11,7 @@ from celery import shared_task
 from tqdm import tqdm
 
 from .dispatch import TRACEROUTE_MAX_PENDING_PER_SOURCE, pending_count_for_source, try_dispatch_one
+from .lifecycle import create_pending_auto_traceroute
 from .models import AutoTraceRoute
 from .source_selection import eligible_traceroute_sources_ordered
 from .strategy_rotation import ordered_strategies_for_feeder, record_strategy_run
@@ -73,14 +74,13 @@ def schedule_traceroutes():
         row_strategy = chosen_strategy or AutoTraceRoute.TARGET_STRATEGY_LEGACY
 
         at_now = timezone.now()
-        auto_tr = AutoTraceRoute.objects.create(
+        auto_tr = create_pending_auto_traceroute(
             source_node=source_node,
             target_node=target_node,
             trigger_type=AutoTraceRoute.TRIGGER_TYPE_MONITORING,
             triggered_by=None,
             trigger_source="scheduler",
             target_strategy=row_strategy,
-            status=AutoTraceRoute.STATUS_PENDING,
             earliest_send_at=at_now,
         )
         if chosen_strategy is not None:
@@ -92,7 +92,6 @@ def schedule_traceroutes():
             row_strategy,
             auto_tr.id,
         )
-        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_PENDING)
         return {"created": 1}
 
     logger.warning("schedule_traceroutes: cascade exhausted, no TR created: %s", attempts)

--- a/Meshflow/traceroute/tests/test_lifecycle.py
+++ b/Meshflow/traceroute/tests/test_lifecycle.py
@@ -1,0 +1,109 @@
+"""Unit tests for traceroute.lifecycle queueing and completion helpers."""
+
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+import users.tests.conftest  # noqa: F401
+from traceroute.lifecycle import (
+    apply_auto_traceroute_completion,
+    create_pending_auto_traceroute,
+    schedule_completed_traceroute_neo4j_export,
+)
+from traceroute.models import AutoTraceRoute
+
+
+@pytest.mark.django_db
+def test_create_pending_auto_traceroute_notifies_by_default(
+    create_managed_node,
+    create_observed_node,
+    create_user,
+):
+    source = create_managed_node()
+    target = create_observed_node()
+    u = create_user()
+    at = timezone.now()
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed") as mock_notify:
+        tr = create_pending_auto_traceroute(
+            source_node=source,
+            target_node=target,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_USER,
+            triggered_by=u,
+            trigger_source="test",
+            target_strategy=None,
+            earliest_send_at=at,
+        )
+    mock_notify.assert_called_once_with(tr.id, AutoTraceRoute.STATUS_PENDING)
+    assert tr.status == AutoTraceRoute.STATUS_PENDING
+    assert tr.trigger_source == "test"
+
+
+@pytest.mark.django_db
+def test_create_pending_auto_traceroute_notify_optional(
+    create_managed_node,
+    create_observed_node,
+):
+    source = create_managed_node()
+    target = create_observed_node()
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed") as mock_notify:
+        create_pending_auto_traceroute(
+            source_node=source,
+            target_node=target,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_MONITORING,
+            triggered_by=None,
+            trigger_source="scheduler",
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_LEGACY,
+            notify_pending=False,
+        )
+    mock_notify.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_apply_auto_traceroute_completion_persists_fields(
+    create_managed_node,
+    create_observed_node,
+    create_user,
+):
+    from packets.models import TraceroutePacket
+
+    source = create_managed_node()
+    target = create_observed_node()
+    u = create_user()
+    tr = AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=target,
+        trigger_type=AutoTraceRoute.TRIGGER_TYPE_USER,
+        triggered_by=u,
+        status=AutoTraceRoute.STATUS_SENT,
+    )
+    packet = TraceroutePacket.objects.create(
+        packet_id=111,
+        from_int=target.node_id,
+        from_str=target.node_id_str,
+        to_int=source.node_id,
+        to_str=source.node_id_str,
+        port_num="TRACEROUTE_APP",
+        route=[1, 2],
+        route_back=[2, 1],
+        snr_towards=[-1.0, -2.0],
+        snr_back=[-1.5, -2.5],
+    )
+    route = [{"node_id": 1, "snr": -1.0}]
+    route_back = [{"node_id": 2, "snr": -2.0}]
+    apply_auto_traceroute_completion(tr, route=route, route_back=route_back, raw_packet=packet)
+    tr.refresh_from_db()
+    assert tr.status == AutoTraceRoute.STATUS_COMPLETED
+    assert tr.route == route
+    assert tr.route_back == route_back
+    assert tr.raw_packet_id == packet.id
+    assert tr.completed_at is not None
+    assert tr.error_message is None
+
+
+def test_schedule_completed_traceroute_neo4j_export_delegates():
+    with patch("traceroute.tasks.push_traceroute_to_neo4j") as mock_push:
+        schedule_completed_traceroute_neo4j_export(42)
+    mock_push.delay.assert_called_once_with(42)

--- a/Meshflow/traceroute/tests/test_new_node_baseline.py
+++ b/Meshflow/traceroute/tests/test_new_node_baseline.py
@@ -171,7 +171,7 @@ def test_enqueue_integrity_error_returns_duplicate(
     target = create_observed_node(node_id=0x71000002)
 
     with patch(
-        "traceroute.new_node_baseline.AutoTraceRoute.objects.create",
+        "traceroute.lifecycle.AutoTraceRoute.objects.create",
         side_effect=IntegrityError("duplicate baseline"),
     ):
         assert enqueue_new_node_baseline(target, observer) == RESULT_DUPLICATE

--- a/Meshflow/traceroute/tests/test_schedule_traceroutes.py
+++ b/Meshflow/traceroute/tests/test_schedule_traceroutes.py
@@ -54,7 +54,7 @@ def test_schedule_traceroutes_creates_when_recent_observation(
     def immediate_async_to_sync(async_func):
         return async_func
 
-    with patch("traceroute.tasks.notify_traceroute_status_changed") as mock_ws:
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed") as mock_ws:
         with patch("traceroute.dispatch.notify_traceroute_status_changed"):
             with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                 with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):

--- a/Meshflow/traceroute/tests/test_schedule_traceroutes_cascade.py
+++ b/Meshflow/traceroute/tests/test_schedule_traceroutes_cascade.py
@@ -28,7 +28,7 @@ def test_first_strategy_wins_records_strategy(
     def immediate_async_to_sync(async_func):
         return async_func
 
-    with patch("traceroute.tasks.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         with patch("traceroute.dispatch.notify_traceroute_status_changed"):
             with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                 with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):
@@ -65,7 +65,7 @@ def test_strategy_cascade_then_legacy_skips_record_strategy_run(
     def immediate_async_to_sync(async_func):
         return async_func
 
-    with patch("traceroute.tasks.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         with patch("traceroute.dispatch.notify_traceroute_status_changed"):
             with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                 with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):
@@ -136,7 +136,7 @@ def test_second_source_after_first_exhausts_including_legacy(
     def immediate_async_to_sync(async_func):
         return async_func
 
-    with patch("traceroute.tasks.notify_traceroute_status_changed"):
+    with patch("traceroute.lifecycle.notify_traceroute_status_changed"):
         with patch("traceroute.dispatch.notify_traceroute_status_changed"):
             with patch("traceroute.dispatch.async_to_sync", side_effect=immediate_async_to_sync):
                 with patch("traceroute.dispatch.get_channel_layer", return_value=channel_layer):


### PR DESCRIPTION
## Summary

This is the first PR for #247. It does **not** close 247.

It introduces a small **core traceroute lifecycle** module (`traceroute.lifecycle`) so operational code queues and completes `AutoTraceRoute` rows through a stable boundary. Analytics and visualisation modules are **not** moved in this PR.

- **`create_pending_auto_traceroute`**: centralises pending row creation (source, target, trigger fields, `earliest_send_at`, status) and optional `notify_traceroute_status_changed(..., pending)`.
- **`apply_auto_traceroute_completion`**: persists completion fields from packet ingestion (routes, `raw_packet`, `completed_at`, clears `error_message`).
- **`schedule_completed_traceroute_neo4j_export`**: lazy wrapper around `push_traceroute_to_neo4j.delay` so Neo4j wiring lives in one place for a follow-up redirect.

**Call sites updated** (behaviour preserved): `schedule_traceroutes`, `enqueue_new_node_baseline`, mesh monitoring `_dispatch_monitoring_round`, DX `plan_event_exploration` queue path, and `TraceroutePacketService` completion path. Product callbacks (DX detection, exploration finished, monitoring completed, completed WebSocket notify) stay in `packets.services.traceroute` in the same order as before.

Public API paths and Celery task names are unchanged.

## Testing performed

- `python -m pytest traceroute mesh_monitoring dx_monitoring packets -q` (308 passed)
- `black .`, `isort .`, `flake8 .` under `Meshflow/`
