### PR TITLE
refactor(nodes): drop ObservedNode.node_id_str DB column (#294)

### DIFF
--- a/Meshflow/common/mesh_node_helpers.py
+++ b/Meshflow/common/mesh_node_helpers.py
@@ -3,7 +3,15 @@
 MeshCore broadcast semantics differ; see docs/features/packet-ingestion/adr/0003-mc-broadcast-semantics.md.
 """
 
+from __future__ import annotations
+
 import base64
+from typing import TYPE_CHECKING
+
+from common.protocol import Protocol
+
+if TYPE_CHECKING:
+    from nodes.models import ObservedNode
 
 MESHTASTIC_BROADCAST_ID = 0xFFFFFFFF
 
@@ -17,6 +25,62 @@ def meshtastic_id_to_hex(meshtastic_id: int) -> str:
         return "^all"
 
     return f"!{meshtastic_id:08x}"
+
+
+def observed_node_search_conditions(query: str):
+    """Build Q filters for ObservedNode search (display id, names, numeric MT id)."""
+    from django.db.models import Q
+
+    from common.meshcore_node_helpers import MC_NODE_ID_STR_PREFIX, normalize_mc_pubkey_prefix
+
+    conditions = Q()
+    q = query.strip()
+
+    if q.startswith("!") and len(q) == 9:
+        try:
+            conditions |= Q(meshtastic_node_id=meshtastic_hex_to_int(q))
+        except ValueError:
+            pass
+    elif q.lower().startswith(MC_NODE_ID_STR_PREFIX):
+        suffix = q[len(MC_NODE_ID_STR_PREFIX) :].strip().lower().replace("0x", "")
+        if suffix:
+            try:
+                if len(suffix) == 12:
+                    prefix = normalize_mc_pubkey_prefix(suffix)
+                    conditions |= Q(mc_pubkey_prefix=prefix) | Q(mc_pubkey__istartswith=prefix)
+                else:
+                    conditions |= Q(mc_pubkey_prefix__icontains=suffix) | Q(mc_pubkey__icontains=suffix)
+            except ValueError:
+                conditions |= Q(mc_pubkey_prefix__icontains=suffix) | Q(mc_pubkey__icontains=suffix)
+    elif q.startswith("!"):
+        try:
+            conditions |= Q(meshtastic_node_id=meshtastic_hex_to_int(q))
+        except ValueError:
+            pass
+    else:
+        hexish = q.lower().replace("0x", "")
+        if hexish and all(c in "0123456789abcdef" for c in hexish):
+            conditions |= Q(mc_pubkey__icontains=hexish) | Q(mc_pubkey_prefix__icontains=hexish)
+
+    try:
+        conditions |= Q(meshtastic_node_id=int(q))
+    except ValueError, TypeError:
+        pass
+
+    conditions |= Q(short_name__icontains=query)
+    conditions |= Q(long_name__icontains=query)
+    return conditions
+
+
+def observed_node_id_str(node: ObservedNode) -> str:
+    """Protocol-aware display id for an ObservedNode (ADR-0001; not persisted)."""
+    from common.meshcore_node_helpers import mc_node_id_str
+
+    if node.protocol == Protocol.MESHCORE:
+        return mc_node_id_str(mc_pubkey=node.mc_pubkey, mc_pubkey_prefix=node.mc_pubkey_prefix)
+    if node.meshtastic_node_id is None:
+        raise ValueError("Meshtastic ObservedNode requires meshtastic_node_id")
+    return meshtastic_id_to_hex(node.meshtastic_node_id)
 
 
 def meshtastic_hex_to_int(node_id: str) -> int:

--- a/Meshflow/common/meshcore_node_helpers.py
+++ b/Meshflow/common/meshcore_node_helpers.py
@@ -107,7 +107,6 @@ def resolve_or_create_mc_observed_node(
         prefix = pubkey_to_prefix(pubkey)
         defaults = {
             "mc_pubkey_prefix": prefix,
-            "node_id_str": mc_node_id_str(mc_pubkey=pubkey),
             "long_name": long_name or f"MC {prefix}",
             "short_name": (short_name or prefix[-4:])[:5],
         }
@@ -156,7 +155,6 @@ def resolve_or_create_mc_observed_node(
             node = ObservedNode.objects.create(
                 protocol=Protocol.MESHCORE,
                 mc_pubkey_prefix=prefix,
-                node_id_str=mc_node_id_str(mc_pubkey_prefix=prefix),
                 long_name=long_name or f"MC {prefix}",
                 short_name=(short_name or prefix[-4:])[:5],
                 last_heard=last_heard,

--- a/Meshflow/common/tests/test_meshcore_node_helpers.py
+++ b/Meshflow/common/tests/test_meshcore_node_helpers.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 import pytest
 
+from common.mesh_node_helpers import observed_node_id_str
 from common.meshcore_node_helpers import (
     mc_node_id_str,
     merge_prefix_stub_into_full,
@@ -33,7 +34,7 @@ def test_resolve_full_pubkey_creates_node():
     assert node.protocol == Protocol.MESHCORE
     assert node.mc_pubkey == FULL_PUBKEY
     assert node.mc_pubkey_prefix == PREFIX
-    assert node.node_id_str == f"mc:{PREFIX}"
+    assert observed_node_id_str(node) == f"mc:{PREFIX}"
     assert node.last_heard == now
 
 
@@ -63,7 +64,6 @@ def test_merge_prefix_stub_into_full():
     stub = ObservedNode.objects.create(
         protocol=Protocol.MESHCORE,
         mc_pubkey_prefix=PREFIX,
-        node_id_str=mc_node_id_str(mc_pubkey_prefix=PREFIX),
         long_name="stub",
         short_name="stub",
     )
@@ -71,7 +71,6 @@ def test_merge_prefix_stub_into_full():
         protocol=Protocol.MESHCORE,
         mc_pubkey=FULL_PUBKEY,
         mc_pubkey_prefix=PREFIX,
-        node_id_str=mc_node_id_str(mc_pubkey=FULL_PUBKEY),
         long_name="full",
         short_name="full",
     )

--- a/Meshflow/common/tests/test_observed_node_id_str.py
+++ b/Meshflow/common/tests/test_observed_node_id_str.py
@@ -1,0 +1,44 @@
+"""Tests for protocol-aware ObservedNode display id (ADR-0001)."""
+
+import pytest
+
+from common.mesh_node_helpers import observed_node_id_str
+from common.protocol import Protocol
+from nodes.models import ObservedNode
+
+FULL_PUBKEY = "a" * 64
+PREFIX = "a" * 12
+
+
+@pytest.mark.django_db
+def test_observed_node_id_str_meshtastic():
+    node = ObservedNode.objects.create(
+        protocol=Protocol.MESHTASTIC,
+        meshtastic_node_id=987654321,
+        long_name="MT",
+        short_name="MT",
+    )
+    assert observed_node_id_str(node) == "!3ade68b1"
+
+
+@pytest.mark.django_db
+def test_observed_node_id_str_meshcore_full_pubkey():
+    node = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey=FULL_PUBKEY,
+        mc_pubkey_prefix=PREFIX,
+        long_name="MC",
+        short_name="MC",
+    )
+    assert observed_node_id_str(node) == f"mc:{PREFIX}"
+
+
+@pytest.mark.django_db
+def test_observed_node_id_str_meshcore_prefix_stub():
+    node = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey_prefix=PREFIX,
+        long_name="stub",
+        short_name="stub",
+    )
+    assert observed_node_id_str(node) == f"mc:{PREFIX}"

--- a/Meshflow/common/tests/test_observed_node_search.py
+++ b/Meshflow/common/tests/test_observed_node_search.py
@@ -1,0 +1,38 @@
+"""Tests for ObservedNode search Q builder."""
+
+import pytest
+
+from common.mesh_node_helpers import observed_node_search_conditions
+from common.protocol import Protocol
+from nodes.models import ObservedNode
+
+FULL_PUBKEY = "b" * 64
+PREFIX = "b" * 12
+
+
+@pytest.mark.django_db
+def test_search_meshtastic_hex_exact(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=0x12345678)
+    qs = ObservedNode.objects.filter(observed_node_search_conditions("!12345678"))
+    assert node in qs
+
+
+@pytest.mark.django_db
+def test_search_meshcore_display_prefix(create_observed_node):
+    node = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=FULL_PUBKEY,
+        mc_pubkey_prefix=PREFIX,
+        long_name="MC node",
+        short_name="MC",
+    )
+    qs = ObservedNode.objects.filter(observed_node_search_conditions(f"mc:{PREFIX}"))
+    assert node in qs
+
+
+@pytest.mark.django_db
+def test_search_by_short_name(create_observed_node):
+    node = create_observed_node(short_name="ZZTOP")
+    qs = ObservedNode.objects.filter(observed_node_search_conditions("ZZTOP"))
+    assert node in qs

--- a/Meshflow/mesh_monitoring/tests/test_notify_watchers_audit.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_watchers_audit.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 
 import nodes.tests.conftest  # noqa: F401
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from mesh_monitoring.services import notify_watchers_node_offline, notify_watchers_verification_started
 from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 from nodes.models import RoleSource
@@ -18,7 +17,6 @@ def test_offline_notify_writes_sent_audit(create_user, create_observed_node):
     user = create_user()
     obs = create_observed_node(
         meshtastic_node_id=0x10101010,
-        node_id_str=meshtastic_id_to_hex(0x10101010),
         long_name="N",
         short_name="SN",
         claimed_by=user,
@@ -37,7 +35,6 @@ def test_offline_notify_writes_skipped_audit_when_discord_unverified(create_user
     user = create_user()
     obs = create_observed_node(
         meshtastic_node_id=0x20202020,
-        node_id_str=meshtastic_id_to_hex(0x20202020),
         claimed_by=user,
     )
     create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
@@ -57,7 +54,6 @@ def test_offline_notify_writes_failed_audit_on_discord_error(create_user, create
     user = create_user()
     obs = create_observed_node(
         meshtastic_node_id=0x30303030,
-        node_id_str=meshtastic_id_to_hex(0x30303030),
         claimed_by=user,
     )
     create_watch_with_offline_threshold(user=user, observed_node=obs, offline_after=60)
@@ -78,7 +74,6 @@ def test_verification_started_writes_sent_and_skipped_audits(create_user, create
     u_skip = create_user(username="watcher_skip")
     obs = create_observed_node(
         meshtastic_node_id=0x40404040,
-        node_id_str=meshtastic_id_to_hex(0x40404040),
         meshtastic_role=RoleSource.ROUTER,
     )
     create_watch_with_offline_threshold(user=u_send, observed_node=obs, offline_after=60)

--- a/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
+++ b/Meshflow/mesh_monitoring/tests/test_notify_watchers_messages.py
@@ -7,7 +7,6 @@ from django.test.utils import override_settings
 import pytest
 
 import nodes.tests.conftest  # noqa: F401
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from mesh_monitoring.services import notify_watchers_node_offline, notify_watchers_verification_started
 from mesh_monitoring.tests.conftest import create_watch_with_offline_threshold
 
@@ -18,7 +17,6 @@ def test_offline_dm_includes_short_name_and_deep_link(create_user, create_observ
     node_id = 0x11223344
     obs = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         long_name="My Long Node Name",
         short_name="MLNN",
         claimed_by=user,
@@ -46,7 +44,6 @@ def test_offline_dm_omits_url_when_frontend_unset(create_user, create_observed_n
     node_id = 0x22334455
     obs = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         long_name="Another Node",
         short_name="ANOD",
         claimed_by=user,
@@ -69,7 +66,6 @@ def test_verification_start_dm_includes_short_name_and_deep_link(create_user, cr
     node_id = 0x33445566
     obs = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         long_name="Verify Me",
         short_name="VFYM",
         claimed_by=user,

--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -6,7 +6,11 @@ from django.db import transaction
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
-from common.mesh_node_helpers import meshtastic_hex_to_int, meshtastic_id_to_hex
+from common.mesh_node_helpers import (
+    meshtastic_hex_to_int,
+    meshtastic_id_to_hex,
+    observed_node_search_conditions,
+)
 from common.protocol import Protocol
 
 from .models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, NodeLatestStatus, ObservedNode
@@ -648,7 +652,6 @@ class ObservedNodeAdmin(admin.ModelAdmin):
         "short_name",
         "long_name",
         "meshtastic_node_id",
-        "node_id_str",
         "mc_pubkey",
         "mc_pubkey_prefix",
         "mac_addr",
@@ -669,6 +672,12 @@ class ObservedNodeAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related("claimed_by", "latest_status")
+
+    def get_search_results(self, request, queryset, search_term):
+        if not search_term:
+            return queryset, False
+        queryset = queryset.filter(observed_node_search_conditions(search_term)).distinct()
+        return queryset, True
 
     def get_fields(self, request, obj=None):
         common = [

--- a/Meshflow/nodes/migrations/0040_observednode_node_id_str_nullable.py
+++ b/Meshflow/nodes/migrations/0040_observednode_node_id_str_nullable.py
@@ -1,0 +1,24 @@
+# #294: allow null before dropping persisted node_id_str
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0039_rename_observednode_meshtastic_identity_fields"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="observednode",
+            name="node_id_str",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                help_text="Display id: !hex8 (Meshtastic) or mc:prefix12 (MeshCore). Deprecated; dropped in #294.",
+                max_length=16,
+                null=True,
+            ),
+        ),
+    ]

--- a/Meshflow/nodes/migrations/0041_remove_observednode_node_id_str.py
+++ b/Meshflow/nodes/migrations/0041_remove_observednode_node_id_str.py
@@ -1,0 +1,17 @@
+# #294: node_id_str is computed per ADR-0001
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0040_observednode_node_id_str_nullable"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="observednode",
+            name="node_id_str",
+        ),
+    ]

--- a/Meshflow/nodes/migrations/0043_observednode_node_id_str_nullable.py
+++ b/Meshflow/nodes/migrations/0043_observednode_node_id_str_nullable.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("nodes", "0039_rename_observednode_meshtastic_identity_fields"),
+        ("nodes", "0042_managednode_bot_version"),
     ]
 
     operations = [

--- a/Meshflow/nodes/migrations/0044_remove_observednode_node_id_str.py
+++ b/Meshflow/nodes/migrations/0044_remove_observednode_node_id_str.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("nodes", "0040_observednode_node_id_str_nullable"),
+        ("nodes", "0043_observednode_node_id_str_nullable"),
     ]
 
     operations = [

--- a/Meshflow/nodes/models.py
+++ b/Meshflow/nodes/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
+from common.mesh_node_helpers import meshtastic_id_to_hex, observed_node_id_str
 from common.protocol import Protocol
 from constellations.models import MessageChannel
 
@@ -256,13 +256,6 @@ class ObservedNode(models.Model):
         db_index=True,
         help_text=_("Meshtastic numeric node id when protocol is Meshtastic; null for MeshCore."),
     )
-    node_id_str = models.CharField(
-        null=False,
-        blank=False,
-        max_length=16,
-        db_index=True,
-        help_text=_("Display id: !hex8 (Meshtastic) or mc:prefix12 (MeshCore)."),
-    )
     mc_pubkey = models.CharField(
         max_length=64,
         null=True,
@@ -355,6 +348,11 @@ class ObservedNode(models.Model):
                 name="nodes_observednode_mc_pubkey_unique",
             ),
         ]
+
+    @property
+    def node_id_str(self) -> str:
+        """Protocol-aware display id (not a DB column; ADR-0001)."""
+        return observed_node_id_str(self)
 
     def __str__(self):
         """Return a string representation of the node, including user's short name if available."""

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from rest_framework import serializers
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
+from common.mesh_node_helpers import meshtastic_id_to_hex, observed_node_id_str
 from common.protocol import Protocol
 from constellations.models import Constellation, ConstellationUserMembership, MessageChannel
 from users.models import User
@@ -1087,7 +1087,7 @@ class ObservedNodeSerializer(serializers.ModelSerializer):
             model = User
             fields = ["id", "username"]
 
-    node_id_str = serializers.CharField(read_only=True)
+    node_id_str = serializers.SerializerMethodField()
     latest_position = serializers.SerializerMethodField()
     latest_device_metrics = serializers.SerializerMethodField()
     latest_environment_metrics = serializers.SerializerMethodField()
@@ -1107,10 +1107,8 @@ class ObservedNodeSerializer(serializers.ModelSerializer):
     owner = OwnerSerializer(source="claimed_by", read_only=True)
     claim = serializers.SerializerMethodField()
 
-    def to_internal_value(self, data):
-        if "meshtastic_node_id" in data:
-            data["node_id_str"] = meshtastic_id_to_hex(data["meshtastic_node_id"])
-        return super().to_internal_value(data)
+    def get_node_id_str(self, obj):
+        return observed_node_id_str(obj)
 
     class Meta:
         model = ObservedNode

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -2,7 +2,6 @@ from django.utils import timezone
 
 import pytest
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import MessageChannel
 from constellations.tests.conftest import create_constellation  # noqa: F401
 from nodes.models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, ObservedNode
@@ -99,8 +98,7 @@ def create_observed_node(observed_node_data):
         data = observed_node_data.copy()
         data.update(kwargs)
         _coerce_observed_node_legacy_kwargs(data)
-        if data.get("meshtastic_node_id") is not None and "node_id_str" not in data:
-            data["node_id_str"] = meshtastic_id_to_hex(data["meshtastic_node_id"])
+        data.pop("node_id_str", None)
         return ObservedNode.objects.create(**data)
 
     return make_observed_node

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -5,7 +5,6 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import NodeAuth, NodeLatestStatus, NodeOwnerClaim
 from nodes.tasks import update_managed_node_statuses
 
@@ -58,7 +57,6 @@ def test_managed_nodes_status_fields_only_returned_with_include_status(
     managed = create_managed_node(owner=user, meshtastic_node_id=123450001, allow_auto_traceroute=True)
     observed = create_observed_node(
         meshtastic_node_id=managed.meshtastic_node_id,
-        node_id_str=meshtastic_id_to_hex(managed.meshtastic_node_id),
         last_heard=now,
     )
     NodeLatestStatus.objects.create(node=observed)
@@ -171,7 +169,6 @@ def test_claim_post_rejected_when_node_owned_by_another_user(create_observed_nod
     node_id = 111222333444
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=owner,
     )
 
@@ -191,7 +188,6 @@ def test_claim_delete_clears_claimed_by_when_owner(create_observed_node, create_
     node_id = 555001001
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=owner,
     )
     NodeOwnerClaim.objects.create(node=node, user=owner, claim_key="k", accepted_at=timezone.now())
@@ -212,7 +208,6 @@ def test_claim_delete_pending_does_not_require_claimed_by(create_observed_node, 
     node_id = 555001002
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=None,
     )
     NodeOwnerClaim.objects.create(node=node, user=owner, claim_key="k2", accepted_at=None)
@@ -232,7 +227,6 @@ def test_claim_delete_does_not_clear_other_users_claimed_by(create_observed_node
     node_id = 555001003
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=other,
     )
     NodeOwnerClaim.objects.create(node=node, user=owner, claim_key="k3", accepted_at=None)
@@ -253,7 +247,6 @@ def test_claim_delete_non_owner_no_claim_returns_404(create_observed_node, creat
     node_id = 555001004
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=owner,
     )
     NodeOwnerClaim.objects.create(node=node, user=owner, claim_key="k4", accepted_at=timezone.now())
@@ -274,7 +267,6 @@ def test_claim_delete_staff_without_own_claim_returns_404(create_observed_node, 
     node_id = 555001005
     node = create_observed_node(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         claimed_by=owner,
     )
     NodeOwnerClaim.objects.create(node=node, user=owner, claim_key="k5", accepted_at=timezone.now())

--- a/Meshflow/nodes/tests/test_observed_node_weather_classification.py
+++ b/Meshflow/nodes/tests/test_observed_node_weather_classification.py
@@ -5,7 +5,6 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import EnvironmentExposure, NodeLatestStatus, WeatherUse
 
 
@@ -16,7 +15,6 @@ def test_observed_node_detail_includes_weather_fields(create_observed_node, crea
     client.force_authenticate(user=user)
     node = create_observed_node(
         meshtastic_node_id=100100100,
-        node_id_str=meshtastic_id_to_hex(100100100),
         weather_use=WeatherUse.INCLUDE,
         environment_exposure=EnvironmentExposure.OUTDOOR,
     )
@@ -32,7 +30,6 @@ def test_environment_settings_editable_for_claim_owner(create_observed_node, cre
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=200200200,
-        node_id_str=meshtastic_id_to_hex(200200200),
         claimed_by=owner,
     )
     client = APIClient()
@@ -45,10 +42,7 @@ def test_environment_settings_editable_for_claim_owner(create_observed_node, cre
 @pytest.mark.django_db
 def test_environment_settings_editable_for_staff(create_observed_node, create_user):
     staff = create_user(is_staff=True)
-    node = create_observed_node(
-        meshtastic_node_id=300300300,
-        node_id_str=meshtastic_id_to_hex(300300300),
-    )
+    node = create_observed_node(meshtastic_node_id=300300300)
     client = APIClient()
     client.force_authenticate(user=staff)
     response = client.get(reverse("observed-node-detail", kwargs={"internal_id": node.internal_id}))
@@ -61,7 +55,6 @@ def test_environment_settings_patch_claim_owner(create_observed_node, create_use
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=400400400,
-        node_id_str=meshtastic_id_to_hex(400400400),
         claimed_by=owner,
     )
     client = APIClient()
@@ -83,10 +76,7 @@ def test_environment_settings_patch_claim_owner(create_observed_node, create_use
 @pytest.mark.django_db
 def test_environment_settings_patch_staff(create_observed_node, create_user):
     staff = create_user(is_staff=True)
-    node = create_observed_node(
-        meshtastic_node_id=500500500,
-        node_id_str=meshtastic_id_to_hex(500500500),
-    )
+    node = create_observed_node(meshtastic_node_id=500500500)
     client = APIClient()
     client.force_authenticate(user=staff)
     url = reverse("observed-node-environment-settings", kwargs={"internal_id": node.internal_id})
@@ -101,7 +91,6 @@ def test_environment_settings_patch_forbidden(create_observed_node, create_user)
     other = create_user()
     node = create_observed_node(
         meshtastic_node_id=600600600,
-        node_id_str=meshtastic_id_to_hex(600600600),
         claimed_by=owner,
     )
     client = APIClient()
@@ -114,10 +103,7 @@ def test_environment_settings_patch_forbidden(create_observed_node, create_user)
 @pytest.mark.django_db
 def test_environment_settings_patch_empty_body(create_observed_node, create_user):
     staff = create_user(is_staff=True)
-    node = create_observed_node(
-        meshtastic_node_id=700700700,
-        node_id_str=meshtastic_id_to_hex(700700700),
-    )
+    node = create_observed_node(meshtastic_node_id=700700700)
     client = APIClient()
     client.force_authenticate(user=staff)
     url = reverse("observed-node-environment-settings", kwargs={"internal_id": node.internal_id})
@@ -133,7 +119,6 @@ def test_weather_list_filter_weather_use(create_observed_node, create_user):
     def make_with_env(node_id, wu):
         n = create_observed_node(
             meshtastic_node_id=node_id,
-            node_id_str=meshtastic_id_to_hex(node_id),
             weather_use=wu,
         )
         NodeLatestStatus.objects.update_or_create(

--- a/Meshflow/nodes/tests/test_rf_propagation.py
+++ b/Meshflow/nodes/tests/test_rf_propagation.py
@@ -8,7 +8,6 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient, APIRequestFactory
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import AntennaPattern, NodeRfProfile, NodeRfPropagationRender
 from nodes.serializers import NodeRfProfileSerializer
 
@@ -38,10 +37,7 @@ def _rf_profile_fields(**overrides):
 
 @pytest.mark.django_db
 def test_node_rf_profile_one_to_one(create_observed_node):
-    node = create_observed_node(
-        meshtastic_node_id=801_801_801,
-        node_id_str=meshtastic_id_to_hex(801_801_801),
-    )
+    node = create_observed_node(meshtastic_node_id=801_801_801)
     NodeRfProfile.objects.create(observed_node=node, antenna_pattern=AntennaPattern.OMNI)
     with pytest.raises(IntegrityError):
         NodeRfProfile.objects.create(observed_node=node, antenna_pattern=AntennaPattern.OMNI)
@@ -49,10 +45,7 @@ def test_node_rf_profile_one_to_one(create_observed_node):
 
 @pytest.mark.django_db
 def test_node_rf_propagation_render_create(create_observed_node):
-    node = create_observed_node(
-        meshtastic_node_id=802_802_802,
-        node_id_str=meshtastic_id_to_hex(802_802_802),
-    )
+    node = create_observed_node(meshtastic_node_id=802_802_802)
     row = NodeRfPropagationRender.objects.create(observed_node=node)
     assert row.status == NodeRfPropagationRender.Status.PENDING
     assert node.latest_rf_render() == row
@@ -63,7 +56,6 @@ def test_rf_profile_serializer_hides_private_for_anonymous(create_observed_node,
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=803_803_803,
-        node_id_str=meshtastic_id_to_hex(803_803_803),
         claimed_by=owner,
     )
     profile = NodeRfProfile.objects.create(
@@ -88,7 +80,6 @@ def test_rf_profile_serializer_hides_private_for_stranger(create_observed_node, 
     stranger = create_user()
     node = create_observed_node(
         meshtastic_node_id=804_804_804,
-        node_id_str=meshtastic_id_to_hex(804_804_804),
         claimed_by=owner,
     )
     profile = NodeRfProfile.objects.create(
@@ -110,7 +101,6 @@ def test_rf_profile_serializer_shows_private_for_owner(create_observed_node, cre
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=805_805_805,
-        node_id_str=meshtastic_id_to_hex(805_805_805),
         claimed_by=owner,
     )
     profile = NodeRfProfile.objects.create(
@@ -134,7 +124,6 @@ def test_rf_profile_serializer_shows_private_for_staff(create_observed_node, cre
     staff = create_user(is_staff=True)
     node = create_observed_node(
         meshtastic_node_id=806_806_806,
-        node_id_str=meshtastic_id_to_hex(806_806_806),
     )
     profile = NodeRfProfile.objects.create(
         observed_node=node,
@@ -155,7 +144,6 @@ def test_rf_profile_get_empty_returns_204(create_observed_node, create_user):
     user = create_user()
     node = create_observed_node(
         meshtastic_node_id=807_807_807,
-        node_id_str=meshtastic_id_to_hex(807_807_807),
     )
     client = APIClient()
     client.force_authenticate(user=user)
@@ -169,7 +157,6 @@ def test_rf_profile_get_after_patch(create_observed_node, create_user):
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=808_808_808,
-        node_id_str=meshtastic_id_to_hex(808_808_808),
         claimed_by=owner,
     )
     client = APIClient()
@@ -202,7 +189,6 @@ def test_rf_profile_patch_owner_staff_stranger_unauth(create_observed_node, crea
     staff = create_user(is_staff=True)
     node = create_observed_node(
         meshtastic_node_id=809_809_809,
-        node_id_str=meshtastic_id_to_hex(809_809_809),
         claimed_by=owner,
     )
     url = reverse("observed-node-rf-profile", kwargs={"internal_id": node.internal_id})
@@ -229,7 +215,6 @@ def test_rf_propagation_get_none_then_pending(create_observed_node, create_user,
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=810_810_810,
-        node_id_str=meshtastic_id_to_hex(810_810_810),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -257,7 +242,6 @@ def test_rf_propagation_recompute_forbidden_stranger(create_observed_node, creat
     stranger = create_user()
     node = create_observed_node(
         meshtastic_node_id=811_811_811,
-        node_id_str=meshtastic_id_to_hex(811_811_811),
         claimed_by=owner,
     )
     client = APIClient()
@@ -272,7 +256,6 @@ def test_rf_propagation_recompute_creates_row(create_observed_node, create_user,
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_812,
-        node_id_str=meshtastic_id_to_hex(812_812_812),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -290,7 +273,6 @@ def test_rf_propagation_recompute_400_when_no_profile(create_observed_node, crea
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_813,
-        node_id_str=meshtastic_id_to_hex(812_812_813),
         claimed_by=owner,
     )
     client = APIClient()
@@ -306,7 +288,6 @@ def test_rf_propagation_recompute_dedup_returns_in_flight(create_observed_node, 
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_814,
-        node_id_str=meshtastic_id_to_hex(812_812_814),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -335,7 +316,6 @@ def test_rf_propagation_recompute_cache_hit_reuses_asset(settings, create_observ
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_815,
-        node_id_str=meshtastic_id_to_hex(812_812_815),
         claimed_by=owner,
     )
     profile = NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -373,7 +353,6 @@ def test_rf_propagation_cancel_marks_in_flight_as_failed(create_observed_node, c
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_816,
-        node_id_str=meshtastic_id_to_hex(812_812_816),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -407,7 +386,6 @@ def test_rf_propagation_cancel_is_noop_when_nothing_in_flight(create_observed_no
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_817,
-        node_id_str=meshtastic_id_to_hex(812_812_817),
         claimed_by=owner,
     )
     client = APIClient()
@@ -424,7 +402,6 @@ def test_rf_propagation_cancel_allows_new_recompute(create_observed_node, create
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_818,
-        node_id_str=meshtastic_id_to_hex(812_812_818),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, **_rf_profile_fields())
@@ -449,7 +426,6 @@ def test_rf_propagation_delete_removes_non_ready_rows(create_observed_node, crea
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=812_812_820,
-        node_id_str=meshtastic_id_to_hex(812_812_820),
         claimed_by=owner,
     )
     NodeRfPropagationRender.objects.create(observed_node=node, status=NodeRfPropagationRender.Status.PENDING)
@@ -482,7 +458,6 @@ def test_rf_propagation_delete_requires_edit_permission(create_observed_node, cr
     stranger = create_user(username="stranger", email="stranger@example.com")
     node = create_observed_node(
         meshtastic_node_id=812_812_821,
-        node_id_str=meshtastic_id_to_hex(812_812_821),
         claimed_by=owner,
     )
     NodeRfPropagationRender.objects.create(observed_node=node, status=NodeRfPropagationRender.Status.PENDING)
@@ -500,7 +475,6 @@ def test_observed_node_detail_rf_flags(create_observed_node, create_user):
     owner = create_user()
     node = create_observed_node(
         meshtastic_node_id=813_813_813,
-        node_id_str=meshtastic_id_to_hex(813_813_813),
         claimed_by=owner,
     )
     NodeRfProfile.objects.create(observed_node=node, antenna_pattern=AntennaPattern.OMNI)
@@ -524,10 +498,7 @@ def test_rf_propagation_asset_missing_file_404(settings, create_observed_node):
 
     with tempfile.TemporaryDirectory() as tmp:
         settings.RF_PROPAGATION_ASSET_DIR = tmp
-        node = create_observed_node(
-            meshtastic_node_id=814_814_814,
-            node_id_str=meshtastic_id_to_hex(814_814_814),
-        )
+        node = create_observed_node(meshtastic_node_id=814_814_814)
         client = APIClient()
         url = reverse("rf-propagation-asset", kwargs={"internal_id": node.internal_id, "filename": "missing.png"})
         response = client.get(url)
@@ -542,10 +513,7 @@ def test_rf_propagation_asset_serves_png_and_cache_control(settings, create_obse
     with tempfile.TemporaryDirectory() as tmp:
         settings.RF_PROPAGATION_ASSET_DIR = tmp
         Path(tmp, "tile.png").write_bytes(b"\x89PNG\r\n\x1a\n")
-        node = create_observed_node(
-            meshtastic_node_id=815_815_815,
-            node_id_str=meshtastic_id_to_hex(815_815_815),
-        )
+        node = create_observed_node(meshtastic_node_id=815_815_815)
         client = APIClient()
         url = reverse("rf-propagation-asset", kwargs={"internal_id": node.internal_id, "filename": "tile.png"})
         response = client.get(url)
@@ -556,10 +524,7 @@ def test_rf_propagation_asset_serves_png_and_cache_control(settings, create_obse
 
 @pytest.mark.django_db
 def test_rf_propagation_asset_rejects_traversal(create_observed_node):
-    node = create_observed_node(
-        meshtastic_node_id=816_816_816,
-        node_id_str=meshtastic_id_to_hex(816_816_816),
-    )
+    node = create_observed_node(meshtastic_node_id=816_816_816)
     client = APIClient()
     url = reverse("rf-propagation-asset", kwargs={"internal_id": node.internal_id, "filename": "bad..name.png"})
     response = client.get(url)

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -11,7 +11,6 @@ from django.db.models import (
     DateTimeField,
     IntegerField,
     OuterRef,
-    Q,
     Subquery,
     Value,
     When,
@@ -28,7 +27,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from common.mesh_node_helpers import meshtastic_hex_to_int
+from common.mesh_node_helpers import observed_node_search_conditions
 from constellations.models import ConstellationUserMembership
 from nodes.constants import INFRASTRUCTURE_ROLES
 from nodes.models import (
@@ -311,31 +310,7 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # Initialize an empty Q object for our conditions
-        conditions = Q()
-
-        # Check if query is a node_id_str (hex format starting with !)
-        if query.startswith("!") and len(query) == 9:
-            try:
-                # Convert hex node_id_str to integer node_id
-                node_id = meshtastic_hex_to_int(query)
-                conditions |= Q(meshtastic_node_id=node_id)
-            except ValueError:
-                # If conversion fails, just continue with other search methods
-                pass
-        else:
-            conditions |= Q(node_id_str__icontains=query)
-
-        # Try to convert query to integer for node_id search if it's numeric
-        try:
-            node_id_query = int(query)
-            conditions |= Q(meshtastic_node_id=node_id_query)
-        except ValueError, TypeError:
-            pass
-
-        # Add conditions for text fields
-        conditions |= Q(short_name__icontains=query)
-        conditions |= Q(long_name__icontains=query)
+        conditions = observed_node_search_conditions(query)
 
         # Search for nodes matching the query
         nodes = ObservedNode.objects.filter(conditions).order_by("meshtastic_node_id")

--- a/Meshflow/packets/receivers.py
+++ b/Meshflow/packets/receivers.py
@@ -73,13 +73,12 @@ def on_packet_received_update_inferred_max_hops(sender, packet, observer, observ
     sender_node_id = getattr(packet, "from_int", None)
     if sender_node_id is None:
         return
-    node_id_str = getattr(packet, "from_str", None) or meshtastic_id_to_hex(sender_node_id)
+    display_id = getattr(packet, "from_str", None) or meshtastic_id_to_hex(sender_node_id)
     observed_node, created = ObservedNode.objects.get_or_create(
         meshtastic_node_id=sender_node_id,
         defaults={
-            "node_id_str": node_id_str,
-            "long_name": "Unknown Node " + node_id_str,
-            "short_name": node_id_str[-4:] if len(node_id_str) >= 4 else "????",
+            "long_name": "Unknown Node " + display_id,
+            "short_name": display_id[-4:] if len(display_id) >= 4 else "????",
         },
     )
     if created:

--- a/Meshflow/packets/serializers.py
+++ b/Meshflow/packets/serializers.py
@@ -7,7 +7,12 @@ from django.utils import timezone as django_timezone
 
 from rest_framework import serializers
 
-from common.mesh_node_helpers import meshtastic_hex_to_int, meshtastic_id_to_hex, parse_b64_mac_address
+from common.mesh_node_helpers import (
+    meshtastic_hex_to_int,
+    meshtastic_id_to_hex,
+    observed_node_id_str,
+    parse_b64_mac_address,
+)
 from common.protocol import Protocol
 from constellations.models import MessageChannel
 from nodes.models import DeviceMetrics, ManagedNode, NodeLatestStatus, ObservedNode, Position
@@ -1302,7 +1307,7 @@ class NodeSerializer(serializers.ModelSerializer):
         short_name = serializers.CharField(required=False, allow_null=True)
 
     id = serializers.IntegerField(source="meshtastic_node_id")
-    id_str = serializers.CharField(source="node_id_str")
+    id_str = serializers.SerializerMethodField()
     macaddr = serializers.CharField(source="mac_addr", allow_null=True, allow_blank=True)
     meshtastic_hw_model = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     meshtastic_public_key = serializers.CharField(required=False, allow_null=True, allow_blank=True)
@@ -1325,6 +1330,9 @@ class NodeSerializer(serializers.ModelSerializer):
             "short_name",
             "last_heard",
         ]
+
+    def get_id_str(self, obj):
+        return observed_node_id_str(obj)
 
     def to_internal_value(self, data):
         """Convert the incoming data to the appropriate format."""
@@ -1351,7 +1359,7 @@ class NodeSerializer(serializers.ModelSerializer):
             else:
                 data["id"] = node_id
 
-            data["id_str"] = meshtastic_id_to_hex(data["id"])
+        data.pop("id_str", None)
 
         # Handle the nested user data
         if "user" in data:
@@ -1443,6 +1451,7 @@ class NodeSerializer(serializers.ModelSerializer):
         # Handle position and device metrics data
         position_data = validated_data.pop("position", None)
         device_metrics_data = validated_data.pop("device_metrics", None)
+        validated_data.pop("node_id_str", None)
 
         # Create the node
         node = ObservedNode.objects.create(**validated_data)
@@ -1457,6 +1466,7 @@ class NodeSerializer(serializers.ModelSerializer):
         # Handle position and device metrics data
         position_data = validated_data.pop("position", None)
         device_metrics_data = validated_data.pop("device_metrics", None)
+        validated_data.pop("node_id_str", None)
 
         # Update the node
         for attr, value in validated_data.items():

--- a/Meshflow/packets/services/base.py
+++ b/Meshflow/packets/services/base.py
@@ -56,15 +56,14 @@ class BasePacketService(abc.ABC):
                 self._dx_previous_last_heard = self.from_node.last_heard
             except ObservedNode.DoesNotExist:
                 self._dx_previous_last_heard = None
-                node_id_str = (
+                display_id = (
                     self.packet.from_str if self.packet.from_str else meshtastic_id_to_hex(self.packet.from_int)
                 )
                 self.from_node = ObservedNode.objects.create(
                     protocol=Protocol.MESHTASTIC,
                     meshtastic_node_id=self.packet.from_int,
-                    node_id_str=node_id_str,
-                    long_name="Unknown Node " + node_id_str,
-                    short_name=node_id_str[-4:] if len(node_id_str) >= 4 else "????",
+                    long_name="Unknown Node " + display_id,
+                    short_name=display_id[-4:] if len(display_id) >= 4 else "????",
                 )
                 self._dx_from_node_created = True
                 new_node_observed.send(sender=self, node=self.from_node, observer=self.observer)

--- a/Meshflow/packets/tests/test_packet_serializers.py
+++ b/Meshflow/packets/tests/test_packet_serializers.py
@@ -64,7 +64,6 @@ class BasePacketSerializerTestCase(TestCase):
 
         cls.from_node = ObservedNode.objects.create(
             meshtastic_node_id=456789,
-            node_id_str=meshtastic_id_to_hex(456789),
             long_name="From Node",
             short_name="FRM",
         )

--- a/Meshflow/packets/tests/test_packet_serializers.py
+++ b/Meshflow/packets/tests/test_packet_serializers.py
@@ -6,7 +6,6 @@ from uuid import uuid4
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from constellations.models import Constellation, MessageChannel
 from nodes.models import ManagedNode, NodeLatestStatus, ObservedNode
 from packets.models import (
@@ -802,7 +801,6 @@ class PacketDeduplicationTest(BasePacketSerializerTestCase):
         # Second sender (different node) for cross-sender test
         cls.from_node_b = ObservedNode.objects.create(
             meshtastic_node_id=111222333,
-            node_id_str=meshtastic_id_to_hex(111222333),
             long_name="From Node B",
             short_name="FRB",
         )

--- a/Meshflow/rf_propagation/tests/test_tasks.py
+++ b/Meshflow/rf_propagation/tests/test_tasks.py
@@ -10,7 +10,6 @@ from unittest.mock import patch
 import pytest
 from PIL import Image
 
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import AntennaPattern, NodeRfProfile, NodeRfPropagationRender
 from rf_propagation.client import EngineFatalError, EngineTransientError
 
@@ -123,7 +122,6 @@ def test_task_happy_path_writes_png_and_marks_ready(asset_dir, create_observed_n
 
     node = create_observed_node(
         meshtastic_node_id=820_820_820,
-        node_id_str=meshtastic_id_to_hex(820_820_820),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -149,7 +147,6 @@ def test_task_uses_bounds_from_geotiff_when_present(asset_dir, create_observed_n
 
     node = create_observed_node(
         meshtastic_node_id=820_820_830,
-        node_id_str=meshtastic_id_to_hex(820_820_830),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -175,7 +172,6 @@ def test_task_falls_back_to_center_bbox_when_geotiff_lacks_georef(asset_dir, cre
 
     node = create_observed_node(
         meshtastic_node_id=820_820_831,
-        node_id_str=meshtastic_id_to_hex(820_820_831),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -198,7 +194,6 @@ def test_task_engine_fatal_marks_failed(asset_dir, create_observed_node):
 
     node = create_observed_node(
         meshtastic_node_id=820_820_821,
-        node_id_str=meshtastic_id_to_hex(820_820_821),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -218,7 +213,6 @@ def test_task_transient_error_retries(asset_dir, create_observed_node, settings)
 
     node = create_observed_node(
         meshtastic_node_id=820_820_822,
-        node_id_str=meshtastic_id_to_hex(820_820_822),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -238,7 +232,6 @@ def test_task_cache_hit_reuses_existing_asset(asset_dir, create_observed_node):
 
     node = create_observed_node(
         meshtastic_node_id=820_820_823,
-        node_id_str=meshtastic_id_to_hex(820_820_823),
     )
     profile = _make_profile(node)
 
@@ -277,7 +270,6 @@ def test_task_retention_keeps_only_n_ready_per_node(asset_dir, create_observed_n
 
     node = create_observed_node(
         meshtastic_node_id=820_820_824,
-        node_id_str=meshtastic_id_to_hex(820_820_824),
     )
     _make_profile(node)
 
@@ -314,7 +306,6 @@ def test_task_missing_profile_fails_gracefully(asset_dir, create_observed_node):
 
     node = create_observed_node(
         meshtastic_node_id=820_820_825,
-        node_id_str=meshtastic_id_to_hex(820_820_825),
     )
     render = NodeRfPropagationRender.objects.create(observed_node=node)
 
@@ -331,7 +322,6 @@ def test_task_skips_when_row_already_cancelled(asset_dir, create_observed_node):
 
     node = create_observed_node(
         meshtastic_node_id=820_820_827,
-        node_id_str=meshtastic_id_to_hex(820_820_827),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(
@@ -360,7 +350,6 @@ def test_task_respects_cancellation_during_engine_run(asset_dir, create_observed
 
     node = create_observed_node(
         meshtastic_node_id=820_820_828,
-        node_id_str=meshtastic_id_to_hex(820_820_828),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -393,7 +382,6 @@ def test_task_handles_row_deleted_mid_flight(asset_dir, create_observed_node, se
 
     node = create_observed_node(
         meshtastic_node_id=820_820_829,
-        node_id_str=meshtastic_id_to_hex(820_820_829),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -421,7 +409,6 @@ def test_task_missing_engine_url_fails(asset_dir, create_observed_node, settings
 
     node = create_observed_node(
         meshtastic_node_id=820_820_826,
-        node_id_str=meshtastic_id_to_hex(820_820_826),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)
@@ -448,7 +435,6 @@ def test_task_compute_hash_includes_engine_tuning_extras(asset_dir, create_obser
 
     node = create_observed_node(
         meshtastic_node_id=820_820_827,
-        node_id_str=meshtastic_id_to_hex(820_820_827),
     )
     _make_profile(node)
     render = NodeRfPropagationRender.objects.create(observed_node=node)

--- a/Meshflow/stats/tests/test_views.py
+++ b/Meshflow/stats/tests/test_views.py
@@ -58,7 +58,7 @@ def test_node_neighbour_stats_uses_from_int_when_relay_node_null(create_managed_
 
     ObservedNode.objects.get_or_create(
         meshtastic_node_id=222222222,
-        defaults={"node_id_str": "!0d3b6cde", "short_name": "SRC", "long_name": "Source Node"},
+        defaults={"short_name": "SRC", "long_name": "Source Node"},
     )
 
     client = APIClient()
@@ -108,7 +108,7 @@ def test_node_neighbour_stats_uses_relay_node_when_set(create_managed_node, crea
 
     ObservedNode.objects.get_or_create(
         meshtastic_node_id=444444444,
-        defaults={"node_id_str": "!1a7a8b90", "short_name": "RLY", "long_name": "Relay Node"},
+        defaults={"short_name": "RLY", "long_name": "Relay Node"},
     )
 
     client = APIClient()
@@ -241,11 +241,11 @@ def test_node_neighbour_stats_lsb_returns_candidates(create_managed_node, create
 
     ObservedNode.objects.get_or_create(
         meshtastic_node_id=1129933592,
-        defaults={"node_id_str": "!43596b18", "short_name": "NodeA", "long_name": "Node A"},
+        defaults={"short_name": "NodeA", "long_name": "Node A"},
     )
     ObservedNode.objects.get_or_create(
         meshtastic_node_id=3456789016,
-        defaults={"node_id_str": "!ce0e3418", "short_name": "NodeB", "long_name": "Node B"},
+        defaults={"short_name": "NodeB", "long_name": "Node B"},
     )
 
     client = APIClient()

--- a/Meshflow/stats/views.py
+++ b/Meshflow/stats/views.py
@@ -366,7 +366,7 @@ def node_neighbour_stats(request, node_id: int):
                 candidates_qs = (
                     ObservedNode.objects.annotate(lsb=Mod(F("meshtastic_node_id"), 256))
                     .filter(lsb=source_val, protocol=Protocol.MESHTASTIC)
-                    .only("meshtastic_node_id", "node_id_str", "short_name")
+                    .only("meshtastic_node_id", "short_name", "protocol", "mc_pubkey", "mc_pubkey_prefix")
                 )
                 candidates = [
                     {
@@ -379,9 +379,9 @@ def node_neighbour_stats(request, node_id: int):
             else:
                 source_type = "full"
                 try:
-                    obs = ObservedNode.objects.only("meshtastic_node_id", "node_id_str", "short_name").get(
-                        meshtastic_node_id=source_val, protocol=Protocol.MESHTASTIC
-                    )
+                    obs = ObservedNode.objects.only(
+                        "meshtastic_node_id", "short_name", "protocol", "mc_pubkey", "mc_pubkey_prefix"
+                    ).get(meshtastic_node_id=source_val, protocol=Protocol.MESHTASTIC)
                     candidates = [
                         {
                             "meshtastic_node_id": obs.meshtastic_node_id,

--- a/Meshflow/traceroute/tests/test_reliability.py
+++ b/Meshflow/traceroute/tests/test_reliability.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 import pytest
 
 import nodes.tests.conftest  # noqa: F401
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import NodeLatestStatus
 from traceroute.models import AutoTraceRoute
 from traceroute.reliability import get_reliability_settings, load_source_target_reliability
@@ -32,13 +31,11 @@ def test_load_reliability_hard_cooldown_consecutive_auto_fails(
     )
     bad = create_observed_node(
         meshtastic_node_id=0xE10000AA,
-        node_id_str=meshtastic_id_to_hex(0xE10000AA),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=bad, latitude=55.6, longitude=-3.5)
     good = create_observed_node(
         meshtastic_node_id=0xE10000BB,
-        node_id_str=meshtastic_id_to_hex(0xE10000BB),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=good, latitude=55.1, longitude=-3.5)
@@ -77,13 +74,11 @@ def test_load_reliability_ignores_non_auto_triggers(
     )
     target = create_observed_node(
         meshtastic_node_id=0xE20000AA,
-        node_id_str=meshtastic_id_to_hex(0xE20000AA),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=target, latitude=56.8, longitude=-3.0)
     other = create_observed_node(
         meshtastic_node_id=0xE20000BB,
-        node_id_str=meshtastic_id_to_hex(0xE20000BB),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=other, latitude=56.1, longitude=-3.0)
@@ -120,7 +115,6 @@ def test_load_reliability_streak_broken_by_recent_success(
     )
     t = create_observed_node(
         meshtastic_node_id=0xE30000AA,
-        node_id_str=meshtastic_id_to_hex(0xE30000AA),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=t, latitude=57.3, longitude=-3.0)

--- a/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
+++ b/Meshflow/traceroute/tests/test_target_selection_managed_nodes.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 import pytest
 
 import nodes.tests.conftest  # noqa: F401
-from common.mesh_node_helpers import meshtastic_id_to_hex
 from nodes.models import NodeLatestStatus
 from traceroute.target_selection import pick_traceroute_target
 
@@ -26,14 +25,12 @@ def test_pick_traceroute_target_excludes_observed_node_whose_mesh_id_is_managed(
     on_mesh_id = other_mn.meshtastic_node_id
     victim = create_observed_node(
         meshtastic_node_id=on_mesh_id,
-        node_id_str=meshtastic_id_to_hex(on_mesh_id),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=victim, latitude=51.01, longitude=-0.11)
 
     free = create_observed_node(
         meshtastic_node_id=0xD1000099,
-        node_id_str=meshtastic_id_to_hex(0xD1000099),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=free, latitude=51.02, longitude=-0.12)
@@ -57,14 +54,12 @@ def test_managed_node_mesh_id_excluded_even_without_managednodestatus_row(create
 
     victim = create_observed_node(
         meshtastic_node_id=0xD2000002,
-        node_id_str=meshtastic_id_to_hex(0xD2000002),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=victim, latitude=52.01, longitude=1.01)
 
     free = create_observed_node(
         meshtastic_node_id=0xD2000099,
-        node_id_str=meshtastic_id_to_hex(0xD2000099),
         last_heard=timezone.now(),
     )
     NodeLatestStatus.objects.create(node=free, latitude=52.02, longitude=1.02)

--- a/Meshflow/traceroute/tests/test_views.py
+++ b/Meshflow/traceroute/tests/test_views.py
@@ -410,12 +410,14 @@ class TestTracerouteTriggerableNodes:
         self, api_client, editor_user, editor_managed_node
     ):
         """position is populated from NodeLatestStatus when the node has been heard."""
-        from common.mesh_node_helpers import meshtastic_id_to_hex
         from nodes.models import NodeLatestStatus, ObservedNode
 
         observed, _ = ObservedNode.objects.get_or_create(
             meshtastic_node_id=editor_managed_node.meshtastic_node_id,
-            defaults={"node_id_str": meshtastic_id_to_hex(editor_managed_node.meshtastic_node_id)},
+            defaults={
+                "long_name": editor_managed_node.name,
+                "short_name": editor_managed_node.name[:5],
+            },
         )
         NodeLatestStatus.objects.update_or_create(node=observed, defaults={"latitude": 55.86, "longitude": -4.25})
         api_client.force_authenticate(user=editor_user)

--- a/Meshflow/traceroute_analytics/tests/test_neo4j_service.py
+++ b/Meshflow/traceroute_analytics/tests/test_neo4j_service.py
@@ -83,12 +83,10 @@ def _edge_param_pairs(mock_session):
 
 def _create_observed_with_coords(node_id: int, lat: float, lng: float, short_name: str = "PEER"):
     """Create an ObservedNode with a NodeLatestStatus carrying coords."""
-    from common.mesh_node_helpers import meshtastic_id_to_hex
     from nodes.models import NodeLatestStatus, ObservedNode
 
     obs = ObservedNode.objects.create(
         meshtastic_node_id=node_id,
-        node_id_str=meshtastic_id_to_hex(node_id),
         short_name=short_name,
         long_name=f"Node {short_name}",
     )

--- a/docs/features/meshcore/feeder-bootstrap.md
+++ b/docs/features/meshcore/feeder-bootstrap.md
@@ -42,9 +42,9 @@ This differs from Meshtastic. You do **not** need an `ObservedNode` row for the 
    - **Default location** (optional): lat/lon for map display as a feeder pin
 3. Save. **Display ID** (read-only after save) is `mc:feeder:<internal id>` — this is not stored in the DB.
 
-**Do not** create feeders via raw SQL on `observednode`: that table still requires `node_id_str` (e.g. `mc:…` from packet ingest). Feeders are `managednode` rows only.
+**Do not** create feeders via raw SQL on `observednode`: feeders are `managednode` rows only. Raw inserts into `observednode` need `protocol` plus identity columns (`meshtastic_node_id` or `mc_pubkey` / `mc_pubkey_prefix`); `node_id_str` is computed at read time (ADR-0001, [#294](https://github.com/pskillen/meshflow-api/issues/294)).
 
-**`node_id_str` on ManagedNode** is a computed property, not a database column. Dropping it from `observednode` is tracked in **[meshflow-api#294](https://github.com/pskillen/meshflow-api/issues/294)** (ADR-0001 §6; deferred in Phase 1).
+**`node_id_str` on ManagedNode and ObservedNode** is a computed property in the API, not a database column on either model.
 
 ## 2. Create Node API key + NodeAuth
 

--- a/docs/features/meshcore/implementation-plan.md
+++ b/docs/features/meshcore/implementation-plan.md
@@ -276,6 +276,12 @@ Use this subsection as the **single inventory** of api-repo refactors tied to Me
 
 - `TextMessage` normalisation for MC; telemetry/ack models; MT pages showing MC; automated 24h trial gate (operator checklist in feeder-bootstrap).
 
+### Phase 1.x — tech debt (ADR-0001 display id)
+
+**Status:** Complete. **Tracking:** [#294](https://github.com/pskillen/meshflow-api/issues/294).
+
+- **Done:** Dropped stored `ObservedNode.node_id_str`; API returns computed `!hex8` / `mc:{prefix12}` via model property and serializers (ADR-0001 §6). Migrations `nodes.0040` (nullable interim), `nodes.0041` (RemoveField). Rollback: re-add column and backfill from computed values on a prod clone during a maintenance window.
+
 ### Verification
 
 1. `python -m pytest Meshflow/meshcore_packets/tests/ Meshflow/common/tests/test_meshcore_node_helpers.py -v`

--- a/docs/features/meshcore/implementation-plan.md
+++ b/docs/features/meshcore/implementation-plan.md
@@ -280,7 +280,7 @@ Use this subsection as the **single inventory** of api-repo refactors tied to Me
 
 **Status:** Complete. **Tracking:** [#294](https://github.com/pskillen/meshflow-api/issues/294).
 
-- **Done:** Dropped stored `ObservedNode.node_id_str`; API returns computed `!hex8` / `mc:{prefix12}` via model property and serializers (ADR-0001 §6). Migrations `nodes.0040` (nullable interim), `nodes.0041` (RemoveField). Rollback: re-add column and backfill from computed values on a prod clone during a maintenance window.
+- **Done:** Dropped stored `ObservedNode.node_id_str`; API returns computed `!hex8` / `mc:{prefix12}` via model property and serializers (ADR-0001 §6). Migrations `nodes.0043` (nullable interim), `nodes.0044` (RemoveField). Rollback: re-add column and backfill from computed values on a prod clone during a maintenance window.
 
 ### Verification
 

--- a/docs/features/meshcore/refactoring-progress.md
+++ b/docs/features/meshcore/refactoring-progress.md
@@ -204,7 +204,7 @@ _Capture follow-ups so they are not lost between sub-plans. Remove or strike thr
 
 - [ ] **API v1 ingest retirement** — [#319](https://github.com/pskillen/meshflow-api/issues/319); bot [#95](https://github.com/pskillen/meshflow-bot/issues/95). Deprecated `POST /raw-packet/` in OpenAPI until bot defaults to v2 only.
 - [ ] **`TextMessage` dual FK** (`original_mt_packet` / `original_mc_packet`) — Phase 2 / separate epic.
-- [ ] **Drop `ObservedNode.node_id_str` DB column** — separate ADR/amendment.
+- [x] **Drop `ObservedNode.node_id_str` DB column** — [#294](https://github.com/pskillen/meshflow-api/issues/294) / ADR-0001 §6.
 - [ ] **Rename Django app `packets` or `/api/packets/` URL prefix** — out of scope for rename index.
 
 ### Resolved since earlier revisions (do not re-open)

--- a/docs/features/packet-ingestion/adr/0001-mc-node-identity.md
+++ b/docs/features/packet-ingestion/adr/0001-mc-node-identity.md
@@ -1,8 +1,10 @@
 # ADR-0001 — MeshCore node identity
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-12
 **Tracking:** [meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
+
+Phase 1 MVP ([#265](https://github.com/pskillen/meshflow-api/issues/265)) kept a stored `node_id_str` column temporarily; [#294](https://github.com/pskillen/meshflow-api/issues/294) removed it in favour of the computed display id in §6.
 
 ## Context
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1019,7 +1019,10 @@ components:
           description: Meshtastic numeric node id on the mesh (null for MeshCore observed nodes)
         node_id_str:
           type: string
-          description: Display id (!hex8 for Meshtastic, mc:prefix12 for MeshCore)
+          readOnly: true
+          description: >
+            Computed display id (not stored). !{hex8} for Meshtastic from meshtastic_node_id;
+            mc:{prefix12} for MeshCore from mc_pubkey or mc_pubkey_prefix (ADR-0001).
         mc_pubkey:
           type: string
           nullable: true
@@ -1471,7 +1474,9 @@ components:
           description: Meshtastic numeric node id on the mesh network
         node_id_str:
           type: string
-          description: The ID of the node in Meshastic !hex format
+          readOnly: true
+          description: >
+            Computed display id (!hex8 or mc:prefix12); see ObservedNode.node_id_str.
         long_name:
           type: string
           description: The long name of the node
@@ -1590,8 +1595,9 @@ components:
               readOnly: true
             node_id_str:
               type: string
-              description: The node ID in hex format
               readOnly: true
+              description: >
+                Computed display id (!hex8 or mc:prefix12); not a database column on ObservedNode.
             long_name:
               type: string
               description: The long name of the node


### PR DESCRIPTION
## Summary

Completes [ADR-0001](docs/features/packet-ingestion/adr/0001-mc-node-identity.md) §6 and closes #294: `ObservedNode.node_id_str` is no longer stored in PostgreSQL. The API still returns `node_id_str` as a protocol-aware computed value (`!{hex8}` for Meshtastic, `mc:{prefix12}` for MeshCore).

- Added `observed_node_id_str()` helper and `ObservedNode.node_id_str` `@property`
- Serializers and ingest paths no longer persist `node_id_str`
- Migrations `nodes.0043` (nullable interim) and `nodes.0044` (RemoveField) — after `0042_managednode_bot_version` on main
- Protocol-aware search in API and Django admin
- OpenAPI documents `node_id_str` as read-only computed

**Rollback (prod):** re-add `CharField`, backfill from computed values per row, restore NOT NULL during a maintenance window.

## Testing performed

- [x] Targeted pytest: `test_observed_node_id_str`, `test_meshcore_node_helpers` (9 passed)
- [x] Full `python -m pytest Meshflow/ -v`
- [x] `python manage.py migrate` on staging PostgreSQL clone

Closes #294