### PR TITLE
feat(traceroutes): stats source_node + strategy aggregates for UI #199

### DIFF
--- a/Meshflow/traceroute_analytics/tests/test_views.py
+++ b/Meshflow/traceroute_analytics/tests/test_views.py
@@ -215,6 +215,107 @@ class TestTracerouteStats:
         assert rows_f[on.node_id]["completed"] == 0
         assert rows_f[on.node_id]["failed"] == 1
 
+    def test_stats_respects_source_node(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn_a = create_managed_node(node_id=666_666_601)
+        mn_b = create_managed_node(node_id=666_666_602)
+        on = create_observed_node()
+        api_client.force_authenticate(user=user)
+
+        create_auto_traceroute(
+            source_node=mn_a,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        )
+        create_auto_traceroute(
+            source_node=mn_a,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_FAILED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        )
+        create_auto_traceroute(
+            source_node=mn_b,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS,
+        )
+
+        resp_all = api_client.get("/api/traceroutes/stats/")
+        assert resp_all.status_code == 200
+        data_all = resp_all.json()
+        assert len(data_all["by_source"]) == 2
+        intra_all = data_all["by_strategy"][AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE]
+        assert intra_all["completed"] == 1
+        assert intra_all["failed"] == 1
+        dx_all = data_all["by_strategy"][AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS]
+        assert dx_all["completed"] == 1
+        assert dx_all["failed"] == 0
+
+        resp_a = api_client.get("/api/traceroutes/stats/", {"source_node": str(mn_a.node_id)})
+        assert resp_a.status_code == 200
+        data_a = resp_a.json()
+        assert len(data_a["by_source"]) == 1
+        assert data_a["by_source"][0]["node_id"] == mn_a.node_id
+        intra_a = data_a["by_strategy"][AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE]
+        assert intra_a["completed"] == 1
+        assert intra_a["failed"] == 1
+        assert AutoTraceRoute.TARGET_STRATEGY_DX_ACROSS not in data_a["by_strategy"]
+
+    def test_by_strategy_split_for_external_trigger_type(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        user = create_user()
+        mn = create_managed_node(node_id=777_777_701)
+        on = create_observed_node()
+        api_client.force_authenticate(user=user)
+
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            trigger_type=AutoTraceRoute.TRIGGER_TYPE_EXTERNAL,
+            target_strategy=None,
+        )
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            target_strategy=AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE,
+        )
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        body = resp.json()
+        by_strategy = body["by_strategy"]
+        by_hypothesis = body["by_strategy_excluding_external"]
+
+        assert by_strategy[AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE]["completed"] == 1
+        assert by_strategy[AutoTraceRoute.TARGET_STRATEGY_LEGACY]["completed"] == 1
+
+        assert by_hypothesis[AutoTraceRoute.TARGET_STRATEGY_INTRA_ZONE]["completed"] == 1
+        assert AutoTraceRoute.TARGET_STRATEGY_LEGACY not in by_hypothesis
+
+        sources = {s["trigger_type"]: s["count"] for s in body["sources"]}
+        assert sources.get(AutoTraceRoute.TRIGGER_TYPE_EXTERNAL) == 1
+
 
 @pytest.mark.django_db
 class TestFeederReach:

--- a/Meshflow/traceroute_analytics/views.py
+++ b/Meshflow/traceroute_analytics/views.py
@@ -16,6 +16,35 @@ from nodes.models import ManagedNode, ObservedNode
 from traceroute.models import AutoTraceRoute
 
 
+def _traceroute_stats_by_strategy(qs):
+    """Aggregate counts per coalesced target_strategy for a queryset."""
+    legacy_label = AutoTraceRoute.TARGET_STRATEGY_LEGACY
+    by_strategy_rows = (
+        qs.annotate(
+            strat=Coalesce(
+                "target_strategy",
+                Value(legacy_label, output_field=CharField(max_length=24)),
+            )
+        )
+        .values("strat")
+        .annotate(
+            completed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_COMPLETED)),
+            failed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_FAILED)),
+            pending=Count("id", filter=Q(status=AutoTraceRoute.STATUS_PENDING)),
+            sent=Count("id", filter=Q(status=AutoTraceRoute.STATUS_SENT)),
+        )
+    )
+    return {
+        row["strat"]: {
+            "completed": row["completed"],
+            "failed": row["failed"],
+            "pending": row["pending"],
+            "sent": row["sent"],
+        }
+        for row in by_strategy_rows
+    }
+
+
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def heatmap_edges(request):
@@ -313,7 +342,12 @@ def constellation_coverage(request):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def traceroute_stats(request):
-    """Traceroute statistics: sources, success/failure, top routers, by source, success over time."""
+    """Traceroute statistics: sources, success/failure, top routers, by source, success over time.
+
+    Optional query params: triggered_at_after, source_node (managed mesh node_id, same as list).
+    ``by_strategy`` includes all trigger types; ``by_strategy_excluding_external`` omits external
+    mesh reports for success-rate style breakdowns (no hypothesis).
+    """
     from django.utils.dateparse import parse_datetime
 
     from common.mesh_node_helpers import meshtastic_id_to_hex
@@ -328,6 +362,14 @@ def traceroute_stats(request):
     if triggered_after:
         qs = qs.filter(triggered_at__gte=triggered_after)
 
+    source_node = request.query_params.get("source_node")
+    if source_node:
+        try:
+            mn = ManagedNode.objects.get(node_id=int(source_node), deleted_at__isnull=True)
+            qs = qs.filter(source_node=mn)
+        except ValueError, ManagedNode.DoesNotExist:
+            pass
+
     # Sources: by trigger_type
     sources = list(qs.values("trigger_type").annotate(count=Count("id")).order_by("-count"))
 
@@ -339,31 +381,10 @@ def traceroute_stats(request):
         .order_by("-count")
     )
 
-    legacy_label = AutoTraceRoute.TARGET_STRATEGY_LEGACY
-    by_strategy_rows = (
-        qs.annotate(
-            strat=Coalesce(
-                "target_strategy",
-                Value(legacy_label, output_field=CharField(max_length=24)),
-            )
-        )
-        .values("strat")
-        .annotate(
-            completed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_COMPLETED)),
-            failed=Count("id", filter=Q(status=AutoTraceRoute.STATUS_FAILED)),
-            pending=Count("id", filter=Q(status=AutoTraceRoute.STATUS_PENDING)),
-            sent=Count("id", filter=Q(status=AutoTraceRoute.STATUS_SENT)),
-        )
+    by_strategy = _traceroute_stats_by_strategy(qs)
+    by_strategy_excluding_external = _traceroute_stats_by_strategy(
+        qs.exclude(trigger_type=AutoTraceRoute.TRIGGER_TYPE_EXTERNAL)
     )
-    by_strategy = {
-        row["strat"]: {
-            "completed": row["completed"],
-            "failed": row["failed"],
-            "pending": row["pending"],
-            "sent": row["sent"],
-        }
-        for row in by_strategy_rows
-    }
 
     # Top routers: intermediate nodes from completed traceroutes
     UNKNOWN_NODE_ID = 0xFFFFFFFF
@@ -487,6 +508,7 @@ def traceroute_stats(request):
             "by_target": by_target,
             "success_over_time": success_over_time,
             "by_strategy": by_strategy,
+            "by_strategy_excluding_external": by_strategy_excluding_external,
         }
     )
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5278,7 +5278,9 @@ paths:
         Returns traceroute stats for the given timeframe: sources (by trigger_type),
         success/failure counts, top routers (intermediate nodes), per-source managed node
         totals (with success rate among finished runs only), per-target observed node totals,
-        success over time (14d), and counts by target_strategy (null mapped to legacy). All authenticated users.
+        success over time (14d), ``by_strategy`` (all trigger types; null mapped to legacy), and
+        ``by_strategy_excluding_external`` (same shape but omits trigger_type external for hypothesis-only
+        success breakdowns). All authenticated users.
       tags: [Traceroutes]
       security:
         - BearerAuth: []
@@ -5290,6 +5292,17 @@ paths:
             type: string
             format: date-time
             description: Filter stats by triggered_at >= value (ISO 8601)
+        - name: source_node
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+          description: >
+            Meshtastic node id of the source managed node; same semantics as GET /traceroutes/
+            source_node. When set, all aggregates (including by_strategy and
+            by_strategy_excluding_external) are limited to
+            traceroutes from that source. Invalid or unknown ids are ignored (no filter).
       responses:
         '200':
           description: Traceroute statistics
@@ -5306,6 +5319,7 @@ paths:
                     by_target,
                     success_over_time,
                     by_strategy,
+                    by_strategy_excluding_external,
                   ]
                 properties:
                   sources:
@@ -5443,7 +5457,24 @@ paths:
                   by_strategy:
                     type: object
                     description: >
-                      Counts per target_strategy (database null aggregated under key `legacy`).
+                      Counts per target_strategy for all traceroutes in the window. Rows with null
+                      target_strategy are aggregated under key `legacy`. Includes trigger_type external.
+                    additionalProperties:
+                      type: object
+                      properties:
+                        completed:
+                          type: integer
+                        failed:
+                          type: integer
+                        pending:
+                          type: integer
+                        sent:
+                          type: integer
+                  by_strategy_excluding_external:
+                    type: object
+                    description: >
+                      Same aggregation as by_strategy but excludes traceroutes with trigger_type external
+                      (mesh reports with no target selection hypothesis). Intended for success-rate-by-strategy views.
                     additionalProperties:
                       type: object
                       properties:


### PR DESCRIPTION
## Summary

Extends `GET /traceroutes/stats/` for [meshtastic-bot-ui#199](https://github.com/pskillen/meshtastic-bot-ui/issues/199) / UI PR [meshtastic-bot-ui#246](https://github.com/pskillen/meshtastic-bot-ui/pull/246).

- Optional `source_node` query param (Meshtastic mesh node id of source managed node; same semantics as traceroute list).
- **`by_strategy`**: counts for all trigger types (includes external mesh reports; null `target_strategy` coalesced to `legacy`) — used for strategy mix.
- **`by_strategy_excluding_external`**: same shape but excludes `trigger_type` external — used for success-rate-by-strategy chart only.
- OpenAPI and `TestTracerouteStats` coverage.

**Ship order:** merge and deploy this PR before the UI PR so the UI always receives `by_strategy_excluding_external`.

## Testing performed

- `python -m pytest traceroute_analytics/tests/test_views.py::TestTracerouteStats -v`