### PR TITLE
feat(traceroute): enrich heatmap-edges with centrality, degree, last_seen, role

### DIFF
--- a/Meshflow/requirements.txt
+++ b/Meshflow/requirements.txt
@@ -21,6 +21,7 @@ celery~=5.4
 django-celery-beat~=2.7
 neo4j>=6.1.0
 h3~=4.1
+networkx~=3.4
 
 # RF propagation pipeline (Meshtastic Site Planner engine client + GeoTIFF→PNG)
 httpx~=0.28

--- a/Meshflow/traceroute_analytics/neo4j_service.py
+++ b/Meshflow/traceroute_analytics/neo4j_service.py
@@ -4,7 +4,9 @@ import logging
 from datetime import datetime
 
 from django.conf import settings
+from django.utils import timezone
 
+import networkx as nx
 from neo4j import GraphDatabase
 from tqdm import tqdm
 
@@ -16,7 +18,74 @@ logger = logging.getLogger(__name__)
 
 UNKNOWN_NODE_ID = 0xFFFFFFFF
 
+# Role classification: treat ObservedNode missing or older than this as offline.
+HEATMAP_OFFLINE_ROLE_HOURS = 24
+
 _driver = None
+
+
+def _heatmap_graph_metrics(edges):
+    """Return betweenness (0–1) and integer degree per node id for aggregated edges."""
+    g = nx.Graph()
+    for e in edges:
+        g.add_edge(e["from_node_id"], e["to_node_id"])
+    if g.number_of_nodes() == 0:
+        return {}, {}
+    betweenness = nx.betweenness_centrality(g, normalized=True)
+    degree = dict(g.degree())
+    return betweenness, degree
+
+
+def _assign_heatmap_roles(nodes, last_heard_by_id, now):
+    """Set ``role`` on each node: backbone, relay, leaf, or offline."""
+    offline_sec = HEATMAP_OFFLINE_ROLE_HOURS * 3600
+
+    def is_offline(nid):
+        lh = last_heard_by_id.get(nid)
+        if lh is None:
+            return True
+        delta = now - lh
+        return delta.total_seconds() > offline_sec
+
+    active = [n for n in nodes if not is_offline(n["node_id"])]
+    if active:
+        sorted_c = sorted(n["centrality"] for n in active)
+        last_i = len(sorted_c) - 1
+        i75 = max(0, min(last_i, int(round(0.75 * last_i))))
+        c75 = sorted_c[i75]
+    else:
+        c75 = 0.0
+
+    for n in nodes:
+        nid = n["node_id"]
+        if is_offline(nid):
+            n["role"] = "offline"
+        elif n["degree"] <= 1:
+            n["role"] = "leaf"
+        elif n["degree"] >= 2 and n["centrality"] >= c75:
+            n["role"] = "backbone"
+        else:
+            n["role"] = "relay"
+
+
+def _enrich_heatmap_nodes(nodes, edges):
+    """Add centrality, degree, last_seen (ISO), and role using NetworkX + ObservedNode."""
+    betweenness, degree = _heatmap_graph_metrics(edges)
+    ids = [n["node_id"] for n in nodes]
+    last_heard_by_id = {}
+    if ids:
+        for row in ObservedNode.objects.filter(node_id__in=ids).values("node_id", "last_heard"):
+            last_heard_by_id[row["node_id"]] = row["last_heard"]
+
+    now = timezone.now()
+    for n in nodes:
+        nid = n["node_id"]
+        n["centrality"] = float(betweenness.get(nid, 0.0))
+        n["degree"] = int(degree.get(nid, 0))
+        lh = last_heard_by_id.get(nid)
+        n["last_seen"] = lh.isoformat() if lh else None
+
+    _assign_heatmap_roles(nodes, last_heard_by_id, now)
 
 
 def get_driver():
@@ -538,6 +607,8 @@ def run_heatmap_query(
                 }
 
     nodes = list(nodes_by_id.values())
+    if nodes:
+        _enrich_heatmap_nodes(nodes, edges)
 
     # Meta: approximate counts (from Django for total TR, from Neo4j for nodes)
     from django.db.models import Q

--- a/Meshflow/traceroute_analytics/tests/test_neo4j_service.py
+++ b/Meshflow/traceroute_analytics/tests/test_neo4j_service.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from django.utils import timezone
+
 import pytest
 
 import nodes.tests.conftest  # noqa: F401 - load fixtures
@@ -406,13 +408,26 @@ class TestRunHeatmapQuery:
         mock_cm.__exit__.return_value = False
         mock_driver.session.return_value = mock_cm
 
-        with patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver):
+        now = timezone.now()
+        with (
+            patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver),
+            patch("traceroute_analytics.neo4j_service.ObservedNode.objects.filter") as mock_obs,
+        ):
+            mock_obs.return_value.values.return_value = [
+                {"node_id": 1, "last_heard": now},
+                {"node_id": 2, "last_heard": now},
+            ]
             data = run_heatmap_query(edge_metric="packets", driver=mock_driver)
 
         assert len(data["edges"]) == 1
         assert data["edges"][0]["weight"] == 5
         assert "avg_snr" not in data["edges"][0]
         assert len(data["nodes"]) == 2
+        by_id = {n["node_id"]: n for n in data["nodes"]}
+        assert by_id[1]["centrality"] == 0.0
+        assert by_id[1]["degree"] == 1
+        assert by_id[1]["role"] == "leaf"
+        assert by_id[1]["last_seen"] is not None
 
     def test_run_heatmap_query_snr_returns_avg_snr_when_present(self):
         """edge_metric=snr returns edges with weight and avg_snr when Neo4j has snr."""
@@ -445,13 +460,22 @@ class TestRunHeatmapQuery:
         mock_cm.__exit__.return_value = False
         mock_driver.session.return_value = mock_cm
 
-        with patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver):
+        now = timezone.now()
+        with (
+            patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver),
+            patch("traceroute_analytics.neo4j_service.ObservedNode.objects.filter") as mock_obs,
+        ):
+            mock_obs.return_value.values.return_value = [
+                {"node_id": 1, "last_heard": now},
+                {"node_id": 2, "last_heard": now},
+            ]
             data = run_heatmap_query(edge_metric="snr", driver=mock_driver)
 
         assert len(data["edges"]) == 1
         assert data["edges"][0]["weight"] == 3
         assert data["edges"][0]["avg_snr"] == -2.5
         assert len(data["nodes"]) == 2
+        assert all("centrality" in n and "role" in n for n in data["nodes"])
 
     def test_run_heatmap_query_snr_omits_avg_snr_when_null(self):
         """edge_metric=snr omits avg_snr when Neo4j returns null (no snr on relationships)."""
@@ -484,9 +508,122 @@ class TestRunHeatmapQuery:
         mock_cm.__exit__.return_value = False
         mock_driver.session.return_value = mock_cm
 
-        with patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver):
+        now = timezone.now()
+        with (
+            patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver),
+            patch("traceroute_analytics.neo4j_service.ObservedNode.objects.filter") as mock_obs,
+        ):
+            mock_obs.return_value.values.return_value = [
+                {"node_id": 1, "last_heard": now},
+                {"node_id": 2, "last_heard": now},
+            ]
             data = run_heatmap_query(edge_metric="snr", driver=mock_driver)
 
         assert len(data["edges"]) == 1
         assert data["edges"][0]["weight"] == 2
         assert "avg_snr" not in data["edges"][0]
+
+    def test_run_heatmap_query_without_observed_marks_offline(self):
+        """Missing ObservedNode rows yield offline role and null last_seen."""
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "from_node_id": 1,
+                    "to_node_id": 2,
+                    "from_lat": 55.0,
+                    "from_lng": -4.0,
+                    "to_lat": 55.1,
+                    "to_lng": -4.1,
+                    "from_node_id_str": "!00000001",
+                    "from_short_name": "A",
+                    "from_long_name": "Node A",
+                    "to_node_id_str": "!00000002",
+                    "to_short_name": "B",
+                    "to_long_name": "Node B",
+                    "weight": 5,
+                }
+            ]
+        )
+        mock_session = MagicMock()
+        mock_session.run.return_value = mock_result
+        mock_driver = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_session
+        mock_cm.__exit__.return_value = False
+        mock_driver.session.return_value = mock_cm
+
+        with (
+            patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver),
+            patch("traceroute_analytics.neo4j_service.ObservedNode.objects.filter") as mock_obs,
+        ):
+            mock_obs.return_value.values.return_value = []
+            data = run_heatmap_query(edge_metric="packets", driver=mock_driver)
+
+        for n in data["nodes"]:
+            assert n["last_seen"] is None
+            assert n["role"] == "offline"
+
+    def test_run_heatmap_query_path_middle_node_backbone(self):
+        """Three-node path: middle node has highest betweenness among degree-2 nodes."""
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter(
+            [
+                {
+                    "from_node_id": 1,
+                    "to_node_id": 2,
+                    "from_lat": 55.0,
+                    "from_lng": -4.0,
+                    "to_lat": 55.05,
+                    "to_lng": -4.05,
+                    "from_node_id_str": "!00000001",
+                    "from_short_name": "A",
+                    "from_long_name": "Node A",
+                    "to_node_id_str": "!00000002",
+                    "to_short_name": "B",
+                    "to_long_name": "Node B",
+                    "weight": 2,
+                },
+                {
+                    "from_node_id": 2,
+                    "to_node_id": 3,
+                    "from_lat": 55.05,
+                    "from_lng": -4.05,
+                    "to_lat": 55.1,
+                    "to_lng": -4.1,
+                    "from_node_id_str": "!00000002",
+                    "from_short_name": "B",
+                    "from_long_name": "Node B",
+                    "to_node_id_str": "!00000003",
+                    "to_short_name": "C",
+                    "to_long_name": "Node C",
+                    "weight": 2,
+                },
+            ]
+        )
+        mock_session = MagicMock()
+        mock_session.run.return_value = mock_result
+        mock_driver = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__.return_value = mock_session
+        mock_cm.__exit__.return_value = False
+        mock_driver.session.return_value = mock_cm
+
+        now = timezone.now()
+        with (
+            patch("traceroute_analytics.neo4j_service.get_driver", return_value=mock_driver),
+            patch("traceroute_analytics.neo4j_service.ObservedNode.objects.filter") as mock_obs,
+        ):
+            mock_obs.return_value.values.return_value = [
+                {"node_id": 1, "last_heard": now},
+                {"node_id": 2, "last_heard": now},
+                {"node_id": 3, "last_heard": now},
+            ]
+            data = run_heatmap_query(edge_metric="packets", driver=mock_driver)
+
+        by_id = {n["node_id"]: n for n in data["nodes"]}
+        assert by_id[2]["centrality"] > by_id[1]["centrality"]
+        assert by_id[2]["centrality"] > by_id[3]["centrality"]
+        assert by_id[2]["role"] == "backbone"
+        assert by_id[1]["role"] == "leaf"
+        assert by_id[3]["role"] == "leaf"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5478,6 +5478,22 @@ paths:
                           type: string
                         long_name:
                           type: string
+                        centrality:
+                          type: number
+                          description: Normalised betweenness centrality (0–1) on the filtered edge subgraph.
+                        degree:
+                          type: integer
+                          description: Distinct neighbours in the filtered subgraph.
+                        last_seen:
+                          type: string
+                          format: date-time
+                          nullable: true
+                          description: ObservedNode last_heard as ISO 8601; null if unknown.
+                        role:
+                          type: string
+                          enum: [backbone, relay, leaf, offline]
+                          description: >-
+                            Derived role from centrality, degree, and recency (server uses ~24h offline cutoff).
                   meta:
                     type: object
                     properties:


### PR DESCRIPTION
# Summary

Adds topology and health fields to the traceroute `heatmap-edges` API so the UI can show which nodes are important to the mesh, which are well-connected, and which have stale observations.

This PR enriches each heatmap node with:

* `centrality`: normalised betweenness centrality (`0–1`) computed from the filtered heatmap subgraph.
* `degree`: count of distinct neighbours in that same filtered subgraph.
* `last_seen`: `ObservedNode.last_heard` from Postgres, returned as ISO 8601 or `null`.
* `role`: server-derived `backbone`, `relay`, `leaf`, or `offline` classification for UI ring/staleness styling.

The graph metrics are computed in-process with NetworkX from the existing aggregated Neo4j `ROUTED_TO` edge result. No Neo4j schema change or re-export is required. `last_seen` comes from a batched Django query against `ObservedNode`, not Neo4j.

## Background

Supports pskillen/meshtastic-bot-ui#156. The paired UI PR is pskillen/meshtastic-bot-ui#237.

This intentionally avoids Neo4j GDS and Celery caching for the first version. If large windows become slow later, those can be added as a follow-up without changing the API shape.

## Deployment notes

* Install the new Python dependency: `networkx~=3.4`.
* No database migration.
* No Neo4j re-export required.
* Merge/deploy this API PR before the UI PR for full behaviour; the UI treats the new fields as optional and degrades to the previous styling if they are absent.

## Testing performed

* `cd /Users/patricks/git_personal/meshflow-api/Meshflow && source ../venv/bin/activate && pip install -q 'networkx~=3.4' && python -m pytest traceroute_analytics/tests/test_neo4j_service.py::TestRunHeatmapQuery -v`
* `cd /Users/patricks/git_personal/meshflow-api/Meshflow && source ../venv/bin/activate && black traceroute_analytics/neo4j_service.py traceroute_analytics/tests/test_neo4j_service.py && isort traceroute_analytics/neo4j_service.py traceroute_analytics/tests/test_neo4j_service.py && flake8 traceroute_analytics/neo4j_service.py traceroute_analytics/tests/test_neo4j_service.py`