### PR TITLE
docs(traceroute): cleanup PR3 — docs, OpenAPI, Celery wrapper rationale (#247)

### DIFF
--- a/Meshflow/traceroute/source_eligibility.py
+++ b/Meshflow/traceroute/source_eligibility.py
@@ -1,4 +1,9 @@
-"""Backward-compatible re-exports; canonical implementation in nodes.managed_node_liveness."""
+"""Stable re-exports of managed-node liveness helpers for the traceroute app.
+
+Canonical implementation: :mod:`nodes.managed_node_liveness`. Import from here
+in ``traceroute`` (views, selection, permissions) so call sites stay colocated
+with traceroute concerns.
+"""
 
 from nodes.managed_node_liveness import (
     DEFAULT_SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS,

--- a/Meshflow/traceroute/tasks.py
+++ b/Meshflow/traceroute/tasks.py
@@ -1,4 +1,17 @@
-"""Celery tasks for traceroute scheduling."""
+"""Celery tasks for traceroute scheduling and lifecycle side effects.
+
+Core mesh scheduling (``schedule_traceroutes``, ``dispatch_pending_traceroutes``,
+``mark_stale_traceroutes_failed``) lives here in full.
+
+Neo4j export, daily ``tr_success_daily`` snapshots, and related backfills are
+implemented in :mod:`traceroute_analytics.tasks` (``*_impl`` functions). Thin
+``@shared_task`` wrappers remain **on this module** so registered Celery names
+stay ``traceroute.tasks.<name>``. That matches ``django_celery_beat`` rows
+created in historical migrations, broker messages already in flight, and
+``management`` commands that call ``.delay`` / ``.apply`` on the stable names.
+To retire a wrapper, add a data migration (or one-off) updating PeriodicTask
+and redeploy with no queued jobs using the old name, then remove the stub.
+"""
 
 import logging
 import os
@@ -121,6 +134,8 @@ def export_traceroutes_to_neo4j():
     """
     One-off export of all completed AutoTraceRoute records to Neo4j.
     Idempotent; can re-run.
+
+    Kept on this module for the stable Celery name (see module docstring).
     """
     from traceroute_analytics.tasks import export_traceroutes_to_neo4j_impl
 
@@ -132,6 +147,8 @@ def push_traceroute_to_neo4j(auto_traceroute_id: int):
     """
     Push a single completed AutoTraceRoute to Neo4j.
     Called when a traceroute completes (from packet receiver).
+
+    Kept on this module for the stable Celery name (see module docstring).
     """
     from traceroute_analytics.tasks import push_traceroute_to_neo4j_impl
 
@@ -190,6 +207,8 @@ def collect_traceroute_success_daily():
     """
     Run daily (e.g. 1:05 AM). For the previous calendar day, count completed and failed
     traceroutes and store in StatsSnapshot (stat_type=tr_success_daily).
+
+    Kept on this module for the stable Celery name (see module docstring).
     """
     from traceroute_analytics.tasks import collect_traceroute_success_daily_impl
 
@@ -201,6 +220,8 @@ def backfill_traceroute_success_daily(days: int = 30):
     """
     Backfill tr_success_daily snapshots for the last N days.
     Idempotent: skips days that already have snapshots (when run sequentially).
+
+    Kept on this module for the stable Celery name (see module docstring).
     """
     from traceroute_analytics.tasks import backfill_traceroute_success_daily_impl
 

--- a/Meshflow/traceroute_analytics/tasks.py
+++ b/Meshflow/traceroute_analytics/tasks.py
@@ -1,6 +1,9 @@
 """Analytics Celery implementations (Neo4j export, daily success snapshots).
 
-Registered Celery names remain on ``traceroute.tasks`` wrappers for beat compatibility.
+Registered task names used by beat and ``.delay()`` calls remain
+``traceroute.tasks.<name>`` via thin wrappers in :mod:`traceroute.tasks`; this
+module holds the ``*_impl`` bodies so ``django_celery_beat`` rows need not be
+rewritten when analytics code moves.
 """
 
 import logging

--- a/Meshflow/traceroute_analytics/tests/test_urls.py
+++ b/Meshflow/traceroute_analytics/tests/test_urls.py
@@ -17,3 +17,4 @@ import pytest
 def test_analytics_paths_resolve(suffix, url_name):
     match = resolve(f"/api/traceroutes/{suffix}")
     assert match.url_name == url_name
+    assert match.func.__module__ == "traceroute_analytics.views"

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -1,14 +1,14 @@
 # Traceroute Feature
 
-The traceroute feature tracks path discovery between Meshtastic nodes on the mesh network. It records source-to-target routes (and return paths), stores them in Django, exports them to Neo4j for graph analysis, and exposes aggregated data for heatmap visualization in the UI.
+The traceroute feature tracks path discovery between Meshtastic nodes on the mesh network. **Core lifecycle** (model, scheduling, dispatch, packet completion, WebSocket status) lives in the **`traceroute`** Django app. **Derived analytics** — Neo4j export and queries, reach/coverage pivots, stats and heatmap HTTP handlers — live in **`traceroute_analytics`**, while public URLs stay under `/api/traceroutes/` for compatibility (see [areas-of-concern](areas-of-concern.md)).
 
 ## Overview
 
 - **AutoTraceRoute**: Django model recording each traceroute request (manual or scheduled) and its result.
 - **Triggering**: Manual (**User**), scheduled mesh exploration (**Monitoring**), **External** (cross-environment / orphaned responses), **Node Watch** (mesh monitoring verification), **DX Watch** (reserved integer for future DX Monitoring exploration), and **New node baseline** (first-seen `ObservedNode`; meshflow-api#236). See [Mesh monitoring](../mesh-monitoring/README.md) for node-watch flows.
 - **Command delivery**: WebSocket (`NodeConsumer`) sends traceroute commands to connected bots (meshtastic-bot).
-- **Completion**: Packet receiver matches incoming `TraceroutePacket` to `AutoTraceRoute` (same source/target within configurable window). If no match exists (e.g. cross-env: prod triggered, pre-prod received), creates an `AutoTraceRoute` with `trigger_type=2` (External). Updates status and pushes to Neo4j.
-- **Heatmap**: Neo4j stores edges; `heatmap-edges` API returns aggregated edges/nodes for map visualization.
+- **Completion**: Packet receiver matches incoming `TraceroutePacket` to `AutoTraceRoute` (same source/target within configurable window). If no match exists (e.g. cross-env: prod triggered, pre-prod received), creates an `AutoTraceRoute` with `trigger_type=2` (External). Updates status and enqueues Neo4j sync (`traceroute_analytics`).
+- **Heatmap / coverage / stats**: Implemented in `traceroute_analytics` (Neo4j + ORM); same `/api/traceroutes/` paths as before.
 
 ## Trigger type (canonical)
 

--- a/docs/features/traceroute/areas-of-concern.md
+++ b/docs/features/traceroute/areas-of-concern.md
@@ -27,7 +27,7 @@ dispatch, monitoring, or DX workflows.
 | New-node baseline traceroutes          | `traceroute`                                    | A first-seen node baseline is a generic operational traceroute, not a user watch and not analytics. It establishes route evidence once per target and is reused by DX exploration dedupe logic, so it belongs with the core lifecycle.        |
 | Mesh watch and node monitoring         | `mesh_monitoring`                               | Watches, presence state, offline verification, watcher notifications, and monitoring-specific source selection are product concerns of mesh monitoring. The app should request `NODE_WATCH` traceroutes through the core traceroute boundary. |
 | DX monitoring and exploration          | `dx_monitoring`                                 | DX event detection, exploration planning, skip reasons, event linking, and DX notifications are product concerns of DX monitoring. The app should request `DX_WATCH` traceroutes through the core traceroute boundary.                        |
-| Source liveness / eligibility snapshot | `nodes` with `traceroute` compatibility exports | Managed-node liveness is fundamentally node state derived from ingestion. `traceroute.source_eligibility` may continue to re-export the canonical node helpers for compatibility.                                                             |
+| Source liveness / eligibility snapshot | `nodes` with `traceroute` import surface | Managed-node liveness is fundamentally node state derived from ingestion. `traceroute.source_eligibility` re-exports `nodes.managed_node_liveness` so traceroute views, selection, and permissions share one import path.                             |
 | Target selection and strategy rotation | `traceroute`                                    | These decide what generic automatic traceroute to run next. They are operational scheduling concerns, even when their output later feeds analytics.                                                                                           |
 | Traceroute analytics                   | `traceroute_analytics`                          | Stats, success/failure breakdowns, top routers, by-source/by-target summaries, success-over-time, and daily `StatsSnapshot` collection are derived reporting products over `AutoTraceRoute`. They should not live in the core lifecycle app.  |
 | Reach and coverage analytics           | `traceroute_analytics`                          | Feeder reach and constellation coverage are visualisation/reporting pivots over completed/failed traceroutes. They are useful, but not required for dispatch, completion, monitoring, or DX event handling.                                   |
@@ -61,13 +61,11 @@ policy in the producer app while preserving one lifecycle implementation.
 
 ## Refactor Notes
 
-When splitting the code:
+The split is implemented:
 
-- Keep the `AutoTraceRoute` model and migrations in `traceroute`.
-- Keep public API paths stable during the first refactor pass.
-- Add compatibility wrappers for Celery task names if existing beat rows or
-queued jobs reference old `traceroute.tasks.*` names.
-- Move analytics implementation first, then clean up compatibility wrappers
-only after deployed task/API compatibility is understood.
-- Update this document when a functional area deliberately changes owner.
+- `AutoTraceRoute` and migrations remain in `traceroute`.
+- Public `/api/traceroutes/` paths are unchanged; analytics handlers live in `traceroute_analytics` and are included from `traceroute.urls`.
+- Celery tasks that historically registered as `traceroute.tasks.*` for analytics (Neo4j push/export, `collect_traceroute_success_daily`, `backfill_traceroute_success_daily`) remain thin wrappers on `traceroute.tasks` so `django_celery_beat` rows and in-flight broker messages keep valid names; implementations are `traceroute_analytics.tasks` (`*_impl`). See module docstring on `Meshflow/traceroute/tasks.py`. Operators do not need a manual migration unless they chose to rename tasks in the database and drain queues first.
+
+Update this document when a functional area deliberately changes owner.
 

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -69,3 +69,7 @@ Celery task `mark_stale_traceroutes_failed` runs every 60 seconds. Traceroutes s
 `push_traceroute_to_neo4j` (Celery, implemented in `traceroute_analytics`): For each completed `AutoTraceRoute`, extracts edges from `route` and `route_back`, upserts `MeshNode` vertices, creates `ROUTED_TO` relationships with `weight` and `triggered_at`. Only edges where both endpoints have coordinates are stored.
 
 Bulk export: `export_traceroutes_to_neo4j` task or `manage.py export_traceroutes_to_neo4j` (with `--async` to queue as Celery task; command lives in `traceroute_analytics`).
+
+## 8. Daily success statistics
+
+Celery beat runs ``collect_traceroute_success_daily`` (daily, e.g. 1:05 AM). The implementation counts completed/failed ``AutoTraceRoute`` rows for the previous calendar day and upserts ``StatsSnapshot`` records (``stat_type=tr_success_daily``). Logic lives in ``traceroute_analytics.tasks``; the registered Celery name remains ``traceroute.tasks.collect_traceroute_success_daily`` so existing periodic task rows keep working.

--- a/docs/features/traceroute/heatmap.md
+++ b/docs/features/traceroute/heatmap.md
@@ -1,6 +1,6 @@
 # Traceroute Heatmap
 
-The heatmap visualizes aggregated traceroute traffic between nodes as arcs on a map. Data is stored in Neo4j and served via the `heatmap-edges` API.
+The heatmap visualizes aggregated traceroute traffic between nodes as arcs on a map. Data is stored in Neo4j and served via the `heatmap-edges` API. **Implementation** (schema, export, query): `traceroute_analytics` (`neo4j_service`, `views.heatmap_edges`). The URL remains `/api/traceroutes/heatmap-edges/` (wired from `traceroute.urls`).
 
 ## Neo4j Schema
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,7 +23,11 @@ tags:
   - name: WebSocket
     description: WebSocket endpoints for real-time node commands
   - name: Traceroutes
-    description: Traceroute history and manual triggering
+    description: >-
+      Traceroute list, detail, and manual trigger (core ``traceroute`` app), plus
+      read-only aggregation endpoints for stats, Neo4j-backed heatmap edges, feeder
+      reach, and constellation coverage (implemented in ``traceroute_analytics`` at
+      the same ``/api/traceroutes/`` paths).
   - name: Mesh Monitoring
     description: User watches on observed nodes for silence detection and offline verification
   - name: DX Monitoring


### PR DESCRIPTION
# Summary

Cleanup and documentation pass for the traceroute refactor (meshflow-api#247), targeting the phase-2 branch `api-247/paddy/traceroute-analytics-app`.

Documentation now matches the final ownership split: core lifecycle stays in `traceroute`; Neo4j, reach/coverage, stats, and heatmap HTTP handlers live in `traceroute_analytics` with stable `/api/traceroutes/` URLs.

**Compatibility retained (by design):** Celery `@shared_task` entries for `export_traceroutes_to_neo4j`, `push_traceroute_to_neo4j`, `collect_traceroute_success_daily`, and `backfill_traceroute_success_daily` remain thin wrappers on `traceroute.tasks` so registered names stay `traceroute.tasks.*`. Historical `django_celery_beat` migrations and in-flight broker messages reference those strings. Implementations are `traceroute_analytics.tasks` (`*_impl`). Module and per-task docstrings explain the removal path (data migration + drain queues if names are ever changed).

`traceroute.source_eligibility` remains a stable re-export of `nodes.managed_node_liveness` for traceroute call sites (not removed).

No public API path changes.

Closes #247

## Testing performed

- `python -m pytest traceroute traceroute_analytics mesh_monitoring dx_monitoring packets nodes -v` (401 passed)
- `black .`, `isort .`, `flake8 .` under `Meshflow/`