### PR TITLE
docs(meshcore): Phase 0.5 ADRs (identity, channels, broadcast, dedup)

### DIFF
--- a/docs/features/packet-ingestion/MESHCORE_PACKET_FIELDS.md
+++ b/docs/features/packet-ingestion/MESHCORE_PACKET_FIELDS.md
@@ -1,0 +1,188 @@
+# MeshCore packet and event fields (Phase 0.4 — capture-verified)
+
+> **Provenance:** This file is a **derivative** of the field reference in **meshflow-bot**, kept here so API work (OpenAPI, ingestion ADRs, reviews) can cite a repo-local copy. The canonical capture bundle and tables live under the bot tree: [`docs/meshcore_packets/MESHCORE_PACKET_FIELDS.md`](https://github.com/pskillen/meshflow-bot/blob/main/docs/meshcore_packets/MESHCORE_PACKET_FIELDS.md) alongside [`docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets). When captures or dump shapes change, update the bot document first, then refresh this derivative.
+
+This document describes the **JSON shapes actually written by `meshflow-bot`** during the Phase 0.4 capture campaign (bundle context: [bot `docs/meshcore_packets/README.md`](https://github.com/pskillen/meshflow-bot/blob/main/docs/meshcore_packets/README.md)). It complements upstream MeshCore / `meshcore_py` documentation: anything listed here was checked against at least one file under that bundle (representative copies under [`docs/packets/meshcore/`](../../packets/meshcore/README.md) in this repo).
+
+**Envelope (every dumped file):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `protocol` | string | Always `meshcore`. |
+| `event_type` | string | Subfolder name / `meshcore` event discriminator (e.g. `rx_log_data`, `channel_message`). |
+| `payload` | object | Event payload; may be empty `{}`. |
+| `attributes` | object | Parallel metadata from the `meshcore` event; often repeats a subset of `payload` for indexing. |
+
+Nested keys use **snake_case** in dumps. Integer times such as `recv_time` / `sender_timestamp` are **Unix seconds** in the samples reviewed.
+
+---
+
+## `advertisement`
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.public_key` | string (hex) | 64 hex chars = 32-byte Ed25519 public key (lowercase in samples). |
+| `attributes.public_key` | string | Same as payload in samples. |
+
+---
+
+## `channel_message` (decoded group text; files may live under `channel_messages/`)
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.type` | string | `"CHAN"` in samples. |
+| `payload.channel_idx` | integer | Zero-based channel index. |
+| `payload.path_hash_mode` | integer | Routing / hash mode flag on wire. |
+| `payload.path_len` | integer | Count of path hops represented in frame. |
+| `payload.txt_type` | integer | Text subtype (0 in samples). |
+| `payload.sender_timestamp` | integer | Sender clock (Unix s). |
+| `payload.text` | string | UTF-8 channel message body. |
+| `attributes.channel_idx` | integer | Duplicate of `payload.channel_idx`. |
+| `attributes.txt_type` | integer | Duplicate of `payload.txt_type`. |
+
+**Capture note:** Channel frames may not carry a full sender pubkey; the bot uses a synthetic `from_id` for dispatch. See [`meshflow-bot` `src/meshcore/translation.py`](https://github.com/pskillen/meshflow-bot/blob/main/src/meshcore/translation.py).
+
+---
+
+## `contact_message` (decoded DM / private text)
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.type` | string | `"PRIV"` in samples. |
+| `payload.pubkey_prefix` | string (hex) | **12 hex chars** (6-byte prefix); used as partial sender identity. |
+| `payload.path_hash_mode` | integer | |
+| `payload.path_len` | integer | |
+| `payload.txt_type` | integer | |
+| `payload.sender_timestamp` | integer | |
+| `payload.text` | string | Message body. |
+| `attributes.pubkey_prefix` | string | Same prefix. |
+| `attributes.txt_type` | integer | |
+
+---
+
+## `control_data`
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.SNR` | number | dB-like SNR as reported by stack. |
+| `payload.RSSI` | integer | dBm. |
+| `payload.path_len` | integer | |
+| `payload.payload_type` | integer | Opaque type code (e.g. `146` in one sample). |
+| `payload.payload` | string (hex) | Opaque body. |
+| `attributes.payload_type` | integer | |
+
+---
+
+## `discover_response`
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.SNR` | number | |
+| `payload.RSSI` | integer | |
+| `payload.path_len` | integer | |
+| `payload.node_type` | integer | Small integer enum (e.g. `2`). |
+| `payload.SNR_in` | number | Inbound SNR where present. |
+| `payload.tag` | string (hex) | Short tag (8 hex chars in samples). |
+| `payload.pubkey` | string (hex) | Full 32-byte public key (64 hex). |
+| `attributes.node_type` | integer | |
+| `attributes.tag` | string | |
+| `attributes.pubkey` | string | |
+
+---
+
+## `messages_waiting`
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload` | object | Empty `{}` in committed samples. |
+| `attributes` | object | Empty `{}` in committed samples. |
+
+Semantics: push notification that the companion has traffic pending; no decoded text in these dumps.
+
+---
+
+## `path_update`
+
+| Field path | Type | Notes |
+|------------|------|--------|
+| `payload.public_key` | string (hex) | Full 64-hex pubkey. |
+| `attributes.public_key` | string | Same. |
+
+---
+
+## `rx_log_data` (raw RX / decoded packet log)
+
+Common fields across samples:
+
+| Field path | Type | Notes |
+|------------|------|-------------|
+| `payload.raw_hex` | string | Full received frame as hex. |
+| `payload.recv_time` | integer | RX time (Unix s). |
+| `payload.snr` | number | |
+| `payload.rssi` | integer | |
+| `payload.payload` | string (hex) | Frame sans outer framing as emitted by decoder (see samples). |
+| `payload.payload_length` | integer | Byte length. |
+| `payload.header` | integer | Header byte / flags (varies by packet). |
+| `payload.route_type` | integer | Numeric route discriminator. |
+| `payload.route_typename` | string | e.g. `FLOOD`, `TC_FLOOD`, `DIRECT`. |
+| `payload.payload_type` | integer | Numeric payload type. |
+| `payload.payload_typename` | string | e.g. `TEXT_MSG`, `ADVERT`, `PATH`, `REQ`, `CONTROL`. |
+| `payload.payload_ver` | integer | |
+| `payload.path_len` | integer | |
+| `payload.path_hash_size` | integer | Bytes per path hash segment. |
+| `payload.path` | string (hex) | Concatenated path hash bytes (may be empty). |
+| `payload.pkt_payload` | string (hex) | Inner payload hex. |
+| `payload.pkt_hash` | integer | 32-bit-ish hash identifier on wire (signed 32-bit in JSON number). |
+| `attributes.recv_time` | integer | |
+| `attributes.route_type` | integer | |
+| `attributes.payload_type` | integer | |
+| `attributes.path_len` | integer | |
+| `attributes.path` | string | |
+
+**Optional** (present when decoder expands the frame — seen on `ADVERT` and some `REQ`):
+
+| Field path | Type | Notes |
+|------------|------|-------------|
+| `payload.transport_code` | string (hex) | Seen on `REQ` / `PATH` / `ADVERT` samples. |
+| `payload.adv_name` | string | Human-readable name from advert. |
+| `payload.adv_key` | string (hex) | Advertised key material (prefix / key field). |
+| `payload.adv_timestamp` | integer | |
+| `payload.signature` | string (hex) | Long Ed25519 signature (128 hex). |
+| `payload.adv_flags` | integer | |
+| `payload.adv_type` | integer | |
+| `payload.adv_lat` | number | Observed `0.0` when position absent. |
+| `payload.adv_lon` | number | Observed `0.0` when position absent. |
+
+---
+
+## `trace_data`
+
+| Field path | Type | Notes |
+|------------|------|-------------|
+| `payload.tag` | integer | Request / trace correlation value (32-bit style). |
+| `payload.auth` | integer | |
+| `payload.flags` | integer | |
+| `payload.path_len` | integer | Number of hops described. |
+| `payload.path` | array | List of hop objects. |
+| `payload.path[].hash` | string (hex) | Present on some hops (1-byte `f3` style in sample). |
+| `payload.path[].snr` | number | SNR for hop. |
+| `attributes.tag` | integer | Same as `payload.tag`. |
+| `attributes.auth_code` | integer | Mirrors `payload.auth` in sample. |
+
+---
+
+## Types not present in this capture tree
+
+The following `meshcore` paths are handled in code but **did not produce JSON files** in this bundle (search the tree for `event_type` if that changes):
+
+- `battery` / battery telemetry pushes  
+- `self_info` / `device_info` as standalone dump files  
+- Dedicated `ack` event dumps  
+
+Absence here does **not** mean the mesh never sends them — only that this listener did not persist files under `docs/meshcore_packets/` for those types during this run. Use that fact when scoping Phase 0.5 ADRs ([meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)).
+
+---
+
+## Mapping hint for future API ingest
+
+For ingestion design, treat **`rx_log_data`** as the authoritative per-packet record (`payload_typename`, route, hashes, optional advert decode). Treat **`channel_message`** / **`contact_message`** as already-decoded text views. Keep **`protocol": "meshcore"`** on every JSON line for mixed-protocol tooling.

--- a/docs/features/packet-ingestion/README.md
+++ b/docs/features/packet-ingestion/README.md
@@ -28,6 +28,28 @@ ingested packets describe the same on-air transmission.
 Sample raw packet payloads (one per port number) live in
 `[docs/packets/](../../packets/)` at the top of `docs/`.
 
+## MeshCore (Phase 0.5 — design only)
+
+MeshCore (MC) is being added as a second first-class protocol alongside
+Meshtastic (MT). The wire shape is different — Ed25519 pubkeys instead of
+32-bit node ids, no `packet_id`, channel index without a channel hash — so
+the API gets a parallel ingest path rather than coercing MC into the MT
+schema.
+
+Phase 0.5 lands the schema decisions only; no models, endpoints, or
+`openapi.yaml` changes yet (those are Phase 1, tracked under
+[meshflow-api#265](https://github.com/pskillen/meshflow-api/issues/265)).
+
+- [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md) — capture-verified
+field reference, derivative of the Phase 0.4 bundle in
+[meshflow-bot/docs/meshcore_packets/](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets).
+- [adr/](adr/README.md) — ADRs covering MC node identity, channels,
+broadcast semantics, and dedup key. Tracked in
+[meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+(epic [#264](https://github.com/pskillen/meshflow-api/issues/264)).
+- Representative MC sample JSONs (one per event shape) live in
+[`docs/packets/meshcore/`](../../packets/meshcore/README.md).
+
 ## End-to-end Flow
 
 ```mermaid

--- a/docs/features/packet-ingestion/adr/0001-mc-node-identity.md
+++ b/docs/features/packet-ingestion/adr/0001-mc-node-identity.md
@@ -1,0 +1,78 @@
+# ADR-0001 — MeshCore node identity
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+
+## Context
+
+Meshtastic (MT) `ObservedNode` is keyed on a 32-bit `node_id` (BigInt) plus a derived `node_id_str` (`!12345678`). MeshCore (MC) has no such identifier on the wire: nodes are identified by **32-byte Ed25519 public keys**.
+
+The Phase 0.4 capture campaign (6 days, South Scotland, firmware 1.15.0 — see [`docs/features/packet-ingestion/MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md)) showed that the per-event identity information varies sharply by event type:
+
+| Event | Identity on the wire | Notes |
+| --- | --- | --- |
+| `advertisement` | Full 64-hex `public_key` | Pubkey only — no name, no position. |
+| `path_update` | Full 64-hex `public_key` | Pubkey only. |
+| `discover_response` | Full 64-hex `pubkey` + 8-hex `tag` + `node_type` | No name, no position. |
+| `rx_log_data` (`ADVERT` decode) | Full 64-hex `adv_key`, **plus** `adv_name`, `adv_lat`, `adv_lon`, `adv_flags`, `adv_type`, `signature` | Only event that ever carries node name and position. `adv_lat=0.0` / `adv_lon=0.0` when absent. |
+| `rx_log_data` (non-ADVERT) | Only on-wire fields: `pkt_hash`, `path`, raw `payload` | No sender identity. |
+| `channel_message` | **No** sender pubkey. Synthetic dispatch id only. | Decoded text view only. |
+| `contact_message` | 12-hex `pubkey_prefix` (6 bytes) | Partial identity only. |
+
+Channel text is therefore identity-blind, and DM text is identity-partial. Node name and location are only ever set by `rx_log_data` frames that the companion was able to decode as `ADVERT`. Any storage model that assumes "every incoming frame names its sender" or "every sender carries a full pubkey at observation time" will not match what the radio actually emits.
+
+The previous backend-migration plan (parent plan §0.5) proposed `mc_pubkey` + `mc_pubkey_hash` (1-byte secondary, "indexed"). The captures show no such hash field on the wire; if we want one we have to compute it client-side, and a 1-byte hash carries no useful selectivity for a single-country mesh.
+
+## Decision
+
+1. **Add `ObservedNode.protocol`** (`IntegerChoices`, `MESHTASTIC=1`, `MESHCORE=2`, indexed). One row per `(protocol, identity)` pair.
+2. **MC primary identity = `mc_pubkey`**, `CharField(max_length=64)`, lowercase hex, nullable. Unique within `protocol=MESHCORE` (partial unique index). Populated whenever we observe a full pubkey: `advertisement.public_key`, `path_update.public_key`, `discover_response.pubkey`, `rx_log_data.adv_key`.
+3. **Secondary identity = `mc_pubkey_prefix`**, `CharField(max_length=12)`, lowercase hex, nullable, **indexed**. Mirrors the on-wire `contact_message.pubkey_prefix` (12 hex chars = 6 bytes). For rows with a full key this is just the first 12 hex of `mc_pubkey`; for prefix-only sightings it is the only identity we have.
+4. **Drop `mc_pubkey_hash`** from the migration plan. Not on the wire, not needed once `mc_pubkey_prefix` is indexed.
+5. **MT-side `node_id` becomes nullable** when `protocol != MESHTASTIC`. Add a row-level CHECK:
+   - `protocol = MESHTASTIC` ⇒ `node_id IS NOT NULL`
+   - `protocol = MESHCORE` ⇒ `mc_pubkey IS NOT NULL OR mc_pubkey_prefix IS NOT NULL`
+6. **`node_id_str` becomes a protocol-aware computed display**: `!{hex8}` for MT, `mc:{first 12 hex}` for MC (matches the convention already used in `meshflow-bot/src/meshcore/radio.py`). No DB column — computed in the model / serializer.
+7. **Node metadata enrichment is ADVERT-driven, not identity-event-driven.** `long_name`, `short_name`, position fields, and any `role`/flags equivalent are only updated when an MC packet receiver sees an `rx_log_data` frame whose decoder expanded an `ADVERT` payload. `advertisement` / `path_update` / `discover_response` only ever touch identity columns and `last_heard`; they never overwrite name/position.
+8. **Prefix-stub reconciliation.** Prefix-only sightings (today only DM text — `contact_message`) follow this rule:
+   - Look up `ObservedNode` where `mc_pubkey LIKE '<prefix>%'` OR `mc_pubkey_prefix = '<prefix>'`.
+   - **Exactly one match** ⇒ update `last_heard` on that row. Done.
+   - **Zero matches** ⇒ insert a "prefix stub" row with `mc_pubkey = NULL` and `mc_pubkey_prefix = <prefix>`.
+   - **Multiple matches** ⇒ leave the existing rows untouched, attach the observation to a prefix-stub row (insert if missing). Reconcile later when a full-pubkey sighting disambiguates.
+   - When a full-pubkey sighting arrives whose first 12 hex match an existing stub row, **merge** the stub into the full-pubkey row (move `PacketObservation` / `last_heard`, delete the stub). Idempotent.
+
+```mermaid
+flowchart LR
+  Sighting["MC sighting"] --> HasFull{"have full pubkey?"}
+  HasFull -->|"yes"| Upsert["upsert ObservedNode by mc_pubkey"]
+  HasFull -->|"no"| Prefix["lookup by mc_pubkey_prefix"]
+  Prefix --> Match{"unique match?"}
+  Match -->|"yes"| Touch["update last_heard"]
+  Match -->|"no / none"| Stub["upsert prefix-stub ObservedNode"]
+  Upsert --> Merge["merge any matching prefix-stubs<br/>into the full-pubkey row"]
+```
+
+## Consequences
+
+- **First-sight nodes are nameless.** A node we first observe via channel text won't appear in `ObservedNode` at all (no identity). A node first observed via DM text appears as a prefix stub with no name/position. Name and position only appear once we hear that node's `ADVERT` frame. The UI must tolerate "MC node with no name yet".
+- **Possible prefix collisions.** 6-byte prefixes are not collision-free over an infinite population, but for a single-country mesh (hundreds to low thousands of nodes) collisions are unlikely. The "multiple matches ⇒ stub" rule fails safe (no false merge), and the operator can resolve stubs later from the admin UI.
+- **`ObservedNode` cardinality grows slightly** by the number of distinct DM-text senders we never get an `ADVERT` for. Acceptable; each prefix stub is one row.
+- **Channel text leaves no identity trail.** This is a protocol limitation, not a modelling choice. `channel_message` rows will be stored against `MeshCoreRawPacket` (Phase 1) but won't create or update `ObservedNode`.
+- **Migration impact.** Making MT `node_id` nullable is a non-trivial schema change on a hot table; Phase 1 must run it during a maintenance window and provide a rollback migration. Pre-flight on a prod-sized DB clone.
+- **Out of scope for this ADR:** how managed-node ownership (`ManagedNode.protocol`, `ManagedNode.mc_pubkey`) and API-key binding work. Phase 1 design ticket will cover that and reuse this identity contract.
+
+## Evidence
+
+Sample files in this repo (one per shape):
+
+- [`docs/packets/meshcore/advertisement/20260506_211140_430432.json`](../../../packets/meshcore/advertisement/20260506_211140_430432.json) — pubkey-only advert event.
+- [`docs/packets/meshcore/path_update/20260506_205759_895381.json`](../../../packets/meshcore/path_update/20260506_205759_895381.json) — pubkey-only routing update.
+- [`docs/packets/meshcore/discover_response/20260506_211530_400913.json`](../../../packets/meshcore/discover_response/20260506_211530_400913.json) — full pubkey + `tag` + `node_type`.
+- [`docs/packets/meshcore/rx_log_data_advert.json`](../../../packets/meshcore/rx_log_data_advert.json) — the only sample carrying `adv_name` / `adv_lat` / `adv_lon` / `signature`.
+- [`docs/packets/meshcore/contact_message/20260506_205758_541689.json`](../../../packets/meshcore/contact_message/20260506_205758_541689.json) — prefix-only DM sender.
+- [`docs/packets/meshcore/channel_message/20260507_094921_075978.json`](../../../packets/meshcore/channel_message/20260507_094921_075978.json) — no sender identity at all.
+
+Field reference: [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md) (`advertisement`, `contact_message`, `discover_response`, `rx_log_data` optional ADVERT fields).
+
+Full capture tree: [`meshflow-bot/docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets).

--- a/docs/features/packet-ingestion/adr/0002-mc-channel-modelling.md
+++ b/docs/features/packet-ingestion/adr/0002-mc-channel-modelling.md
@@ -1,0 +1,53 @@
+# ADR-0002 — MeshCore channel modelling
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+
+## Context
+
+Meshtastic models channels as a fixed-size, named, ordered slot table on each radio. The API mirrors this with `MessageChannel` plus eight `ManagedNode.channel_0..channel_7` foreign keys, and `PacketObservation.channel` resolves a packet's channel index against the observer's slot table.
+
+MeshCore does not have an equivalent on-wire concept. From the Phase 0.4 captures (see [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md)):
+
+- `channel_message` carries `payload.channel_idx` (zero-based integer) and `path_hash_mode` / `path_len`, but **no channel name and no channel hash**.
+- No other event in the bundle (`advertisement`, `path_update`, `discover_response`, `rx_log_data`, `contact_message`, `control_data`, `trace_data`, `messages_waiting`) carries any channel-related identifier.
+- MC channel names ("Public", "Galloway", etc.) are an operator/configuration concept on the companion device; they are not transmitted.
+
+The earlier plan proposed `MessageChannel.mc_channel_hash`. We have no on-wire evidence for one in this firmware (1.15.0). Adding a column we never populate produces dead schema; deferring it costs nothing because the index is the dispatch key.
+
+We still need a way to:
+
+- Resolve `(observer, channel_idx)` → a `MessageChannel` row for `PacketObservation`.
+- Associate `ManagedNode` rows with the channels they participate in, since MC has no fixed 0..7 slot mapping.
+
+## Decision
+
+1. **Add `MessageChannel.protocol`** (same enum as `ObservedNode.protocol`). Channels are single-protocol; an MT channel and an MC channel are distinct rows even if their names happen to match.
+2. **MC channel identifiers on `MessageChannel`:**
+   - `mc_channel_idx` — `PositiveSmallIntegerField`, nullable. Zero-based index as seen in `channel_message.channel_idx`.
+   - `name` — existing operator-set string (no change). For MC, populated out of band (admin UI / config) since the wire carries no name.
+3. **Defer `mc_channel_hash`.** Revisit if/when a firmware revision starts emitting one on the wire. No column added now.
+4. **Replace the fixed `channel_0..channel_7` slots, for MC managed nodes, with an M2M:**
+   - `ManagedNode.mc_channels` — `ManyToManyField(MessageChannel, related_name='managed_nodes_mc', blank=True)`.
+   - The existing `channel_0..channel_7` FKs stay MT-only and untouched. Single-protocol managed nodes only use one or the other side; the model does not need a CHECK constraint here because the existing `ManagedNode.protocol` (Phase 1) already determines which side is populated.
+5. **Channel resolution on `PacketObservation` stays an FK to `MessageChannel`.** For MC packets, the serializer resolves the channel as:
+   - look up the observer `ManagedNode`,
+   - filter `observer.mc_channels.filter(mc_channel_idx=<idx>)`,
+   - if not found, auto-create a `MessageChannel` row with `protocol=MESHCORE`, `mc_channel_idx=<idx>`, `name=f"MC channel {idx}"`, and attach it to the observer's `mc_channels`. An operator can rename it later.
+6. **Uniqueness:** `UniqueConstraint(fields=['protocol', 'mc_channel_idx', 'constellation'])` where applicable (matches the existing constellation-scoped uniqueness pattern on MT channels). MC channels are scoped to a constellation just like MT ones — channel index 0 in Scotland is not the same row as channel index 0 in another constellation.
+
+## Consequences
+
+- **Operators name MC channels manually.** No automatic name discovery (none on the wire); the auto-created `"MC channel N"` placeholder is good enough until someone updates it.
+- **No backfill needed** for existing data — MC is greenfield in this codebase.
+- **`mc_channels` M2M lets a managed node "subscribe" to an arbitrary subset of MC channels**, which fits the protocol better than 8 fixed slots. UI and admin screens for `ManagedNode` need a small per-protocol branch.
+- **If MC firmware later adds a channel hash on the wire**, we can add `mc_channel_hash` and a matching unique constraint without touching the dispatch path — `channel_idx` continues to be the primary dispatch key.
+- **Risk:** auto-creating `MessageChannel` rows on first sight could pollute the table if an attacker sends bogus channel indices via a compromised observer. Mitigation: limit to indices `0..63` (MC's plausible range) and require channel rows to be attached to the **observer's** `mc_channels` only on packets the observer authenticated for — which they already are.
+- **Out of scope:** UI for managing `mc_channels` per managed node; covered in Phase 1.7 (UI ticket).
+
+## Evidence
+
+- [`docs/packets/meshcore/channel_message/20260507_094921_075978.json`](../../../packets/meshcore/channel_message/20260507_094921_075978.json) — shows `channel_idx`, no name, no hash.
+- [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md) — `channel_message` section.
+- Absence: grepping the Phase 0.4 capture tree ([`meshflow-bot/docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets)) for `channel_hash`, `channel_name`, or `chan_id` returns no matches.

--- a/docs/features/packet-ingestion/adr/0003-mc-broadcast-semantics.md
+++ b/docs/features/packet-ingestion/adr/0003-mc-broadcast-semantics.md
@@ -1,0 +1,59 @@
+# ADR-0003 — MeshCore broadcast vs directed semantics
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+
+## Context
+
+Meshtastic represents broadcast destinations with the sentinel value `to_int == 0xFFFFFFFF`. The API and downstream features (text messages, traceroute, mesh monitoring, DX) rely on that single sentinel to distinguish a broadcast from a directed transmission.
+
+MeshCore has no such sentinel. From the Phase 0.4 captures (see [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md)):
+
+- `channel_message` (`type=CHAN`) — group/channel text. Carries `channel_idx`, `path_hash_mode`, `path_len`, `txt_type`, `sender_timestamp`, `text`. **Does not carry any destination identifier.** Every channel_message is implicitly a broadcast on that channel.
+- `contact_message` (`type=PRIV`) — DM text. Carries `pubkey_prefix` of the **sender** (12-hex) plus body. **No destination field either**, because the local companion received it; the destination is "me" (the connected radio).
+- `rx_log_data` — route metadata: `route_type` (numeric) and `route_typename` (`FLOOD`, `TC_FLOOD`, `DIRECT`). These describe **how the frame is forwarded**, not who it is for. A `DIRECT` can be unicast or a fragment of a flood; a `FLOOD` can still carry a directed payload (the radio still forwards it to neighbours).
+- No event in the bundle carries a `to_pubkey` or `to_pubkey_hash` field.
+
+We therefore need an unambiguous, capture-supported way to mark "this on-air transmission was a broadcast" without inventing wire fields. We also want to avoid baking the MT sentinel pattern into MC schema (no `0xFFFF...` magic value over a key field that has no defined width on the wire).
+
+## Decision
+
+1. **`MeshCoreRawPacket.to_pubkey`** — `CharField(max_length=64)`, hex, nullable. Set only when the wire / decoded event names a specific recipient. **In Phase 0.4 captures this is always `NULL`.**
+2. **`MeshCoreRawPacket.to_pubkey_prefix`** — `CharField(max_length=12)`, hex, nullable. Same rule.
+3. **Broadcast indicator = absence.** A row is broadcast iff `to_pubkey IS NULL AND to_pubkey_prefix IS NULL`. **No sentinel value is introduced.** Code that asks "is this a broadcast?" reads:
+
+   ```python
+   is_broadcast = packet.to_pubkey is None and packet.to_pubkey_prefix is None
+   ```
+
+4. **Per-event mapping (Phase 1):**
+
+   | MC event / decode | Stored as | Direction |
+   | --- | --- | --- |
+   | `channel_message` (`type=CHAN`) | `MeshCoreTextPacket` with `to_pubkey = NULL` and the resolved `MessageChannel` FK | broadcast |
+   | `contact_message` (`type=PRIV`) | `MeshCoreTextPacket` with `to_pubkey_prefix = <observer's own pubkey prefix>` | directed (to us) |
+   | `rx_log_data` (`TEXT_MSG`, `ADVERT`, `PATH`, `REQ`, `CONTROL`, …) | `MeshCoreRawPacket`; `to_pubkey*` only populated if the decoded payload exposes a recipient | usually broadcast (advert, path, control); directed for `REQ`/`RESP` if the decoder yields one |
+
+5. **`route_type` / `route_typename` are preserved** on `MeshCoreRawPacket` as descriptive columns (`route_type` IntegerChoices, `route_typename` CharField for forward-compat). They are **not** used as the broadcast indicator. The names are stored to keep raw-log inspection useful without a lookup table; downstream code should branch on `route_type` (the integer) when needed.
+6. **`MessageChannel` FK on the observation** stays the way a broadcast is *attributed* to a channel. A broadcast `channel_message` has `to_pubkey IS NULL` AND `MeshCorePacketObservation.channel` set. A directed `contact_message` has `to_pubkey_prefix` set AND `MeshCorePacketObservation.channel = NULL` (DM has no channel).
+7. **Cross-protocol query convenience.** For mixed-protocol surfaces (UI, stats), the protocol-agnostic broadcast predicate is:
+   - MT: `to_int == 0xFFFFFFFF`
+   - MC: `to_pubkey IS NULL AND to_pubkey_prefix IS NULL`
+
+   Expose this as an `is_broadcast` `@property` on each raw-packet model, and as a `BooleanField`-style annotation on serializers, rather than a stored column. Avoid leaking the MT sentinel into MC code paths.
+
+## Consequences
+
+- **No sentinel magic for MC.** Future firmware that does add a recipient field can populate `to_pubkey*` without a schema break. The "broadcast == NULL" rule continues to hold.
+- **`is_broadcast` is a derived value** in two places (one per protocol). The risk of drift is small because each protocol's model owns its own predicate; cross-protocol code uses a tiny helper rather than a shared column.
+- **`route_typename` is informational, not a contract.** Downstream apps must not branch on the string. If we later need a stable enum, we already have `route_type` (the integer).
+- **DM-to-someone-else.** In the rare case the local companion observes a DM addressed to a different node (unusual on MC because PRIV is decrypted locally to "me"), the serializer leaves `to_pubkey*` `NULL`. We choose "unknown directed recipient" over inventing one. Phase 2 may revisit if we see such events in the wild.
+- **Out of scope:** ACK / REQ / RESP recipient extraction — depends on Phase 2 subclass decoders. ADR-0003 only commits to the storage shape; those subclasses will populate `to_pubkey*` when their decoders produce one.
+
+## Evidence
+
+- [`docs/packets/meshcore/channel_message/20260507_094921_075978.json`](../../../packets/meshcore/channel_message/20260507_094921_075978.json) — no destination field; only `channel_idx`.
+- [`docs/packets/meshcore/contact_message/20260506_205758_541689.json`](../../../packets/meshcore/contact_message/20260506_205758_541689.json) — `pubkey_prefix` is the sender, not the recipient.
+- [`docs/packets/meshcore/rx_log_data_text.json`](../../../packets/meshcore/rx_log_data_text.json), [`rx_log_data_advert.json`](../../../packets/meshcore/rx_log_data_advert.json), [`rx_log_data_path.json`](../../../packets/meshcore/rx_log_data_path.json), [`rx_log_data_req.json`](../../../packets/meshcore/rx_log_data_req.json), [`rx_log_data_control.json`](../../../packets/meshcore/rx_log_data_control.json) — `route_type` / `route_typename` present; no recipient field on any of them.
+- Field reference: [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md) (`channel_message`, `contact_message`, `rx_log_data`).

--- a/docs/features/packet-ingestion/adr/0004-mc-dedup-key.md
+++ b/docs/features/packet-ingestion/adr/0004-mc-dedup-key.md
@@ -1,0 +1,54 @@
+# ADR-0004 — MeshCore deduplication key
+
+**Status:** Proposed
+**Date:** 2026-05-12
+**Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+
+## Context
+
+Meshtastic ingestion deduplicates on `(from_int, packet_id, rx_time window)` — see [`DEDUPLICATION.md`](../DEDUPLICATION.md). The window (`PACKET_DEDUP_WINDOW_MINUTES`, default 10) collapses observations of the same on-air transmission heard by multiple feeders into one `RawPacket` plus N `PacketObservation` rows.
+
+MeshCore has no `packet_id` and no consistent sender id on every event. The Phase 0.4 captures (see [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md)) show:
+
+- **`rx_log_data` carries a `pkt_hash`** — a 32-bit-ish integer derived by the radio decoder from the frame's contents. Sample: `"pkt_hash": 808099514` in [`docs/packets/meshcore/rx_log_data_text.json`](../../../packets/meshcore/rx_log_data_text.json). Every `rx_log_data` sample in the bundle has one.
+- **Decoded text events (`channel_message`, `contact_message`) do not carry `pkt_hash`.** They are the radio's "I already decoded this for you" view of an `rx_log_data` it just processed. The companion typically emits both — an `rx_log_data` for the raw frame **and** a decoded `channel_message` / `contact_message` for the human-readable payload.
+- **`advertisement`, `path_update`, `discover_response`, `control_data`, `messages_waiting`, `trace_data`** carry no `pkt_hash` either, but they are not directly comparable to `rx_log_data` — they are different `event_type`s of decoder output, not duplicates of the same wire frame.
+
+The previous backend-migration plan proposed `(from_pubkey_hash, packet_hash, rx_time window)`. With ADR-0001 dropping `from_pubkey_hash` (not on the wire, replaced by `mc_pubkey_prefix` for identity), the proposed key becomes redundant on its second component: the wire `pkt_hash` is already derived from the sender + payload bytes by the radio decoder.
+
+## Decision
+
+1. **Primary MC dedup key:** `(pkt_hash, rx_time window)`.
+   - `pkt_hash` is the on-wire identifier exposed by `rx_log_data.pkt_hash`. Stored on `MeshCoreRawPacket.pkt_hash` (`BigIntegerField`, indexed; widened from 32-bit because MC may flip the sign bit in JSON).
+   - No `from_pubkey*` component. Two unrelated senders producing the same `pkt_hash` within the dedup window would collide, but `pkt_hash` is wide enough (~32 bits of entropy over decoded frame bytes) that the birthday probability over a country-mesh's traffic rate is negligible. We accept the residual risk; the dedup window bounds the impact to ≤ `MESHCORE_PACKET_DEDUP_WINDOW_MINUTES` of one frame.
+2. **Window env var:** `MESHCORE_PACKET_DEDUP_WINDOW_MINUTES`, default `10`. Same default as MT for operator familiarity. Documented in `docs/ENV_VARS.md` (Phase 1 task).
+3. **Match semantics** (mirrors `find_existing_packet` for MT):
+   - Same `pkt_hash`.
+   - Incoming `rx_time` within `window` of the existing row's `first_reported_time`.
+   - Match ⇒ insert `MeshCorePacketObservation` against the existing `MeshCoreRawPacket`. No new raw row.
+   - No match (or out of window) ⇒ insert a new `MeshCoreRawPacket` and its first observation.
+   - Same `(observer, packet)` twice ⇒ idempotent; no second observation row.
+4. **Decoded twins (`channel_message`, `contact_message`):**
+   - These do not have `pkt_hash` from the companion, but they are a decoded view of an `rx_log_data` the companion *just* emitted (typically within the same callback tick).
+   - **Storage rule:** `rx_log_data` is the authoritative `MeshCoreRawPacket` row. Decoded text events are stored as a `MeshCoreTextPacket` subclass row (Phase 1) **linked** to the raw row when we can match them, or stand-alone when we cannot.
+   - **Matching decoded → raw** is best-effort: within a short window (default `MESHCORE_DECODED_TWIN_WINDOW_SECONDS = 5`), look back at recent `rx_log_data` rows from the same observer where `payload_typename = TEXT_MSG` and the decoded payload bytes are a substring of `rx_log_data.payload`. If a match is found, set `MeshCoreTextPacket.raw_packet_fk = <that raw row>`. If not, leave the FK null. **This match is informational, not part of dedup.**
+   - **Decoded-only dedup:** the dedup key for a decoded event with no `pkt_hash` falls back to `(event_type, sha256(canonical payload), rx_time window)` to prevent counting the same decoded twin twice if the companion emits it twice. Stored as `MeshCoreRawPacket.surrogate_hash` (nullable BigInt). Only one of `pkt_hash` or `surrogate_hash` is set on a given row; a partial unique index enforces this.
+5. **Non-text non-`rx_log_data` events** (`advertisement`, `path_update`, `discover_response`, `control_data`, `messages_waiting`, `trace_data`) follow the same surrogate-hash rule: their dedup key is `(event_type, sha256(canonical payload), rx_time window)`. These are infrequent enough that the collision risk of the surrogate hash is irrelevant in practice.
+6. **Per-observer idempotency** (same as MT): `MeshCorePacketObservation` has a unique constraint on `(packet, observer)` so retries from the bot never create duplicates.
+
+## Consequences
+
+- **`pkt_hash` is signed in JSON.** The sample shows a positive value, but the companion's encoding can produce values outside the `int32` positive range. Store as `BigIntegerField` and treat as opaque. Do not reinterpret the sign.
+- **Cross-protocol dedup is impossible**, and we do not attempt it. An MT and an MC packet are never "the same" packet for dedup purposes — they are different protocols on different radios.
+- **Decoded-twin linkage is best-effort.** Phase 1 ships with the matching helper; if it misses, the decoded text row exists without a raw FK and we still have the data. Phase 2 can revisit using `sender_timestamp` + observer correlation if the simple substring match proves too lossy.
+- **No `from_pubkey_hash` index needed** for dedup. Identity indexes (`mc_pubkey`, `mc_pubkey_prefix`) are owned by ADR-0001 and serve identity queries, not dedup lookups.
+- **Operational tuning:** as with MT, `MESHCORE_PACKET_DEDUP_WINDOW_MINUTES` is the single knob. We expect identical default behaviour because the on-air retransmit cadences are comparable; if Phase 1 acceptance shows otherwise, tune per-protocol.
+- **Out of scope:** cross-environment dedup (prod + pre-prod). MT already keeps these separate per instance (see `DEDUPLICATION.md`); MC follows the same rule.
+
+## Evidence
+
+- [`docs/packets/meshcore/rx_log_data_text.json`](../../../packets/meshcore/rx_log_data_text.json) — `"pkt_hash": 808099514`, `route_typename: "FLOOD"`, `payload_typename: "TEXT_MSG"`.
+- [`docs/packets/meshcore/rx_log_data_advert.json`](../../../packets/meshcore/rx_log_data_advert.json), [`rx_log_data_path.json`](../../../packets/meshcore/rx_log_data_path.json), [`rx_log_data_req.json`](../../../packets/meshcore/rx_log_data_req.json), [`rx_log_data_control.json`](../../../packets/meshcore/rx_log_data_control.json) — all carry `pkt_hash`.
+- [`docs/packets/meshcore/channel_message/20260507_094921_075978.json`](../../../packets/meshcore/channel_message/20260507_094921_075978.json), [`contact_message/20260506_205758_541689.json`](../../../packets/meshcore/contact_message/20260506_205758_541689.json) — no `pkt_hash`; decoded views only.
+- Field reference: [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md) (`rx_log_data` common fields — `pkt_hash`).
+- MT contract for comparison: [`DEDUPLICATION.md`](../DEDUPLICATION.md).

--- a/docs/features/packet-ingestion/adr/README.md
+++ b/docs/features/packet-ingestion/adr/README.md
@@ -1,0 +1,38 @@
+# Architecture Decision Records — MeshCore packet ingestion
+
+Lightweight ADRs for MeshCore (MC) ingestion and modelling, scoped under packet ingestion. They are **proposed** until merged; reviewer feedback may change individual decisions.
+
+**Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276) (epic [meshflow-api#264](https://github.com/pskillen/meshflow-api/issues/264)).
+
+**Evidence:** cite JSON under [`docs/packets/meshcore/`](../../../packets/meshcore/README.md) and field tables in [`MESHCORE_PACKET_FIELDS.md`](../MESHCORE_PACKET_FIELDS.md).
+
+## Index
+
+Planned records (add the matching Markdown file in this directory when the ADR is drafted):
+
+| File | Title |
+| --- | ----- |
+| `0001-mc-node-identity.md` | MeshCore node identity (`ObservedNode`, pubkey / prefix, ADVERT enrichment) |
+| `0002-mc-channel-modelling.md` | MeshCore channel modelling (`MessageChannel`, indices, managed node mapping) |
+| `0003-mc-broadcast-semantics.md` | Broadcast vs directed semantics (MT vs MC on the wire) |
+| `0004-mc-dedup-key.md` | Deduplication key for MC (`pkt_hash`, windows, decoded twins) |
+
+## ADR format (use in each `NNNN-title.md`)
+
+Keep each ADR short. Use the following section headings in order:
+
+### Context
+
+What forces the decision: constraints, capture findings, compatibility with Meshtastic (MT) ingestion, open questions.
+
+### Decision
+
+What we will do (or not do), in plain language. Bullet points are fine.
+
+### Consequences
+
+Trade-offs, follow-up work, risks, and what stays out of scope.
+
+### Evidence
+
+Pointers to this repo: e.g. `docs/packets/meshcore/...` sample files and relevant rows in `MESHCORE_PACKET_FIELDS.md`. The full Phase 0.4 capture tree remains in **meshflow-bot** [`docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets).

--- a/docs/packets/meshcore/README.md
+++ b/docs/packets/meshcore/README.md
@@ -1,0 +1,23 @@
+# MeshCore representative samples (API-side)
+
+One JSON file per **visible shape** from the Phase 0.4 capture campaign, copied from **meshflow-bot** for citation in ADRs and reviews without vendoring the full capture tree.
+
+**Provenance:** Full bundle, inventory, and filenames live in [meshflow-bot `docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets) (see the “Representative samples” table in that README). Files here match those paths unless noted.
+
+| Shape | Path in this repo |
+| ----- | ----------------- |
+| Advertisement | [`advertisement/20260506_211140_430432.json`](advertisement/20260506_211140_430432.json) |
+| Channel text (`CHAN`) | [`channel_message/20260507_094921_075978.json`](channel_message/20260507_094921_075978.json) |
+| Contact / DM (`PRIV`) | [`contact_message/20260506_205758_541689.json`](contact_message/20260506_205758_541689.json) |
+| Control | [`control_data/20260506_211530_400099.json`](control_data/20260506_211530_400099.json) |
+| Discover response | [`discover_response/20260506_211530_400913.json`](discover_response/20260506_211530_400913.json) |
+| Messages waiting | [`messages_waiting/20260506_205758_540343.json`](messages_waiting/20260506_205758_540343.json) |
+| Path update | [`path_update/20260506_205759_895381.json`](path_update/20260506_205759_895381.json) |
+| RX log — `TEXT_MSG` | [`rx_log_data_text.json`](rx_log_data_text.json) |
+| RX log — `ADVERT` (decoded) | [`rx_log_data_advert.json`](rx_log_data_advert.json) |
+| RX log — `PATH` | [`rx_log_data_path.json`](rx_log_data_path.json) |
+| RX log — `REQ` | [`rx_log_data_req.json`](rx_log_data_req.json) |
+| RX log — `CONTROL` | [`rx_log_data_control.json`](rx_log_data_control.json) |
+| Trace data | [`trace_data/20260507_154102_445613.json`](trace_data/20260507_154102_445613.json) |
+
+Field tables: [`docs/features/packet-ingestion/MESHCORE_PACKET_FIELDS.md`](../../features/packet-ingestion/MESHCORE_PACKET_FIELDS.md).

--- a/docs/packets/meshcore/advertisement/20260506_211140_430432.json
+++ b/docs/packets/meshcore/advertisement/20260506_211140_430432.json
@@ -1,0 +1,10 @@
+{
+  "protocol": "meshcore",
+  "event_type": "advertisement",
+  "payload": {
+    "public_key": "f3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc"
+  },
+  "attributes": {
+    "public_key": "f3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc"
+  }
+}

--- a/docs/packets/meshcore/channel_message/20260507_094921_075978.json
+++ b/docs/packets/meshcore/channel_message/20260507_094921_075978.json
@@ -1,0 +1,17 @@
+{
+  "protocol": "meshcore",
+  "event_type": "channel_message",
+  "payload": {
+    "type": "CHAN",
+    "channel_idx": 0,
+    "path_hash_mode": 2,
+    "path_len": 2,
+    "txt_type": 0,
+    "sender_timestamp": 1778147355,
+    "text": "tinker_tam base: LoftPi: Galloway telemetry failed; mesh amber; power GRID; CPU 51.5'C"
+  },
+  "attributes": {
+    "channel_idx": 0,
+    "txt_type": 0
+  }
+}

--- a/docs/packets/meshcore/contact_message/20260506_205758_541689.json
+++ b/docs/packets/meshcore/contact_message/20260506_205758_541689.json
@@ -1,0 +1,17 @@
+{
+  "protocol": "meshcore",
+  "event_type": "contact_message",
+  "payload": {
+    "type": "PRIV",
+    "pubkey_prefix": "e563a2e933ce",
+    "path_hash_mode": 1,
+    "path_len": 0,
+    "txt_type": 0,
+    "sender_timestamp": 1778101079,
+    "text": "Hi"
+  },
+  "attributes": {
+    "pubkey_prefix": "e563a2e933ce",
+    "txt_type": 0
+  }
+}

--- a/docs/packets/meshcore/control_data/20260506_211530_400099.json
+++ b/docs/packets/meshcore/control_data/20260506_211530_400099.json
@@ -1,0 +1,14 @@
+{
+  "protocol": "meshcore",
+  "event_type": "control_data",
+  "payload": {
+    "SNR": -0.5,
+    "RSSI": -112,
+    "path_len": 0,
+    "payload_type": 146,
+    "payload": "921299a13ecaf3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc"
+  },
+  "attributes": {
+    "payload_type": 146
+  }
+}

--- a/docs/packets/meshcore/discover_response/20260506_211530_400913.json
+++ b/docs/packets/meshcore/discover_response/20260506_211530_400913.json
@@ -1,0 +1,18 @@
+{
+  "protocol": "meshcore",
+  "event_type": "discover_response",
+  "payload": {
+    "SNR": -0.5,
+    "RSSI": -112,
+    "path_len": 0,
+    "node_type": 2,
+    "SNR_in": 4.5,
+    "tag": "99a13eca",
+    "pubkey": "f3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc"
+  },
+  "attributes": {
+    "node_type": 2,
+    "tag": "99a13eca",
+    "pubkey": "f3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc"
+  }
+}

--- a/docs/packets/meshcore/messages_waiting/20260506_205758_540343.json
+++ b/docs/packets/meshcore/messages_waiting/20260506_205758_540343.json
@@ -1,0 +1,6 @@
+{
+  "protocol": "meshcore",
+  "event_type": "messages_waiting",
+  "payload": {},
+  "attributes": {}
+}

--- a/docs/packets/meshcore/path_update/20260506_205759_895381.json
+++ b/docs/packets/meshcore/path_update/20260506_205759_895381.json
@@ -1,0 +1,10 @@
+{
+  "protocol": "meshcore",
+  "event_type": "path_update",
+  "payload": {
+    "public_key": "e563a2e933ce8c930d8e2a6b80d648b4993fdb2536181eb8202d7bf9bfff880e"
+  },
+  "attributes": {
+    "public_key": "e563a2e933ce8c930d8e2a6b80d648b4993fdb2536181eb8202d7bf9bfff880e"
+  }
+}

--- a/docs/packets/meshcore/rx_log_data_advert.json
+++ b/docs/packets/meshcore/rx_log_data_advert.json
@@ -1,0 +1,39 @@
+{
+  "protocol": "meshcore",
+  "event_type": "rx_log_data",
+  "payload": {
+    "raw_hex": "fd901014170000866f82ef610e706a88206edc9b4cd741f3bcf176cb8acf637a617782a677716218a5dcb2964f3c852df100e647aab943f1620902b0fb69fe7ece37c5b56f78d82da3a9b9843bba7826ebfb307c4b96126da1451310659449f0d76b901162081be084d39e7cdf11ed6eab17a221ef0f05f6a7d51ed78a0d9200000000000000006268642d746573742d66726f6f64",
+    "recv_time": 1778102299,
+    "snr": -0.75,
+    "rssi": -112,
+    "payload": "1014170000866f82ef610e706a88206edc9b4cd741f3bcf176cb8acf637a617782a677716218a5dcb2964f3c852df100e647aab943f1620902b0fb69fe7ece37c5b56f78d82da3a9b9843bba7826ebfb307c4b96126da1451310659449f0d76b901162081be084d39e7cdf11ed6eab17a221ef0f05f6a7d51ed78a0d9200000000000000006268642d746573742d66726f6f64",
+    "payload_length": 147,
+    "header": 16,
+    "route_type": 0,
+    "route_typename": "TC_FLOOD",
+    "payload_type": 4,
+    "payload_typename": "ADVERT",
+    "payload_ver": 0,
+    "transport_code": "14170000",
+    "path_len": 6,
+    "path_hash_size": 3,
+    "path": "6f82ef610e706a88206edc9b4cd741f3bcf1",
+    "pkt_payload": "76cb8acf637a617782a677716218a5dcb2964f3c852df100e647aab943f1620902b0fb69fe7ece37c5b56f78d82da3a9b9843bba7826ebfb307c4b96126da1451310659449f0d76b901162081be084d39e7cdf11ed6eab17a221ef0f05f6a7d51ed78a0d9200000000000000006268642d746573742d66726f6f64",
+    "pkt_hash": 2361064815,
+    "adv_name": "bhd-test-frood",
+    "adv_key": "76cb8acf637a617782a677716218a5dcb2964f3c852df100e647aab943f16209",
+    "adv_timestamp": 1778102274,
+    "signature": "fe7ece37c5b56f78d82da3a9b9843bba7826ebfb307c4b96126da1451310659449f0d76b901162081be084d39e7cdf11ed6eab17a221ef0f05f6a7d51ed78a0d",
+    "adv_flags": 146,
+    "adv_type": 2,
+    "adv_lat": 0.0,
+    "adv_lon": 0.0
+  },
+  "attributes": {
+    "recv_time": 1778102299,
+    "route_type": 0,
+    "payload_type": 4,
+    "path_len": 6,
+    "path": "6f82ef610e706a88206edc9b4cd741f3bcf1"
+  }
+}

--- a/docs/packets/meshcore/rx_log_data_control.json
+++ b/docs/packets/meshcore/rx_log_data_control.json
@@ -1,0 +1,30 @@
+{
+  "protocol": "meshcore",
+  "event_type": "rx_log_data",
+  "payload": {
+    "raw_hex": "fe902e00921299a13ecaf3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc",
+    "recv_time": 1778102130,
+    "snr": -0.5,
+    "rssi": -112,
+    "payload": "2e00921299a13ecaf3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc",
+    "payload_length": 40,
+    "header": 46,
+    "route_type": 2,
+    "route_typename": "DIRECT",
+    "payload_type": 11,
+    "payload_typename": "CONTROL",
+    "payload_ver": 0,
+    "path_len": 0,
+    "path_hash_size": 1,
+    "path": "",
+    "pkt_payload": "921299a13ecaf3bcf18b78deee33596d29d49aa6891d30ac6e2c97e7e6a9b81907f1470afcfc",
+    "pkt_hash": 2648484388
+  },
+  "attributes": {
+    "recv_time": 1778102130,
+    "route_type": 2,
+    "payload_type": 11,
+    "path_len": 0,
+    "path": ""
+  }
+}

--- a/docs/packets/meshcore/rx_log_data_path.json
+++ b/docs/packets/meshcore/rx_log_data_path.json
@@ -1,0 +1,31 @@
+{
+  "protocol": "meshcore",
+  "event_type": "rx_log_data",
+  "payload": {
+    "raw_hex": "0090201c33000081f3bcf19670d51ac9b0808be3f0caca2a3243fe80e92372",
+    "recv_time": 1778102115,
+    "snr": 0.0,
+    "rssi": -112,
+    "payload": "201c33000081f3bcf19670d51ac9b0808be3f0caca2a3243fe80e92372",
+    "payload_length": 29,
+    "header": 32,
+    "route_type": 0,
+    "route_typename": "TC_FLOOD",
+    "payload_type": 8,
+    "payload_typename": "PATH",
+    "payload_ver": 0,
+    "transport_code": "1c330000",
+    "path_len": 1,
+    "path_hash_size": 3,
+    "path": "f3bcf1",
+    "pkt_payload": "9670d51ac9b0808be3f0caca2a3243fe80e92372",
+    "pkt_hash": 3138934464
+  },
+  "attributes": {
+    "recv_time": 1778102115,
+    "route_type": 0,
+    "payload_type": 8,
+    "path_len": 1,
+    "path": "f3bcf1"
+  }
+}

--- a/docs/packets/meshcore/rx_log_data_req.json
+++ b/docs/packets/meshcore/rx_log_data_req.json
@@ -1,0 +1,31 @@
+{
+  "protocol": "meshcore",
+  "event_type": "rx_log_data",
+  "payload": {
+    "raw_hex": "ef8f00d56800008270929ff3bcf16a96128f55f5805391374b46955f9fc17c4045cb",
+    "recv_time": 1778102178,
+    "snr": -4.25,
+    "rssi": -113,
+    "payload": "00d56800008270929ff3bcf16a96128f55f5805391374b46955f9fc17c4045cb",
+    "payload_length": 32,
+    "header": 0,
+    "route_type": 0,
+    "route_typename": "TC_FLOOD",
+    "payload_type": 0,
+    "payload_typename": "REQ",
+    "payload_ver": 0,
+    "transport_code": "d5680000",
+    "path_len": 2,
+    "path_hash_size": 3,
+    "path": "70929ff3bcf1",
+    "pkt_payload": "6a96128f55f5805391374b46955f9fc17c4045cb",
+    "pkt_hash": 2594296151
+  },
+  "attributes": {
+    "recv_time": 1778102178,
+    "route_type": 0,
+    "payload_type": 0,
+    "path_len": 2,
+    "path": "70929ff3bcf1"
+  }
+}

--- a/docs/packets/meshcore/rx_log_data_text.json
+++ b/docs/packets/meshcore/rx_log_data_text.json
@@ -1,0 +1,30 @@
+{
+  "protocol": "meshcore",
+  "event_type": "rx_log_data",
+  "payload": {
+    "raw_hex": "31d509401ae56383d7fa65703f498a938926a544d4edd5cb",
+    "recv_time": 1778101078,
+    "snr": 12.25,
+    "rssi": -43,
+    "payload": "09401ae56383d7fa65703f498a938926a544d4edd5cb",
+    "payload_length": 22,
+    "header": 9,
+    "route_type": 1,
+    "route_typename": "FLOOD",
+    "payload_type": 2,
+    "payload_typename": "TEXT_MSG",
+    "payload_ver": 0,
+    "path_len": 0,
+    "path_hash_size": 2,
+    "path": "",
+    "pkt_payload": "1ae56383d7fa65703f498a938926a544d4edd5cb",
+    "pkt_hash": 808099514
+  },
+  "attributes": {
+    "recv_time": 1778101078,
+    "route_type": 1,
+    "payload_type": 2,
+    "path_len": 0,
+    "path": ""
+  }
+}

--- a/docs/packets/meshcore/trace_data/20260507_154102_445613.json
+++ b/docs/packets/meshcore/trace_data/20260507_154102_445613.json
@@ -1,0 +1,23 @@
+{
+  "protocol": "meshcore",
+  "event_type": "trace_data",
+  "payload": {
+    "tag": 1743129214,
+    "auth": 0,
+    "flags": 0,
+    "path_len": 1,
+    "path": [
+      {
+        "hash": "f3",
+        "snr": -9.75
+      },
+      {
+        "snr": -3.25
+      }
+    ]
+  },
+  "attributes": {
+    "tag": 1743129214,
+    "auth_code": 0
+  }
+}


### PR DESCRIPTION
# Summary

MeshCore Phase 0.5 — ADRs (docs-only PR).

Lands the four MeshCore (MC) ingestion design decisions in `docs/features/packet-ingestion/adr/`, informed by the Phase 0.4 capture campaign (6 days, South Scotland, firmware 1.15.0). No code, model, endpoint, or `openapi.yaml` changes — those land in Phase 1 (#265).

Closes #276 (epic #264).

What's in this PR:

- **`docs/features/packet-ingestion/MESHCORE_PACKET_FIELDS.md`** — capture-verified field reference. Derivative of the bot bundle at [meshflow-bot/docs/meshcore_packets/](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets); the bot copy stays the provenance anchor tied to the raw capture tree.
- **`docs/packets/meshcore/`** — one representative JSON per event shape (advertisement, channel_message, contact_message, control_data, discover_response, messages_waiting, path_update, rx_log_data ×5 decoded shapes, trace_data). Used as cite-targets from the ADRs.
- **`docs/features/packet-ingestion/adr/`** — ADR directory with a short README + lightweight template.
  - **ADR-0001 — MC node identity:** `ObservedNode.protocol` discriminator; primary id `mc_pubkey` (full 32-byte Ed25519), secondary `mc_pubkey_prefix` (12 hex chars, indexed). **Drops `mc_pubkey_hash`** (not on the wire). Node name and position only ever flow from `rx_log_data` frames decoded as `ADVERT`. Prefix-stub reconciliation rule covers DM text where the sender is only a 12-hex prefix.
  - **ADR-0002 — MC channel modelling:** `MessageChannel.protocol` + nullable `mc_channel_idx`. Defers `mc_channel_hash` (none seen). Replaces fixed `channel_0..7` slots, for MC managed nodes, with an `mc_channels` M2M. Auto-creates `"MC channel N"` placeholders on first sight with an operator-rename path.
  - **ADR-0003 — Broadcast semantics:** MC broadcast indicator is **absence of recipient** (`to_pubkey IS NULL AND to_pubkey_prefix IS NULL`). No sentinel value introduced (no MC equivalent of MT's `0xFFFFFFFF`). `route_typename` (`FLOOD`/`DIRECT`/`TC_FLOOD`) is preserved as descriptive, not as the broadcast indicator.
  - **ADR-0004 — Dedup key:** `(pkt_hash, rx_time window)` using `rx_log_data.pkt_hash` (stored as `BigIntegerField` to accommodate signed-in-JSON values). New env `MESHCORE_PACKET_DEDUP_WINDOW_MINUTES` (default 10, matches MT). Decoded-twin (`channel_message` / `contact_message`) handling and a surrogate-hash fallback for events that have no `pkt_hash`.
- **`docs/features/packet-ingestion/README.md`** — adds a "MeshCore (Phase 0.5 — design only)" subsection linking to the field reference, ADR index, and sample bundle.

## Background

Phase 0.4 capture campaign surfaced two facts that reshape the original migration plan:

1. **Node metadata is not in identity events.** `advertisement`, `path_update`, and `discover_response` carry only a pubkey; name and position live exclusively inside `rx_log_data` frames where the decoder was able to expand an `ADVERT` payload (`adv_name`, `adv_lat`, `adv_lon`, `signature`). Channel text frames carry no sender pubkey at all; DM text carries only a 12-hex (6-byte) prefix. ADR-0001 documents how `ObservedNode` rows are reconciled across these partial sightings.
2. **`pkt_hash` is the only universal per-frame identifier**, and it's only on `rx_log_data`. The originally proposed `from_pubkey_hash + packet_hash` key drops to just `pkt_hash` (ADR-0004), with a surrogate hash for events that don't carry one.

No manual steps required for pre-prod / prod — this is a docs-only change.

## Testing performed

- Markdown link sanity-check across the new files (no new lint warnings; three pre-existing `MD012/no-multiple-blanks` warnings in `README.md` left untouched).
- ADRs cross-reference the sample JSONs that were also added in this PR (relative paths verified).
- No code touched; no test suite changes.