### PR TITLE
feat(nodes): bot version reporting for managed feeders

### DIFF
--- a/Meshflow/nodes/migrations/0042_managednode_bot_version.py
+++ b/Meshflow/nodes/migrations/0042_managednode_bot_version.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0041_rename_metrics_meshtastic_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="managednode",
+            name="bot_version",
+            field=models.CharField(
+                blank=True,
+                help_text="Last meshflow-bot version reported by this feeder on connect.",
+                max_length=128,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="managednode",
+            name="bot_version_reported_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="When bot_version was last reported by the feeder.",
+                null=True,
+            ),
+        ),
+    ]

--- a/Meshflow/nodes/models.py
+++ b/Meshflow/nodes/models.py
@@ -140,6 +140,18 @@ class ManagedNode(models.Model):
         help_text=_("If True, this node may be used for auto-scheduled traceroutes and manual triggers."),
     )
 
+    bot_version = models.CharField(
+        max_length=128,
+        null=True,
+        blank=True,
+        help_text=_("Last meshflow-bot version reported by this feeder on connect."),
+    )
+    bot_version_reported_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text=_("When bot_version was last reported by the feeder."),
+    )
+
     deleted_at = models.DateTimeField(
         null=True,
         blank=True,

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -393,6 +393,8 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             "constellation_id",
             "constellation",
             "allow_auto_traceroute",
+            "bot_version",
+            "bot_version_reported_at",
             "position",
             "device_metrics",
             "latest_environment_metrics",
@@ -416,6 +418,8 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             "node_id_str",
             "owner",
             "constellation",
+            "bot_version",
+            "bot_version_reported_at",
         ]
 
     STATUS_FIELDS = (

--- a/Meshflow/packets/tests/test_bot_version_report.py
+++ b/Meshflow/packets/tests/test_bot_version_report.py
@@ -1,0 +1,65 @@
+from django.urls import reverse
+
+import pytest
+from rest_framework.test import APIClient
+
+from nodes.models import NodeAuth
+
+
+@pytest.mark.django_db
+def test_bot_version_put_updates_managed_node(create_managed_node, create_node_api_key):
+    managed_node = create_managed_node(meshtastic_node_id=42424242)
+    api_key = create_node_api_key(owner=managed_node.owner, constellation=managed_node.constellation)
+    NodeAuth.objects.create(api_key=api_key, node=managed_node)
+
+    client = APIClient()
+    url = reverse("meshtastic-bot-version", kwargs={"node_id": managed_node.meshtastic_node_id})
+    response = client.put(
+        url,
+        {"bot_version": "2.1.0"},
+        format="json",
+        HTTP_X_API_KEY=api_key.key,
+    )
+
+    assert response.status_code == 200
+    assert response.data["bot_version"] == "2.1.0"
+    managed_node.refresh_from_db()
+    assert managed_node.bot_version == "2.1.0"
+    assert managed_node.bot_version_reported_at is not None
+
+
+@pytest.mark.django_db
+def test_bot_version_denied_for_unlinked_node(create_managed_node, create_node_api_key):
+    managed_node = create_managed_node(meshtastic_node_id=11111111)
+    other_node = create_managed_node(meshtastic_node_id=22222222)
+    api_key = create_node_api_key(owner=managed_node.owner, constellation=managed_node.constellation)
+    NodeAuth.objects.create(api_key=api_key, node=managed_node)
+
+    client = APIClient()
+    url = reverse("meshtastic-bot-version", kwargs={"node_id": other_node.meshtastic_node_id})
+    response = client.put(
+        url,
+        {"bot_version": "2.1.0"},
+        format="json",
+        HTTP_X_API_KEY=api_key.key,
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_bot_version_blank_rejected(create_managed_node, create_node_api_key):
+    managed_node = create_managed_node(meshtastic_node_id=33333333)
+    api_key = create_node_api_key(owner=managed_node.owner, constellation=managed_node.constellation)
+    NodeAuth.objects.create(api_key=api_key, node=managed_node)
+
+    client = APIClient()
+    url = reverse("meshtastic-bot-version", kwargs={"node_id": managed_node.meshtastic_node_id})
+    response = client.put(
+        url,
+        {"bot_version": "   "},
+        format="json",
+        HTTP_X_API_KEY=api_key.key,
+    )
+
+    assert response.status_code == 400

--- a/Meshflow/packets/urls.py
+++ b/Meshflow/packets/urls.py
@@ -2,7 +2,7 @@
 
 from django.urls import include, path
 
-from .views import NodeUpsertView, PacketIngestView
+from .views import ManagedNodeBotVersionView, NodeUpsertView, PacketIngestView
 
 urlpatterns = [
     path(
@@ -11,6 +11,7 @@ urlpatterns = [
             [
                 path("ingest/", PacketIngestView.as_view(), name="meshtastic-packet-ingest"),
                 path("nodes/", NodeUpsertView.as_view(), name="meshtastic-node-upsert"),
+                path("bot-version/", ManagedNodeBotVersionView.as_view(), name="meshtastic-bot-version"),
             ]
         ),
     ),

--- a/Meshflow/packets/views.py
+++ b/Meshflow/packets/views.py
@@ -1,4 +1,6 @@
-from rest_framework import status
+from django.utils import timezone
+
+from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -266,3 +268,63 @@ class NodeUpsertView(APIView):
                 )
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class ManagedNodeBotVersionSerializer(serializers.Serializer):
+    """Body for feeder-reported meshflow-bot version."""
+
+    bot_version = serializers.CharField(max_length=128, trim_whitespace=True)
+
+
+class ManagedNodeBotVersionView(APIView):
+    """
+    Update the reporting meshflow-bot version for the authenticated managed node.
+
+    Only the feeder whose Node API key is linked to the ``meshtastic_node_id`` in the URL
+    may call this endpoint (same auth as packet ingest).
+    """
+
+    authentication_classes = [NodeAPIKeyAuthentication]
+    permission_classes = [NodeAuthorizationPermission]
+
+    def put(self, request, node_id, format=None):
+        return self._update(request)
+
+    def post(self, request, node_id, format=None):
+        return self._update(request)
+
+    def patch(self, request, node_id, format=None):
+        return self._update(request)
+
+    def _update(self, request):
+        managed_node = request.auth.node if hasattr(request.auth, "node") else None
+        if not managed_node:
+            return Response(
+                {"status": "error", "message": "No authenticated node found"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        serializer = ManagedNodeBotVersionSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        bot_version = serializer.validated_data["bot_version"]
+        if not bot_version:
+            return Response(
+                {"bot_version": ["This field may not be blank."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        now = timezone.now()
+        managed_node.bot_version = bot_version
+        managed_node.bot_version_reported_at = now
+        managed_node.save(update_fields=["bot_version", "bot_version_reported_at"])
+
+        return Response(
+            {
+                "status": "success",
+                "bot_version": managed_node.bot_version,
+                "bot_version_reported_at": managed_node.bot_version_reported_at,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1743,6 +1743,18 @@ components:
           type: boolean
           description: If true, this node may be used for auto-scheduled traceroutes and manual triggers
           default: false
+        bot_version:
+          type: string
+          nullable: true
+          maxLength: 128
+          description: Last meshflow-bot version reported by this feeder on connect
+          readOnly: true
+        bot_version_reported_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: When bot_version was last reported by the feeder
+          readOnly: true
         last_packet_ingested_at:
           type: string
           format: date-time
@@ -3583,6 +3595,85 @@ paths:
       responses:
         '200':
           description: Paginated MeshCore raw packets
+
+  /packets/{meshtastic_node_id}/bot-version/:
+    put:
+      summary: Report meshflow-bot version (feeder)
+      description: >
+        Meshtastic feeder bots report their software version on connect. The path segment is
+        the observer's Meshtastic numeric node id and must match the authenticated ManagedNode
+        linked to the Node API key. JWT users cannot update these fields via managed-node CRUD.
+      tags: [Meshtastic packets]
+      security:
+        - NodeApiKeyAuth: []
+      parameters:
+        - name: meshtastic_node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+          description: Meshtastic numeric node id of the observer (feeder)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [bot_version]
+              properties:
+                bot_version:
+                  type: string
+                  maxLength: 128
+                  description: Bot release tag, semver, or git describe output
+      responses:
+        '200':
+          description: Version recorded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                  bot_version:
+                    type: string
+                  bot_version_reported_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Invalid or empty bot_version
+        '403':
+          description: API key not linked to this managed node
+    post:
+      summary: Report meshflow-bot version (feeder, alias)
+      description: Same as PUT; provided for clients that prefer POST.
+      tags: [Meshtastic packets]
+      security:
+        - NodeApiKeyAuth: []
+      parameters:
+        - name: meshtastic_node_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [bot_version]
+              properties:
+                bot_version:
+                  type: string
+                  maxLength: 128
+      responses:
+        '200':
+          description: Version recorded
+        '400':
+          description: Invalid or empty bot_version
+        '403':
+          description: API key not linked to this managed node
 
   /packets/{meshtastic_node_id}/nodes/:
     post:


### PR DESCRIPTION
## Summary

- Add `ManagedNode.bot_version` and `bot_version_reported_at` (migration `0042`).
- New feeder-only endpoint `PUT`/`POST`/`PATCH` `/api/packets/{meshtastic_node_id}/bot-version/` using Node API key auth (same as ingest).
- Expose fields read-only on managed-node list/detail serializers and OpenAPI.

Deploy API before bot/UI. Old bots continue to work without reporting a version.

**Tracking:** [meshflow-bot#99](https://github.com/pskillen/meshflow-bot/issues/99)

**Related PRs:** meshflow-bot and meshflow-ui `bot-99/pskillen/bot-version-report` branches.

## Testing performed

- `pytest packets/tests/test_bot_version_report.py` (3 tests)
- black / isort / flake8 on changed files

Closes meshflow-bot#99 (API portion).