### PR TITLE
chore(admin): MeshCore-aware Django admin filters and lists

### DIFF
--- a/Meshflow/constellations/admin.py
+++ b/Meshflow/constellations/admin.py
@@ -20,6 +20,7 @@ class ConstellationAdmin(admin.ModelAdmin):
     form = ConstellationAdminForm
     list_display = (
         "name",
+        "protocol",
         "created_by",
         "get_member_count",
         "get_admin_count",
@@ -28,12 +29,12 @@ class ConstellationAdmin(admin.ModelAdmin):
         "bot_default_ignore_portnums",
         "bot_default_hop_limit",
     )
-    list_filter = ("created_by",)
+    list_filter = (("protocol", admin.ChoicesFieldListFilter), "created_by")
     search_fields = ("name", "description", "created_by__username", "created_by__email")
     ordering = ("name",)
     readonly_fields = ("created_by",)
     fieldsets = (
-        (None, {"fields": ("name", "description", "created_by", "map_color")}),
+        (None, {"fields": ("name", "description", "protocol", "created_by", "map_color")}),
         (
             _("Bot setup defaults"),
             {
@@ -125,7 +126,11 @@ class ConstellationUserMembershipAdmin(admin.ModelAdmin):
 
 @admin.register(MessageChannel)
 class MessageChannelAdmin(admin.ModelAdmin):
-    list_display = ("id", "name", "constellation")
-    list_filter = ("constellation",)
+    list_display = ("id", "name", "protocol", "mc_channel_idx", "constellation")
+    list_filter = (
+        ("protocol", admin.ChoicesFieldListFilter),
+        "constellation",
+        ("mc_channel_idx", admin.EmptyFieldListFilter),
+    )
     search_fields = ("name", "id")
     ordering = ("name",)

--- a/Meshflow/meshcore_packets/admin.py
+++ b/Meshflow/meshcore_packets/admin.py
@@ -1,22 +1,60 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 
+from common.protocol import Protocol
 from meshcore_packets.models import MeshCorePacketObservation, MeshCoreRawPacket, MeshCoreTextPacket
+from nodes.models import ManagedNode
+
+
+class MeshCoreObserverFilter(admin.SimpleListFilter):
+    """Filter packets/observations by feeder (ManagedNode)."""
+
+    title = _("Observer feeder")
+    parameter_name = "observer"
+
+    def lookups(self, request, model_admin):
+        qs = (
+            ManagedNode.objects.filter(protocol=Protocol.MESHCORE, deleted_at__isnull=True)
+            .select_related("constellation")
+            .order_by("name")[:50]
+        )
+        return [(str(n.internal_id), f"{n.name} ({n.constellation.name})") for n in qs]
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(observer_id=self.value())
+        return queryset
 
 
 @admin.register(MeshCoreRawPacket)
 class MeshCoreRawPacketAdmin(admin.ModelAdmin):
     list_display = ("id", "event_type", "payload_type", "from_pubkey_prefix", "rx_time", "observer")
-    list_filter = ("payload_type", "event_type")
-    search_fields = ("from_pubkey", "from_pubkey_prefix")
+    list_filter = (
+        "payload_type",
+        "event_type",
+        MeshCoreObserverFilter,
+        "observer__constellation",
+        ("from_pubkey", admin.EmptyFieldListFilter),
+    )
+    search_fields = ("from_pubkey", "from_pubkey_prefix", "observer__name")
     readonly_fields = ("id", "first_reported_time")
+    list_select_related = ("observer", "observer__constellation")
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("observer", "observer__constellation")
 
 
 @admin.register(MeshCoreTextPacket)
 class MeshCoreTextPacketAdmin(admin.ModelAdmin):
-    list_display = ("id", "payload_type", "text", "channel", "rx_time")
-    search_fields = ("text",)
+    list_display = ("id", "payload_type", "text", "channel", "rx_time", "observer")
+    list_filter = ("payload_type", MeshCoreObserverFilter, "observer__constellation")
+    search_fields = ("text", "observer__name")
+    list_select_related = ("observer", "channel")
 
 
 @admin.register(MeshCorePacketObservation)
 class MeshCorePacketObservationAdmin(admin.ModelAdmin):
     list_display = ("id", "packet", "observer", "rx_time", "upload_time")
+    list_filter = (MeshCoreObserverFilter, "observer__constellation")
+    list_select_related = ("packet", "observer", "observer__constellation")
+    date_hierarchy = "upload_time"

--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -11,6 +11,25 @@ from common.protocol import Protocol
 
 from .models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, NodeLatestStatus, ObservedNode
 
+
+class ManagedNodeActiveFilter(admin.SimpleListFilter):
+    title = _("Feeder status")
+    parameter_name = "feeder_active"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("active", _("Active")),
+            ("deleted", _("Soft-deleted")),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "active":
+            return queryset.filter(deleted_at__isnull=True)
+        if self.value() == "deleted":
+            return queryset.filter(deleted_at__isnull=False)
+        return queryset
+
+
 MANAGED_NODE_COMMON_FIELDS = (
     "protocol",
     "node_id",
@@ -21,6 +40,64 @@ MANAGED_NODE_COMMON_FIELDS = (
     "latlong",
 )
 MANAGED_NODE_CHANNEL_FIELDS = tuple(f"channel_{i}" for i in range(8))
+
+
+class ProtocolListFilter(admin.SimpleListFilter):
+    """Filter rows by mesh protocol (Meshtastic / MeshCore)."""
+
+    title = _("Protocol")
+    parameter_name = "protocol"
+
+    def lookups(self, request, model_admin):
+        return Protocol.choices
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(protocol=int(self.value()))
+        return queryset
+
+
+class MeshCoreObservedIdentityFilter(admin.SimpleListFilter):
+    """MeshCore ObservedNode rows by identity completeness (ADR-0001)."""
+
+    title = _("MeshCore identity")
+    parameter_name = "mc_identity"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("full", _("Full pubkey")),
+            ("prefix_stub", _("Prefix stub only")),
+            ("no_identity", _("Missing pubkey and prefix")),
+        )
+
+    def queryset(self, request, queryset):
+        mc = queryset.filter(protocol=Protocol.MESHCORE)
+        if self.value() == "full":
+            return mc.filter(mc_pubkey__isnull=False)
+        if self.value() == "prefix_stub":
+            return mc.filter(mc_pubkey__isnull=True, mc_pubkey_prefix__isnull=False)
+        if self.value() == "no_identity":
+            return mc.filter(mc_pubkey__isnull=True, mc_pubkey_prefix__isnull=True)
+        return queryset
+
+
+class ApiKeyLinkedProtocolFilter(admin.SimpleListFilter):
+    """Node API keys that have at least one linked ManagedNode of a protocol."""
+
+    title = _("Linked feeder protocol")
+    parameter_name = "linked_protocol"
+
+    def lookups(self, request, model_admin):
+        return Protocol.choices
+
+    def queryset(self, request, queryset):
+        if not self.value():
+            return queryset
+        protocol = int(self.value())
+        return queryset.filter(
+            node_links__node__protocol=protocol,
+            node_links__node__deleted_at__isnull=True,
+        ).distinct()
 
 
 class CopyToClipboardWidget(forms.Widget):
@@ -364,7 +441,9 @@ class ManagedNodeAdmin(admin.ModelAdmin):
         "status_last_packet_ingested_at",
     )
     list_filter = (
-        "protocol",
+        ProtocolListFilter,
+        ("constellation__protocol", admin.ChoicesFieldListFilter),
+        ManagedNodeActiveFilter,
         "owner",
         "constellation",
         "allow_auto_traceroute",
@@ -428,9 +507,13 @@ class ManagedNodeStatusAdmin(admin.ModelAdmin):
         "is_sending_data",
         "updated_at",
     )
-    list_select_related = ("node", "node__owner")
-    list_filter = ("is_sending_data",)
-    search_fields = ("node__name", "node__node_id")
+    list_select_related = ("node", "node__owner", "node__constellation")
+    list_filter = (
+        "is_sending_data",
+        ("node__protocol", admin.ChoicesFieldListFilter),
+        "node__constellation",
+    )
+    search_fields = ("node__name", "node__node_id", "node__owner__username")
     readonly_fields = (
         "node",
         "last_packet_ingested_at",
@@ -461,6 +544,7 @@ class NodeAPIKeyAdmin(admin.ModelAdmin):
     )
     list_filter = (
         "constellation",
+        ApiKeyLinkedProtocolFilter,
         "owner",
         "is_active",
     )
@@ -531,12 +615,15 @@ class NodeLatestStatusInline(admin.StackedInline):
 class ObservedNodeAdmin(admin.ModelAdmin):
     inlines = [NodeLatestStatusInline]
     list_display = (
+        "protocol",
         "short_name",
         "long_name",
         "node_id",
         "node_id_str",
+        "mc_pubkey_prefix",
         "hw_model",
         "get_inferred_max_hops",
+        "last_heard",
         "environment_exposure",
         "weather_use",
         "claimed_by",
@@ -548,17 +635,22 @@ class ObservedNodeAdmin(admin.ModelAdmin):
 
     get_inferred_max_hops.short_description = "Inferred max hops"
     list_filter = (
+        ProtocolListFilter,
+        MeshCoreObservedIdentityFilter,
         "hw_model",
         "environment_exposure",
         "weather_use",
         "claimed_by",
         "role",
+        ("last_heard", admin.EmptyFieldListFilter),
     )
     search_fields = (
         "short_name",
         "long_name",
         "node_id",
         "node_id_str",
+        "mc_pubkey",
+        "mc_pubkey_prefix",
         "mac_addr",
         "hw_model",
         "public_key",
@@ -566,28 +658,38 @@ class ObservedNodeAdmin(admin.ModelAdmin):
     )
     readonly_fields = (
         "internal_id",
+        "protocol",
         "node_id",
         "node_id_str",
         "mac_addr",
         "public_key",
         "role",
+        "last_heard",
     )
 
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("claimed_by", "latest_status")
+
     def get_fields(self, request, obj=None):
-        """Show all fields for observed nodes."""
-        fields = [
+        common = [
+            "protocol",
             "node_id",
-            "mac_addr",
+            "node_id_str",
             "long_name",
             "short_name",
-            "hw_model",
-            "public_key",
+            "last_heard",
             "environment_exposure",
             "weather_use",
             "claimed_by",
             "role",
         ]
-        return fields
+        if obj and obj.protocol == Protocol.MESHCORE:
+            return common + ["mc_pubkey", "mc_pubkey_prefix"]
+        return common + [
+            "mac_addr",
+            "hw_model",
+            "public_key",
+        ]
 
 
 # NOTE: You need to create the template file for NodeIdDatalistWidget at:


### PR DESCRIPTION
## Summary

- **Constellations admin:** show/filter by `protocol`; expose `protocol` on constellation fieldsets; MessageChannel admin lists `protocol` and `mc_channel_idx` with protocol-aware filters.
- **Nodes admin:** protocol list filters for managed/observed nodes and API keys; MeshCore identity filter on observed nodes; feeder active filter; MC-specific fieldsets and pubkey fields; richer `ManagedNodeStatus` / `NodeAPIKey` list filters.
- **MeshCore packets admin:** observer feeder filter (MeshCore `ManagedNode`), constellation filters, and `select_related` for operator list views.

Part of epic [#265](https://github.com/pskillen/meshflow-api/issues/265) (MeshCore Phase 1).

## Testing performed

- `black`, `isort`, `flake8` on the three admin modules (clean).
- No runtime/admin UI smoke test in this PR (config-only admin changes).