### PR TITLE
docs(api): OpenAPI contract alignment for Meshtastic paths (SP-01 #308)

### DIFF
--- a/docs/features/meshcore/implementation-plan.md
+++ b/docs/features/meshcore/implementation-plan.md
@@ -2,6 +2,8 @@
 
 This file is the **single cross-repo index** for the MeshCore and related multi-protocol work. **Each epic or phase should add its own dated section** below; do not rewrite prior sections except to fix factual errors.
 
+**Rename / relabelling track:** Sub-plans in `IdeaProjects/MeshFlow/.cursor/plans/` ([index](file:///Users/patricks/IdeaProjects/MeshFlow/.cursor/plans/meshcore-rename-index.plan.md)). GitHub: sub-epic [#307](https://github.com/pskillen/meshflow-api/issues/307) under [#266](https://github.com/pskillen/meshflow-api/issues/266). Progress: [`refactoring-progress.md`](./refactoring-progress.md).
+
 **Convention for contributors**
 
 - Add a new `##` section with a clear phase name, **completion date (or “in progress”)**, and **repos touched**.

--- a/docs/features/meshcore/refactoring-progress.md
+++ b/docs/features/meshcore/refactoring-progress.md
@@ -18,7 +18,7 @@ Living tracker for the [rename audit index](file:///Users/patricks/IdeaProjects/
 
 | ID | Sub-plan | Repos | PRs | Status | Issue | PR |
 |----|----------|-------|-----|--------|-------|-----|
-| SP-01 | OpenAPI contract docs | api | 1 | in_progress | [#308](https://github.com/pskillen/meshflow-api/issues/308) | |
+| SP-01 | OpenAPI contract docs | api | 1 | in_progress | [#308](https://github.com/pskillen/meshflow-api/issues/308) | [#320](https://github.com/pskillen/meshflow-api/pull/320) |
 | SP-02 | Comment-only labelling | api, bot, ui | 1–3 | not_started | [#309](https://github.com/pskillen/meshflow-api/issues/309) | |
 | SP-03 | `node_id` → `meshtastic_node_id` | api, bot, ui | 1 (coordinated) | not_started | [#310](https://github.com/pskillen/meshflow-api/issues/310) | |
 | SP-04 | ObservedNode MT identity fields | api, ui | 1 | not_started | [#312](https://github.com/pskillen/meshflow-api/issues/312) | |

--- a/docs/features/meshcore/refactoring-progress.md
+++ b/docs/features/meshcore/refactoring-progress.md
@@ -1,0 +1,92 @@
+# MeshCore / multi-protocol — refactoring progress (rename & labelling)
+
+Living tracker for the [rename audit index](file:///Users/patricks/IdeaProjects/MeshFlow/.cursor/plans/meshcore-rename-index.plan.md) sub-plans.
+
+**Sub-plans:** `IdeaProjects/MeshFlow/.cursor/plans/` · **Sub-epic:** [#307](https://github.com/pskillen/meshflow-api/issues/307) (parent [#266](https://github.com/pskillen/meshflow-api/issues/266))
+
+**Update this file in every PR** that executes a sub-plan (even doc-only PRs).
+
+**Convention**
+
+- Status: `not_started` | `in_progress` | `merged` | `deferred`
+- Link the GitHub issue when filed; link the PR when opened.
+- After merge, set status to `merged` and note the merge commit or PR number.
+
+---
+
+## Sub-plan index
+
+| ID | Sub-plan | Repos | PRs | Status | Issue | PR |
+|----|----------|-------|-----|--------|-------|-----|
+| SP-01 | OpenAPI contract docs | api | 1 | in_progress | [#308](https://github.com/pskillen/meshflow-api/issues/308) | |
+| SP-02 | Comment-only labelling | api, bot, ui | 1–3 | not_started | [#309](https://github.com/pskillen/meshflow-api/issues/309) | |
+| SP-03 | `node_id` → `meshtastic_node_id` | api, bot, ui | 1 (coordinated) | not_started | [#310](https://github.com/pskillen/meshflow-api/issues/310) | |
+| SP-04 | ObservedNode MT identity fields | api, ui | 1 | not_started | [#312](https://github.com/pskillen/meshflow-api/issues/312) | |
+| SP-05 | MtRawPacket wire + observations | api | 1 | not_started | [#311](https://github.com/pskillen/meshflow-api/issues/311) | |
+| SP-06 | ManagedNode channels + constellation bot defaults | api, ui | 1 | not_started | [#313](https://github.com/pskillen/meshflow-api/issues/313) | |
+| SP-07 | TextMessage MT fields | api, ui | 1 | not_started | [#314](https://github.com/pskillen/meshflow-api/issues/314) | |
+| SP-08 | NodeLatestStatus / metrics MT columns | api | 1 | not_started | [#315](https://github.com/pskillen/meshflow-api/issues/315) | |
+| SP-09 | UI client branding | ui | 1 | not_started | [#316](https://github.com/pskillen/meshflow-api/issues/316) | |
+| SP-10 | Bot local naming | bot | 1 | not_started | [#317](https://github.com/pskillen/meshflow-api/issues/317) | |
+| SP-11 | ObservedNode lookup by `internal_id` | api, ui | 1 | deferred | [#318](https://github.com/pskillen/meshflow-api/issues/318) | |
+
+Parent index: [meshcore-rename-index](file:///Users/patricks/IdeaProjects/MeshFlow/.cursor/plans/meshcore-rename-index.plan.md) · Phase context: [implementation-plan.md](./implementation-plan.md)
+
+---
+
+## Per-step notes (append as work lands)
+
+### SP-01 — OpenAPI contract docs
+
+- **Merged:** —
+- **Notes:** OpenAPI drift fix (#308): `/packets/{node_id}/ingest|nodes/`; `ObservedNode.internal_id` UUID; Meshtastic-only notes on device-metrics bulk, nested observed-node metrics, `/stats/nodes/{node_id}/*`; legacy **Packets** tag points to **Meshtastic packets**.
+
+### SP-02 — Comment-only labelling
+
+- **Merged:** —
+- **Notes:**
+
+### SP-03 — `meshtastic_node_id`
+
+- **Merged:** —
+- **Notes:**
+
+### SP-04 — ObservedNode MT identity fields
+
+- **Merged:** —
+- **Notes:**
+
+### SP-05 — Packet wire fields
+
+- **Merged:** —
+- **Notes:**
+
+### SP-06 — Channels + constellation
+
+- **Merged:** —
+- **Notes:**
+
+### SP-07 — Text messages
+
+- **Merged:** —
+- **Notes:**
+
+### SP-08 — Metrics columns
+
+- **Merged:** —
+- **Notes:**
+
+### SP-09 — UI branding
+
+- **Merged:** —
+- **Notes:**
+
+### SP-10 — Bot local naming
+
+- **Merged:** —
+- **Notes:**
+
+### SP-11 — Lookup `internal_id` (deferred)
+
+- **Merged:** —
+- **Notes:**

--- a/docs/features/meshcore/refactoring-progress.md
+++ b/docs/features/meshcore/refactoring-progress.md
@@ -39,7 +39,7 @@ Parent index: [meshcore-rename-index](file:///Users/patricks/IdeaProjects/MeshFl
 ### SP-01 — OpenAPI contract docs
 
 - **Merged:** —
-- **Notes:** OpenAPI drift fix (#308): `/packets/{node_id}/ingest|nodes/`; `ObservedNode.internal_id` UUID; Meshtastic-only notes on device-metrics bulk, nested observed-node metrics, `/stats/nodes/{node_id}/*`; legacy **Packets** tag points to **Meshtastic packets**.
+- **Notes:** OpenAPI drift fix (#308): `/packets/{node_id}/ingest|nodes/`; `ObservedNode.internal_id` UUID; Meshtastic-only notes on device-metrics bulk, nested observed-node metrics, `/stats/nodes/{node_id}/*`; legacy **Packets** tag; deprecated `POST /raw-packet/`; observed-node detail `node_id` Meshtastic-only (+ MeshCore via list until #318). Follow-up v1 retirement: API [#319](https://github.com/pskillen/meshflow-api/issues/319), bot [#95](https://github.com/pskillen/meshflow-bot/issues/95).
 
 ### SP-02 — Comment-only labelling
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3420,6 +3420,38 @@ paths:
         '503':
           description: Discord API or bot token misconfiguration
 
+  /raw-packet/:
+    post:
+      deprecated: true
+      summary: Ingest a packet (legacy v1)
+      description: >
+        **Deprecated.** Meshtastic bots should use ``POST /packets/{node_id}/ingest/`` instead
+        (v2 ingest; observer nodenum in the path). This URL is still used by meshtastic-bot when
+        ``api_version`` is 1 (``/api/raw-packet/``). It is not registered in the current Django
+        urlconf; production stacks may proxy it to the v2 ingest route or run an older API build.
+      tags: [Meshtastic packets]
+      security:
+        - NodeApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IncomingPacket'
+      responses:
+        '201':
+          description: Packet ingested successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Success'
+        '400':
+          description: Invalid packet data
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /packets/{node_id}/ingest/:
     post:
       summary: Ingest a Meshtastic packet
@@ -4314,6 +4346,10 @@ paths:
   /nodes/observed-nodes/{node_id}/:
     get:
       summary: Get observed node details
+      description: >
+        Detail lookup by Meshtastic numeric ``node_id`` (``ObservedNode.node_id``). For MeshCore
+        nodes, use ``GET /nodes/observed-nodes/?protocol=meshcore`` (and search) until lookup by
+        ``internal_id`` is added ([#318](https://github.com/pskillen/meshflow-api/issues/318)).
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4323,6 +4359,7 @@ paths:
           required: true
           schema:
             type: integer
+          description: Meshtastic numeric node id (detail routes); not MeshCore pubkey or ``internal_id``
       responses:
         '200':
           description: Node details
@@ -4333,6 +4370,7 @@ paths:
 
     put:
       summary: Update observed node
+      description: Path ``node_id`` is the Meshtastic numeric id; see GET for MeshCore lookup limits.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4342,6 +4380,7 @@ paths:
           required: true
           schema:
             type: integer
+          description: Meshtastic numeric node id (detail routes); not MeshCore pubkey or ``internal_id``
       requestBody:
         required: true
         content:
@@ -4358,6 +4397,7 @@ paths:
 
     delete:
       summary: Delete observed node
+      description: Path ``node_id`` is the Meshtastic numeric id; see GET for MeshCore lookup limits.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4367,6 +4407,7 @@ paths:
           required: true
           schema:
             type: integer
+          description: Meshtastic numeric node id (detail routes); not MeshCore pubkey or ``internal_id``
       responses:
         '204':
           description: Node deleted successfully

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -21,7 +21,9 @@ tags:
   - name: MeshCore packets
     description: MeshCore packet ingestion (Node API key) and read-only packet list
   - name: Packets
-    description: Legacy tag name; prefer Meshtastic packets for /api/packets operations
+    description: >
+      Legacy tag name retained for compatibility. All Meshtastic packet ingestion and feeder
+      node upsert operations use the **Meshtastic packets** tag and live under ``/api/packets/{node_id}/``.
   - name: Constellations
     description: Constellation management endpoints
   - name: Nodes
@@ -1001,8 +1003,9 @@ components:
         but may also be manually added by a listener system.
       properties:
         internal_id:
-          type: integer
-          description: The internal ID of the observed node
+          type: string
+          format: uuid
+          description: Stable primary key (UUID) for this observed node
         protocol:
           $ref: '#/components/schemas/MeshProtocol'
           description: Mesh protocol for this observed node
@@ -3417,15 +3420,23 @@ paths:
         '503':
           description: Discord API or bot token misconfiguration
 
-  /packets/ingest/:
+  /packets/{node_id}/ingest/:
     post:
-      summary: Ingest a packet
+      summary: Ingest a Meshtastic packet
       description: >
-        Node bots should send incoming packets to this endpoint. The endpoint will automatically
-        identify the packet type and process it accordingly.
+        Meshtastic feeder bots POST incoming packets here. The path ``node_id`` is the observer's
+        Meshtastic numeric node number and must match the authenticated ManagedNode. The endpoint
+        identifies the packet type and processes it accordingly.
       tags: [Meshtastic packets]
       security:
         - NodeApiKeyAuth: []
+      parameters:
+        - name: node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Meshtastic numeric node id of the observer (feeder)
       requestBody:
         required: true
         content:
@@ -3508,18 +3519,23 @@ paths:
         '200':
           description: Paginated MeshCore raw packets
 
-  /packets/nodes/:
+  /packets/{node_id}/nodes/:
     post:
-      summary: Upsert node information
+      summary: Upsert observed node (feeder)
       description: >
-        Node bots should send node information updates to this endpoint. The endpoint will automatically
-        match the node information to an existing node, or create a new node if it doesn't exist.
-
-        This endpoint is similar to the /nodes/observed-nodes endpoint, but is specifically used by
-        node bots, and is authenticated with a Node API Key.
+        Meshtastic feeder bots upsert observed-node rows via this endpoint. The path ``node_id`` is
+        the observer's Meshtastic numeric node number and must match the authenticated ManagedNode.
+        Similar to ``/nodes/observed-nodes/`` but scoped to Node API key auth for bots.
       tags: [Meshtastic packets]
       security:
         - NodeApiKeyAuth: []
+      parameters:
+        - name: node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Meshtastic numeric node id of the observer (feeder)
       requestBody:
         required: true
         content:
@@ -4086,6 +4102,7 @@ paths:
     get:
       summary: Bulk device metrics for multiple nodes
       description: >
+        Meshtastic-only: ``node_ids`` are Meshtastic numeric node numbers (``ObservedNode.node_id``).
         Get device metrics (battery, channel utilisation, uptime) for multiple nodes in one request.
         Returns flat list; frontend groups by node_id for per-node charts.
         Reusable by Infrastructure, Monitor, My Nodes pages.
@@ -4146,7 +4163,8 @@ paths:
           description: Invalid request (e.g. missing node_ids)
     post:
       summary: Bulk device metrics (POST)
-      description: Same as GET but with node_ids, start_date, end_date in request body
+      description: >
+        Meshtastic-only: same as GET; ``node_ids`` in the body are Meshtastic numeric node numbers.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4160,6 +4178,7 @@ paths:
                   type: array
                   items:
                     type: integer
+                  description: Meshtastic numeric node ids
                 start_date:
                   type: string
                   format: date-time
@@ -4385,7 +4404,9 @@ paths:
   /nodes/observed-nodes/{node_id}/device_metrics/:
     get:
       summary: Get device metrics for a specific node
-      description: Returns a list of device metrics for a specific node with optional date filtering
+      description: >
+        Meshtastic-only: path ``node_id`` is the Meshtastic numeric node number (``ObservedNode.node_id``).
+        Returns device metrics for that node with optional date filtering.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4415,7 +4436,9 @@ paths:
   /nodes/observed-nodes/{node_id}/environment_metrics/:
     get:
       summary: Get environment metrics for a specific node
-      description: Returns a list of environment metrics for a specific node with optional date filtering
+      description: >
+        Meshtastic-only: path ``node_id`` is the Meshtastic numeric node number (``ObservedNode.node_id``).
+        Returns environment metrics for that node with optional date filtering.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4445,7 +4468,9 @@ paths:
   /nodes/observed-nodes/{node_id}/power_metrics/:
     get:
       summary: Get power metrics for a specific node
-      description: Returns a list of power metrics for a specific node with optional date filtering
+      description: >
+        Meshtastic-only: path ``node_id`` is the Meshtastic numeric node number (``ObservedNode.node_id``).
+        Returns power metrics for that node with optional date filtering.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -5152,7 +5177,9 @@ paths:
   /stats/nodes/{node_id}/packets/:
     get:
       summary: Get packet stats for a specific node
-      description: Returns the packet stats for a specific node with optional date filtering
+      description: >
+        Meshtastic-only: ``node_id`` is the Meshtastic numeric node number. Aggregates
+        ``MtRawPacket`` traffic sent by that node (excludes self-only device-metric observations).
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -5196,7 +5223,9 @@ paths:
   /stats/nodes/{node_id}/received/:
     get:
       summary: Get received packet stats for a specific node
-      description: Returns statistics for packets received/heard by a specific node over time intervals
+      description: >
+        Meshtastic-only: ``node_id`` is the Meshtastic numeric node number. Statistics for
+        packets heard by that node (via ``PacketObservation``) over time intervals.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -5241,8 +5270,9 @@ paths:
     get:
       summary: Get neighbour stats for a managed node
       description: >
-        Returns packet counts grouped by source node (direct sender or last-hop relay)
-        for packets received by the specified managed node.
+        Meshtastic-only: ``node_id`` is the Meshtastic numeric node number of the managed/observed
+        node. Returns packet counts grouped by source (direct sender or last-hop relay) for
+        Meshtastic packets received by that node.
       tags: [Nodes]
       security:
         - BearerAuth: []


### PR DESCRIPTION
## Summary

Align `openapi.yaml` with current Django Meshtastic routes and document protocol scope for the meshcore rename (SP-01, no migrations).

- Fix packet ingest paths: `POST /packets/{node_id}/ingest/` and `/packets/{node_id}/nodes/` (was unscoped `/packets/ingest/` and `/packets/nodes/`)
- `ObservedNode.internal_id`: `string` + `format: uuid` (was integer)
- Meshtastic-only notes on device-metrics bulk, nested observed-node metrics, and `/stats/nodes/{node_id}/*`
- Legacy **Packets** OpenAPI tag points to **Meshtastic packets**
- Deprecated `POST /raw-packet/` documented for v1 bots (not in current urlconf)
- Observed-node detail routes: `node_id` is Meshtastic numeric id; MeshCore clients use list + `protocol` until #318
- Progress tracker updated; follow-up v1 retirement tracked in #319 / meshflow-bot#95

Closes #308

## Testing performed

- [x] Manual review: `packets/` paths in OpenAPI match `Meshflow/packets/urls.py` + `Meshflow/urls.py` mount
- [x] No `makemigrations` / model changes