### PR TITLE
fix(auth): default JWT access lifetime to 30 days

### DIFF
--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -306,7 +306,7 @@ REST_FRAMEWORK = {
 # JWT Settings
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(
-        minutes=int(os.environ.get("JWT_ACCESS_TOKEN_LIFETIME_MINUTES", 1440))  # 24h default
+        minutes=int(os.environ.get("JWT_ACCESS_TOKEN_LIFETIME_MINUTES", 43200))  # 30d default (matches refresh)
     ),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=int(os.environ.get("JWT_REFRESH_TOKEN_LIFETIME_DAYS", 30))),  # 30d default
     "ROTATE_REFRESH_TOKENS": True,

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -31,7 +31,7 @@ This document describes all environment variables used by the Meshflow Django pr
 
 | Variable                        | Default   | Description                                              | Allowable Values         |
 |----------------------------------|-----------|----------------------------------------------------------|-------------------------|
-| `JWT_ACCESS_TOKEN_LIFETIME_MINUTES` | `1440`  | JWT access token lifetime in minutes (default 24h).      | Integer (string)        |
+| `JWT_ACCESS_TOKEN_LIFETIME_MINUTES` | `43200` | JWT access token lifetime in minutes (default 30d).     | Integer (string)        |
 | `JWT_REFRESH_TOKEN_LIFETIME_DAYS`   | `30`    | JWT refresh token lifetime in days (default 30d).        | Integer (string)        |
 
 ---
@@ -186,7 +186,7 @@ Tunables for [automatic target selection reliability](../features/traceroute/alg
 
 ## 3. JWT / Authentication
 
-- **JWT_ACCESS_TOKEN_LIFETIME_MINUTES**: How long (in minutes) JWT access tokens are valid.
+- **JWT_ACCESS_TOKEN_LIFETIME_MINUTES**: How long (in minutes) JWT access tokens are valid (default 30 days, aligned with refresh token lifetime).
 - **JWT_REFRESH_TOKEN_LIFETIME_DAYS**: How long (in days) JWT refresh tokens are valid.
 
 ## 4. Django Allauth / Social Auth
@@ -250,7 +250,7 @@ POSTGRES_PASSWORD=supersecret
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
-JWT_ACCESS_TOKEN_LIFETIME_MINUTES=1440
+JWT_ACCESS_TOKEN_LIFETIME_MINUTES=43200
 JWT_REFRESH_TOKEN_LIFETIME_DAYS=30
 
 SITE_ID=1

--- a/docs/RECENCY.md
+++ b/docs/RECENCY.md
@@ -47,7 +47,7 @@ source of truth for defaults.
 | `MESH_MONITORING_VERIFICATION_NOTIFY_COOLDOWN_SECONDS` | `3600` (s) | Min gap between verification-start Discord DMs |
 | `MESH_MONITORING_NOTIFY_VERIFICATION_START` | unset = on | Toggle verification-start DMs |
 | `AUTO_TR_SOURCE_SELECTION_ALGO` | `least_recently_used` | Source picker (uses `triggered_at` history) |
-| `JWT_ACCESS_TOKEN_LIFETIME_MINUTES` | `1440` (24 h) | JWT access token TTL |
+| `JWT_ACCESS_TOKEN_LIFETIME_MINUTES` | `43200` (30 d) | JWT access token TTL |
 | `JWT_REFRESH_TOKEN_LIFETIME_DAYS` | `30` | JWT refresh token TTL |
 | `RF_PROPAGATION_POLL_MAX_SECONDS` | `300` | Max Site Planner poll budget per render |
 | `RF_PROPAGATION_READY_RETENTION` | `3` | On-disk ready PNG retention count (not a duration) |
@@ -267,7 +267,7 @@ Implemented in [`Meshflow/stats/tasks.py`](../Meshflow/stats/tasks.py).
 | Item | Default | Purpose |
 | --- | --- | --- |
 | Discord connect OAuth `STATE_MAX_AGE` | **900 s (15 min)** | Max age of signed OAuth connect state + cache key |
-| `SIMPLE_JWT` access lifetime | **1440 min (24 h)** | JWT access token (env: `JWT_ACCESS_TOKEN_LIFETIME_MINUTES`) |
+| `SIMPLE_JWT` access lifetime | **43200 min (30 d)** | JWT access token (env: `JWT_ACCESS_TOKEN_LIFETIME_MINUTES`) |
 | `SIMPLE_JWT` refresh lifetime | **30 days** | JWT refresh token (env: `JWT_REFRESH_TOKEN_LIFETIME_DAYS`) |
 
 ---


### PR DESCRIPTION
# Summary

Raises the default **JWT access token** lifetime from **24 hours** to **30 days** so it matches the existing default **refresh token** lifetime (30 days). Operators can still override via `JWT_ACCESS_TOKEN_LIFETIME_MINUTES`.

This addresses the session-length expectation described in [#258](https://github.com/pskillen/meshflow-api/issues/258). The SPA already refreshes access tokens proactively and on 401 when a refresh token is present; longer-lived access tokens reduce unnecessary refresh churn and align the default "logged in" horizon with refresh.

**Deploy note:** Environments that explicitly set `JWT_ACCESS_TOKEN_LIFETIME_MINUTES=1440` keep 24h behaviour until that env var is removed or updated.

Related consolidation (constants / docs): [#197](https://github.com/pskillen/meshflow-api/issues/197), [meshtastic-bot-ui#202](https://github.com/pskillen/meshtastic-bot-ui/issues/202).

## Testing performed

- `python -m pytest users/tests/test_discord_connect_oauth.py -q` (from `Meshflow/` with venv)

Closes #258