### PR TITLE
refactor(packets): decouple packet side effects with signals (#256)

### DIFF
--- a/Meshflow/dx_monitoring/apps.py
+++ b/Meshflow/dx_monitoring/apps.py
@@ -9,4 +9,6 @@ class DxMonitoringConfig(AppConfig):
     verbose_name = _("DX Monitoring")
 
     def ready(self):
+        import dx_monitoring.receivers  # noqa: F401
+
         from . import signals  # noqa: F401

--- a/Meshflow/dx_monitoring/receivers.py
+++ b/Meshflow/dx_monitoring/receivers.py
@@ -1,0 +1,53 @@
+"""Dispatch receivers for packet post-processing signals."""
+
+import logging
+
+from django.dispatch import receiver
+
+from packets.signals import packet_from_node_processed
+
+logger = logging.getLogger(__name__)
+
+
+def on_auto_traceroute_completed_from_packet(
+    sender,
+    auto_tr,
+    traceroute_packet,
+    packet_observation,
+    observer=None,
+    from_node=None,
+    **kwargs,
+):
+    """DX detection and exploration follow-up after traceroute completion (order preserved)."""
+    from dx_monitoring.exploration import on_auto_traceroute_exploration_finished
+    from dx_monitoring.services import maybe_detect_dx_from_completed_traceroute
+
+    maybe_detect_dx_from_completed_traceroute(auto_tr, traceroute_packet, packet_observation)
+    on_auto_traceroute_exploration_finished(auto_tr)
+
+
+@receiver(packet_from_node_processed)
+def on_packet_from_node_processed(
+    sender,
+    packet,
+    observer,
+    observation,
+    from_node,
+    previous_last_heard=None,
+    from_node_created=False,
+    **kwargs,
+):
+    """Run DX candidate rules before ObservedNode.last_heard is updated."""
+    from dx_monitoring.services import maybe_detect_dx_candidate
+
+    try:
+        maybe_detect_dx_candidate(
+            packet=packet,
+            observer=observer,
+            observation=observation,
+            from_node=from_node,
+            previous_last_heard=previous_last_heard,
+            from_node_created=from_node_created,
+        )
+    except Exception:
+        logger.exception("dx_monitoring: candidate detection failed for packet %s", getattr(packet, "id", None))

--- a/Meshflow/dx_monitoring/services.py
+++ b/Meshflow/dx_monitoring/services.py
@@ -7,7 +7,7 @@ observed-node resolution when MeshCore rows share this pipeline.
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.conf import settings
 from django.db import transaction
@@ -27,9 +27,6 @@ from dx_monitoring.models import (
 from nodes.models import ManagedNode, NodeLatestStatus, ObservedNode
 from packets.models import MtRawPacket, PacketObservation, TraceroutePacket
 from traceroute.models import AutoTraceRoute
-
-if TYPE_CHECKING:
-    from packets.services.base import BasePacketService
 
 
 def is_direct_packet_observation(observation: PacketObservation) -> bool:
@@ -260,15 +257,19 @@ def _get_or_create_active_event(
     return event
 
 
-def maybe_detect_dx_candidate(packet_service: BasePacketService) -> None:
+def maybe_detect_dx_candidate(
+    *,
+    packet: MtRawPacket,
+    observer: ManagedNode,
+    observation: PacketObservation,
+    from_node: ObservedNode,
+    previous_last_heard,
+    from_node_created: bool = False,
+) -> None:
     """Run DX rules after packet-specific processing, before ``last_heard`` update."""
+    del from_node_created  # reserved for future rules
     if not getattr(settings, "DX_MONITORING_DETECTION_ENABLED", False):
         return
-
-    packet: MtRawPacket = packet_service.packet
-    observer: ManagedNode = packet_service.observer
-    observation: PacketObservation = packet_service.observation
-    from_node: ObservedNode = packet_service.from_node
 
     if isinstance(packet, TraceroutePacket):
         return
@@ -293,7 +294,6 @@ def maybe_detect_dx_candidate(packet_service: BasePacketService) -> None:
     quiet_days = int(getattr(settings, "DX_MONITORING_RETURNED_DX_QUIET_DAYS", 30))
 
     prior_dx = _prior_dx_events_exist(constellation.id, from_node.pk)
-    previous_last_heard = getattr(packet_service, "_dx_previous_last_heard", None)
 
     dest_lat, dest_lon = _destination_coords(from_node)
     obs_lat, obs_lon = _observer_coords(observer)

--- a/Meshflow/dx_monitoring/tests/test_detection.py
+++ b/Meshflow/dx_monitoring/tests/test_detection.py
@@ -175,6 +175,67 @@ def test_returned_dx_node_after_quiet_period(
 @override_settings(
     DX_MONITORING_DETECTION_ENABLED=True,
     DX_MONITORING_CLUSTER_DISTANCE_KM=150.0,
+    DX_MONITORING_DIRECT_DISTANCE_KM=5000.0,
+    DX_MONITORING_RETURNED_DX_QUIET_DAYS=30,
+)
+def test_packet_from_node_processed_passes_previous_last_heard_before_update(
+    create_managed_node,
+    create_observed_node,
+    create_packet_observation,
+    create_user,
+    create_position_packet,
+):
+    """DX candidate signal must fire with pre-update last_heard (ordering regression)."""
+    observer = create_managed_node(
+        meshtastic_node_id=0xE2000099,
+        default_location_latitude=55.95,
+        default_location_longitude=-3.19,
+    )
+    user = create_user()
+    remote_id = 0xBEEF0299
+    remote_hex = meshtastic_id_to_hex(remote_id)
+    quiet_before = timezone.now() - timedelta(days=40)
+
+    dest = create_observed_node(meshtastic_node_id=remote_id)
+    dest.last_heard = quiet_before
+    dest.save(update_fields=["last_heard"])
+    NodeLatestStatus.objects.update_or_create(
+        node=dest,
+        defaults={"latitude": 51.5, "longitude": -0.12},
+    )
+    DxNodeMetadata.objects.get_or_create(observed_node=dest)
+    t_prior = timezone.now()
+    DxEvent.objects.create(
+        constellation=observer.constellation,
+        destination=dest,
+        reason_code=DxReasonCode.NEW_DISTANT_NODE,
+        first_observed_at=t_prior,
+        last_observed_at=t_prior,
+        active_until=t_prior + timedelta(hours=1),
+    )
+
+    pos = create_position_packet(
+        packet_id=929999,
+        from_int=remote_id,
+        from_str=remote_hex,
+        latitude=51.5,
+        longitude=-0.12,
+    )
+    pos.first_reported_time = timezone.now()
+    pos.save(update_fields=["first_reported_time"])
+    obs = create_packet_observation(packet=pos, observer=observer)
+
+    with patch("dx_monitoring.services.maybe_detect_dx_candidate") as mock_detect:
+        PositionPacketService().process_packet(pos, observer, obs, user)
+
+    mock_detect.assert_called_once()
+    assert mock_detect.call_args.kwargs["previous_last_heard"] == quiet_before
+
+
+@pytest.mark.django_db
+@override_settings(
+    DX_MONITORING_DETECTION_ENABLED=True,
+    DX_MONITORING_CLUSTER_DISTANCE_KM=150.0,
     DX_MONITORING_DIRECT_DISTANCE_KM=80.0,
 )
 def test_distant_observation_direct_threshold(

--- a/Meshflow/mesh_monitoring/receivers.py
+++ b/Meshflow/mesh_monitoring/receivers.py
@@ -3,7 +3,7 @@ import logging
 from django.dispatch import receiver
 
 from mesh_monitoring.battery import evaluate_device_metrics_for_battery_alert
-from packets.signals import device_metrics_recorded
+from packets.signals import device_metrics_recorded, node_last_heard_advanced
 
 logger = logging.getLogger(__name__)
 
@@ -19,3 +19,28 @@ def on_device_metrics_recorded(sender, observed_node, battery_level, reported_ti
         )
     except Exception:
         logger.exception("mesh_monitoring: battery evaluation failed for node %s", observed_node.node_id_str)
+
+
+def on_auto_traceroute_completed_from_packet(sender, auto_tr, **kwargs):
+    """Clear offline verification when a node-watch traceroute completes."""
+    from mesh_monitoring.services import on_monitoring_traceroute_completed
+
+    try:
+        on_monitoring_traceroute_completed(auto_tr)
+    except Exception:
+        logger.exception("mesh_monitoring: monitor TR completion failed for auto_tr %s", auto_tr.id)
+
+
+@receiver(node_last_heard_advanced)
+def on_node_last_heard_advanced(sender, observed_node, last_heard=None, **kwargs):
+    """Reset monitoring presence when any packet advances last_heard."""
+    from mesh_monitoring.services import clear_presence_on_packet_from_node
+
+    del last_heard
+    try:
+        clear_presence_on_packet_from_node(observed_node)
+    except Exception:
+        logger.exception(
+            "mesh_monitoring: clear presence failed for node %s",
+            observed_node.node_id_str,
+        )

--- a/Meshflow/packets/apps.py
+++ b/Meshflow/packets/apps.py
@@ -8,3 +8,6 @@ class PacketsConfig(AppConfig):
     def ready(self):
         """Import signal handlers when Django is ready."""
         import packets.receivers  # noqa
+        from packets.traceroute_completion_wiring import connect_auto_traceroute_completed_receivers
+
+        connect_auto_traceroute_completed_receivers()

--- a/Meshflow/packets/services/base.py
+++ b/Meshflow/packets/services/base.py
@@ -6,7 +6,7 @@ from common.mesh_node_helpers import meshtastic_id_to_hex
 from common.protocol import Protocol
 from nodes.models import ManagedNode, ObservedNode
 from packets.models import MtRawPacket, PacketObservation
-from packets.signals import new_node_observed
+from packets.signals import new_node_observed, node_last_heard_advanced, packet_from_node_processed
 from users.models import User
 
 
@@ -35,9 +35,15 @@ class BasePacketService(abc.ABC):
         self._dx_previous_last_heard = None
         self._get_or_create_from_node()
         self._process_packet()
-        from dx_monitoring.services import maybe_detect_dx_candidate
-
-        maybe_detect_dx_candidate(self)
+        packet_from_node_processed.send(
+            sender=self.__class__,
+            packet=self.packet,
+            observer=self.observer,
+            observation=self.observation,
+            from_node=self.from_node,
+            previous_last_heard=self._dx_previous_last_heard,
+            from_node_created=self._dx_from_node_created,
+        )
         self._update_node_last_heard()
 
     @abc.abstractmethod
@@ -74,11 +80,14 @@ class BasePacketService(abc.ABC):
         """Update the last_heard timestamp of the node that sent the packet."""
         if self.packet.from_int and self.packet.first_reported_time:
             try:
-                self.from_node.last_heard = self.packet.first_reported_time
+                last_heard = self.packet.first_reported_time
+                self.from_node.last_heard = last_heard
                 self.from_node.save(update_fields=["last_heard"])
-                from mesh_monitoring.services import clear_presence_on_packet_from_node
-
-                clear_presence_on_packet_from_node(self.from_node)
+                node_last_heard_advanced.send(
+                    sender=self.__class__,
+                    observed_node=self.from_node,
+                    last_heard=last_heard,
+                )
             except ObservedNode.DoesNotExist:
                 # If the node doesn't exist, we don't need to update it
                 pass

--- a/Meshflow/packets/services/traceroute.py
+++ b/Meshflow/packets/services/traceroute.py
@@ -8,10 +8,10 @@ from django.utils import timezone
 
 from packets.models import TraceroutePacket
 from packets.services.base import BasePacketService
+from packets.signals import auto_traceroute_completed_from_packet
 from traceroute.lifecycle import (
     apply_auto_traceroute_completion,
     create_external_inferred_auto_traceroute,
-    schedule_completed_traceroute_neo4j_export,
 )
 from traceroute.models import AutoTraceRoute
 
@@ -75,17 +75,12 @@ class TraceroutePacketService(BasePacketService):
             raw_packet=self.packet,
         )
 
-        from dx_monitoring.exploration import on_auto_traceroute_exploration_finished
-        from dx_monitoring.services import maybe_detect_dx_from_completed_traceroute
-
-        maybe_detect_dx_from_completed_traceroute(auto_tr, self.packet, self.observation)
-        on_auto_traceroute_exploration_finished(auto_tr)
-
-        # Lazy imports so tests can patch traceroute.ws_notify / mesh_monitoring.services / lifecycle Neo4j hook.
-        from mesh_monitoring.services import on_monitoring_traceroute_completed
-        from traceroute.ws_notify import notify_traceroute_status_changed
-
-        on_monitoring_traceroute_completed(auto_tr)
-        notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
-        schedule_completed_traceroute_neo4j_export(auto_tr.id)
+        auto_traceroute_completed_from_packet.send(
+            sender=self.__class__,
+            auto_tr=auto_tr,
+            traceroute_packet=self.packet,
+            packet_observation=self.observation,
+            observer=self.observer,
+            from_node=self.from_node,
+        )
         logger.info("Linked TraceroutePacket %s to AutoTraceRoute %s", self.packet.id, auto_tr.id)

--- a/Meshflow/packets/signals.py
+++ b/Meshflow/packets/signals.py
@@ -29,6 +29,18 @@ traceroute_packet_received = Signal()
 # kwargs: observed_node, device_metrics, battery_level, reported_time
 device_metrics_recorded = Signal()
 
+# Emitted after a traceroute response is linked to an AutoTraceRoute and completion is persisted.
+# kwargs: auto_tr, traceroute_packet, packet_observation, observer, from_node
+auto_traceroute_completed_from_packet = Signal()
+
+# Emitted after packet-type processing, before ObservedNode.last_heard is updated (DX candidate rules).
+# kwargs: packet, observer, observation, from_node, previous_last_heard, from_node_created
+packet_from_node_processed = Signal()
+
+# Emitted after ObservedNode.last_heard is advanced for this ingest.
+# kwargs: observed_node, last_heard
+node_last_heard_advanced = Signal()
+
 
 # Converted packet signals
 # These are used to signal that a text message has been received

--- a/Meshflow/packets/tests/test_device_metrics_service.py
+++ b/Meshflow/packets/tests/test_device_metrics_service.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -6,6 +7,7 @@ import pytest
 
 from nodes.models import DeviceMetrics, NodeLatestStatus, ObservedNode
 from packets.services.device_metrics import DeviceMetricsPacketService
+from packets.signals import device_metrics_recorded
 
 
 @pytest.mark.django_db
@@ -40,8 +42,12 @@ def test_process_device_metrics_packet(
     user = create_user()
 
     initial_count = DeviceMetrics.objects.count()
-    service.process_packet(packet, observer, observation, user)
+    with patch.object(device_metrics_recorded, "send") as mock_send:
+        service.process_packet(packet, observer, observation, user)
     assert DeviceMetrics.objects.count() == initial_count + 1
+    mock_send.assert_called_once()
+    _, kwargs = mock_send.call_args
+    assert kwargs["battery_level"] == float(packet.battery_level or 0.0)
 
     metrics = DeviceMetrics.objects.latest("id")
     assert metrics.node.meshtastic_node_id == packet.from_int

--- a/Meshflow/packets/tests/test_traceroute_service.py
+++ b/Meshflow/packets/tests/test_traceroute_service.py
@@ -13,13 +13,15 @@ from packets.services.traceroute import TraceroutePacketService
 from packets.signals import auto_traceroute_completed_from_packet
 from traceroute.models import AutoTraceRoute
 
+pytest_plugins = ["packets.tests.test_traceroute_receiver"]
+
 
 @pytest.mark.django_db
 def test_traceroute_service_emits_completion_signal(
     create_managed_node,
     create_observed_node,
     create_traceroute_packet,
-    create_packet_observation,
+    create_packet_observation_for_tr,
     create_user,
 ):
     source = create_managed_node()
@@ -31,7 +33,7 @@ def test_traceroute_service_emits_completion_signal(
         route=[],
         route_back=[],
     )
-    observation = create_packet_observation(packet=packet, observer=source)
+    observation = create_packet_observation_for_tr(packet=packet, observer=source)
     now = timezone.now()
     packet.first_reported_time = now
     packet.save(update_fields=["first_reported_time"])
@@ -47,6 +49,7 @@ def test_traceroute_service_emits_completion_signal(
 
     mock_send.assert_called_once()
     _, kwargs = mock_send.call_args
+    assert kwargs["auto_tr"].pk == auto_tr.pk
     assert kwargs["auto_tr"].status == AutoTraceRoute.STATUS_COMPLETED
     assert kwargs["traceroute_packet"] == packet
     assert kwargs["packet_observation"] == observation

--- a/Meshflow/packets/tests/test_traceroute_service.py
+++ b/Meshflow/packets/tests/test_traceroute_service.py
@@ -1,0 +1,54 @@
+"""Tests for TraceroutePacketService signal emission."""
+
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+import packets.tests.conftest  # noqa: F401
+import users.tests.conftest  # noqa: F401
+from packets.services.traceroute import TraceroutePacketService
+from packets.signals import auto_traceroute_completed_from_packet
+from traceroute.models import AutoTraceRoute
+
+
+@pytest.mark.django_db
+def test_traceroute_service_emits_completion_signal(
+    create_managed_node,
+    create_observed_node,
+    create_traceroute_packet,
+    create_packet_observation,
+    create_user,
+):
+    source = create_managed_node()
+    target = create_observed_node(meshtastic_node_id=0xABCD1234)
+    user = create_user()
+    packet = create_traceroute_packet(
+        observer=source,
+        from_int=target.meshtastic_node_id,
+        route=[],
+        route_back=[],
+    )
+    observation = create_packet_observation(packet=packet, observer=source)
+    now = timezone.now()
+    packet.first_reported_time = now
+    packet.save(update_fields=["first_reported_time"])
+    auto_tr = AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_SENT,
+        triggered_at=now,
+    )
+
+    with patch.object(auto_traceroute_completed_from_packet, "send") as mock_send:
+        TraceroutePacketService().process_packet(packet, source, observation, user)
+
+    mock_send.assert_called_once()
+    _, kwargs = mock_send.call_args
+    assert kwargs["auto_tr"].status == AutoTraceRoute.STATUS_COMPLETED
+    assert kwargs["traceroute_packet"] == packet
+    assert kwargs["packet_observation"] == observation
+    assert kwargs["observer"] == source
+    assert kwargs["from_node"] == target

--- a/Meshflow/packets/tests/test_traceroute_service.py
+++ b/Meshflow/packets/tests/test_traceroute_service.py
@@ -12,6 +12,7 @@ import users.tests.conftest  # noqa: F401
 from packets.services.traceroute import TraceroutePacketService
 from packets.signals import auto_traceroute_completed_from_packet
 from traceroute.models import AutoTraceRoute
+from traceroute.tests.factories import make_auto_traceroute
 
 pytest_plugins = ["packets.tests.test_traceroute_receiver"]
 
@@ -37,7 +38,10 @@ def test_traceroute_service_emits_completion_signal(
     now = timezone.now()
     packet.first_reported_time = now
     packet.save(update_fields=["first_reported_time"])
-    auto_tr = AutoTraceRoute.objects.create(
+    auto_tr = make_auto_traceroute(
+        create_managed_node,
+        create_observed_node,
+        create_user,
         source_node=source,
         target_node=target,
         status=AutoTraceRoute.STATUS_SENT,

--- a/Meshflow/packets/traceroute_completion_wiring.py
+++ b/Meshflow/packets/traceroute_completion_wiring.py
@@ -1,0 +1,15 @@
+"""Register auto_traceroute_completed_from_packet handlers in product order (dx → mesh → traceroute)."""
+
+from packets.signals import auto_traceroute_completed_from_packet
+
+
+def connect_auto_traceroute_completed_receivers() -> None:
+    """Connect completion handlers once; called from packets.apps.PacketsConfig.ready()."""
+    from dx_monitoring.receivers import on_auto_traceroute_completed_from_packet as dx_handler
+    from mesh_monitoring.receivers import on_auto_traceroute_completed_from_packet as mesh_handler
+    from traceroute.receivers import on_auto_traceroute_completed_from_packet as tr_handler
+
+    signal = auto_traceroute_completed_from_packet
+    signal.connect(dx_handler, dispatch_uid="dx_monitoring.auto_traceroute_completed")
+    signal.connect(mesh_handler, dispatch_uid="mesh_monitoring.auto_traceroute_completed")
+    signal.connect(tr_handler, dispatch_uid="traceroute.auto_traceroute_completed")

--- a/Meshflow/traceroute/receivers.py
+++ b/Meshflow/traceroute/receivers.py
@@ -3,6 +3,7 @@
 from django.dispatch import receiver
 
 from packets.signals import new_node_observed
+from traceroute.models import AutoTraceRoute
 from traceroute.new_node_baseline import enqueue_new_node_baseline
 
 
@@ -10,3 +11,12 @@ from traceroute.new_node_baseline import enqueue_new_node_baseline
 def on_new_node_observed_enqueue_baseline_traceroute(sender, node, observer, **kwargs):
     """Queue a baseline route capture for a brand-new ObservedNode (non-DX infrastructure)."""
     enqueue_new_node_baseline(node, observer)
+
+
+def on_auto_traceroute_completed_from_packet(sender, auto_tr, **kwargs):
+    """Notify WebSocket clients and enqueue Neo4j export after packet-driven completion."""
+    from traceroute.lifecycle import schedule_completed_traceroute_neo4j_export
+    from traceroute.ws_notify import notify_traceroute_status_changed
+
+    notify_traceroute_status_changed(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
+    schedule_completed_traceroute_neo4j_export(auto_tr.id)

--- a/Meshflow/traceroute/tests/test_completion_receivers.py
+++ b/Meshflow/traceroute/tests/test_completion_receivers.py
@@ -1,0 +1,27 @@
+"""Tests for auto_traceroute_completed_from_packet traceroute receiver."""
+
+from unittest.mock import patch
+
+import pytest
+
+import nodes.tests.conftest  # noqa: F401
+from traceroute.models import AutoTraceRoute
+from traceroute.receivers import on_auto_traceroute_completed_from_packet
+
+
+@pytest.mark.django_db
+def test_completion_receiver_notifies_and_schedules_neo4j(create_managed_node, create_observed_node):
+    source = create_managed_node()
+    target = create_observed_node()
+    auto_tr = AutoTraceRoute.objects.create(
+        source_node=source,
+        target_node=target,
+        status=AutoTraceRoute.STATUS_COMPLETED,
+    )
+
+    with patch("traceroute.ws_notify.notify_traceroute_status_changed") as mock_notify:
+        with patch("traceroute.tasks.push_traceroute_to_neo4j") as mock_task:
+            on_auto_traceroute_completed_from_packet(sender=None, auto_tr=auto_tr)
+
+    mock_notify.assert_called_once_with(auto_tr.id, AutoTraceRoute.STATUS_COMPLETED)
+    mock_task.delay.assert_called_once_with(auto_tr.id)

--- a/Meshflow/traceroute/tests/test_completion_receivers.py
+++ b/Meshflow/traceroute/tests/test_completion_receivers.py
@@ -5,17 +5,18 @@ from unittest.mock import patch
 import pytest
 
 import nodes.tests.conftest  # noqa: F401
+import users.tests.conftest  # noqa: F401
 from traceroute.models import AutoTraceRoute
 from traceroute.receivers import on_auto_traceroute_completed_from_packet
+from traceroute.tests.factories import make_auto_traceroute
 
 
 @pytest.mark.django_db
-def test_completion_receiver_notifies_and_schedules_neo4j(create_managed_node, create_observed_node):
-    source = create_managed_node()
-    target = create_observed_node()
-    auto_tr = AutoTraceRoute.objects.create(
-        source_node=source,
-        target_node=target,
+def test_completion_receiver_notifies_and_schedules_neo4j(create_managed_node, create_observed_node, create_user):
+    auto_tr = make_auto_traceroute(
+        create_managed_node,
+        create_observed_node,
+        create_user,
         status=AutoTraceRoute.STATUS_COMPLETED,
     )
 

--- a/docs/features/mesh-monitoring/flow.md
+++ b/docs/features/mesh-monitoring/flow.md
@@ -7,7 +7,7 @@ Companion to [README.md](README.md). Diagrams use **Mermaid**; node IDs avoid sp
 | Component | Responsibility |
 |-----------|------------------|
 | **`mesh_monitoring` (Django app)** | `NodeWatch`, `NodePresence`, `NodeMonitoringConfig`; Celery task `process_node_watch_presence`; `selection` of monitoring TR sources; `services` state machine; watch + config REST views |
-| **`packets`** | Update `ObservedNode.last_heard`; on advance, call into `mesh_monitoring` to clear presence; emit **`device_metrics_recorded`** after persisting device metrics; TR packet receiver completes `AutoTraceRoute` rows |
+| **`packets`** | Update `ObservedNode.last_heard`; emit **`node_last_heard_advanced`** and **`device_metrics_recorded`**; TR packet service completes `AutoTraceRoute` and emits **`auto_traceroute_completed_from_packet`** |
 | **`traceroute`** | `AutoTraceRoute` including `trigger_type=4` (Node Watch); `pick_traceroute_target` excludes nodes under verification/offline; channel layer sends commands to bots |
 | **`meshtastic-bot`** | WebSocket client receives `traceroute` command, runs TR on radio, reports packets back to API |
 | **`push_notifications.discord`** | Send DM to a verified Discord user id (no OAuth in this module) |

--- a/docs/features/packet-ingestion/README.md
+++ b/docs/features/packet-ingestion/README.md
@@ -234,29 +234,28 @@ this is the first time we have heard from them, and emitting
 - Update `ObservedNode.last_heard`.
 - Update `NodeLatestStatus` (latest position, latest device metrics, inferred
 max hops) for telemetry/position packets.
-- Hand off to DX monitoring for candidate detection on the same call
-(`maybe_detect_dx_candidate`).
-- Clear mesh-monitoring presence state on any packet that advances
-`last_heard` (`clear_presence_on_packet_from_node`).
+- Emit post-processing signals (`packet_from_node_processed`,
+`node_last_heard_advanced`, `device_metrics_recorded`,
+`auto_traceroute_completed_from_packet`) for cross-app reactions.
 
 Beyond that, the `packets` app deliberately stops. Other apps subscribe to
-the same signals and own their own normalisation:
+ingest and post-processing signals and own their own normalisation. See
+[signals.md](signals.md) for kwargs and wiring order.
 
 - **Text messages** (`text_messages`) — listens for
 `message_packet_received` and creates `TextMessage` rows. Also handles
 node-claim secret-token detection and emits `node_claim_authorized` and
 `text_message_received`. See [features/node-lifecycle/](../node-lifecycle/)
 and the text-messages feature docs.
-- **Traceroutes** (`traceroute`, `traceroute_analytics`) — listens for
-`traceroute_packet_received` to match incoming responses to pending
-`AutoTraceRoute` rows (or create an `External` row for cross-environment
-responses), and to push edges into Neo4j. See
+- **Traceroutes** (`traceroute`, `traceroute_analytics`) — `TraceroutePacketService`
+completes `AutoTraceRoute` rows; `auto_traceroute_completed_from_packet`
+receivers handle WebSocket notify and Neo4j export. See
 [features/traceroute/](../traceroute/).
-- **Mesh monitoring** (`mesh_monitoring`) — uses `last_heard` updates and
-`device_metrics_recorded` for offline-verification and battery-alert
-decisions. See [features/mesh-monitoring/](../mesh-monitoring/).
-- **DX monitoring** (`dx_monitoring`) — invoked inline from
-`BasePacketService` to evaluate distant/returning-node observations. See
+- **Mesh monitoring** (`mesh_monitoring`) — `device_metrics_recorded`,
+`node_last_heard_advanced`, and traceroute completion receivers. See
+[features/mesh-monitoring/](../mesh-monitoring/).
+- **DX monitoring** (`dx_monitoring`) — `packet_from_node_processed` and
+traceroute completion receivers for candidate detection. See
 [features/dx-monitoring/](../dx-monitoring/).
 
 If you are adding a new downstream feature, the right pattern is almost

--- a/docs/features/packet-ingestion/signals.md
+++ b/docs/features/packet-ingestion/signals.md
@@ -1,0 +1,45 @@
+# Packet post-processing signals
+
+Neutral Django signals emitted by `packets` services after persistence. Feature apps subscribe in their own `receivers` modules and must not be imported from `packets/services/`.
+
+## Ingest vs post-processing
+
+1. **Ingest** (`PacketIngestView`) saves `MtRawPacket` + `PacketObservation`, then sends `packet_received` and the type-specific `*_packet_received` signal.
+2. **`packets/receivers.py`** runs the matching `*PacketService` (`BasePacketService.process_packet`).
+3. **Post-processing signals** (this document) fire from inside services for cross-app side effects.
+
+## Signals
+
+| Signal | Emitted from | kwargs | Typical subscribers |
+|--------|----------------|--------|---------------------|
+| `device_metrics_recorded` | `DeviceMetricsPacketService` | `observed_node`, `device_metrics`, `battery_level`, `reported_time` | `mesh_monitoring` (battery alerts) |
+| `auto_traceroute_completed_from_packet` | `TraceroutePacketService` | `auto_tr`, `traceroute_packet`, `packet_observation`, `observer`, `from_node` | `dx_monitoring`, `mesh_monitoring`, `traceroute` (see wiring below) |
+| `packet_from_node_processed` | `BasePacketService` (after `_process_packet`, **before** `last_heard` update) | `packet`, `observer`, `observation`, `from_node`, `previous_last_heard`, `from_node_created` | `dx_monitoring` (candidate detection) |
+| `node_last_heard_advanced` | `BasePacketService._update_node_last_heard` | `observed_node`, `last_heard` | `mesh_monitoring` (clear presence flags) |
+
+Definitions and docstrings: `Meshflow/packets/signals.py`.
+
+## Multi-app handler order
+
+Django runs receivers in connection order. For `auto_traceroute_completed_from_packet`, handlers are registered explicitly in **`packets/traceroute_completion_wiring.py`** (called from `PacketsConfig.ready()`):
+
+1. `dx_monitoring` — distant-hop detection, then exploration row completion
+2. `mesh_monitoring` — node-watch verification clear
+3. `traceroute` — WebSocket status + Neo4j export enqueue
+
+Feature modules define plain functions (not `@receiver` on that signal) to avoid duplicate connections.
+
+`packet_from_node_processed` and `node_last_heard_advanced` use `@receiver` in the owning app; each has a single subscriber.
+
+## Adding a new subscriber
+
+1. Implement a handler in **your app** (`myapp/receivers.py`).
+2. Import it from `myapp.apps.AppConfig.ready()` (or, for `auto_traceroute_completed_from_packet` only, add to `traceroute_completion_wiring.py` in the correct order).
+3. Do **not** import your app from `packets/services/`.
+4. Add tests that patch your handler or downstream services, not the packet service.
+
+## Related
+
+- [Packet ingestion overview](README.md)
+- [Traceroute flow](../traceroute/flow.md)
+- [Mesh monitoring flow](../mesh-monitoring/flow.md)

--- a/docs/features/traceroute/flow.md
+++ b/docs/features/traceroute/flow.md
@@ -46,7 +46,7 @@ When the traceroute response is received, the bot reports it as a packet. The pa
 
 ## 5. `TraceroutePacketService`: match, complete, `last_heard`
 
-`packets.receivers.on_traceroute_packet_received` delegates to `TraceroutePacketService` — the same `BasePacketService` pattern as other packet types: resolve the sender (`from_int`) as `ObservedNode`, run `_process_packet`, then `_update_node_last_heard` and `clear_presence_on_packet_from_node` for mesh monitoring.
+`packets.receivers.on_traceroute_packet_received` delegates to `TraceroutePacketService` — the same `BasePacketService` pattern as other packet types: resolve the sender (`from_int`) as `ObservedNode`, run `_process_packet`, emit `packet_from_node_processed` (DX skips traceroute packets), update `last_heard`, emit `node_last_heard_advanced` (mesh monitoring clears presence).
 
 `TraceroutePacketService._process_packet`:
 
@@ -54,7 +54,7 @@ When the traceroute response is received, the bot reports it as a packet. The pa
 2. If no match: creates an **external** `AutoTraceRoute` (cross-env or orphaned response). Use case: prod triggers a TR, but the response is ingested by pre-prod (shared node feeding both APIs). Pre-prod has no prior record, so it creates one with `trigger_type=2` (External), `triggered_at=now()`. The target `ObservedNode` is ensured by `BasePacketService._get_or_create_from_node` before this step.
 3. Builds `route` and `route_back` from packet data (node_ids + SNR).
 4. Marks `STATUS_COMPLETED`, saves route/route_back (possibly empty for a direct RF path), links `raw_packet`, clears any prior `error_message`. Empty hop lists match Meshtastic firmware’s “no intermediate hops” case; they are not treated as failure once a response packet is ingested.
-5. Calls `on_monitoring_traceroute_completed` for monitor traceroutes, `notify_traceroute_status_changed()` for WebSocket clients, and `push_traceroute_to_neo4j.delay(auto_tr.id)`.
+5. Emits `auto_traceroute_completed_from_packet`. Receivers (wired in order: dx_monitoring → mesh_monitoring → traceroute) run DX distant-hop detection and exploration follow-up, node-watch verification clear, WebSocket `notify_traceroute_status_changed`, and `push_traceroute_to_neo4j.delay`. See [packet-ingestion signals](../packet-ingestion/signals.md).
 
 True no-response for API-triggered traceroutes remains `pending` or `sent` until Celery marks them failed (see §6).
 


### PR DESCRIPTION
## Summary

- Add post-processing signals (`auto_traceroute_completed_from_packet`, `packet_from_node_processed`, `node_last_heard_advanced`) alongside existing `device_metrics_recorded`.
- `TraceroutePacketService` persists completion then emits `auto_traceroute_completed_from_packet`; dx_monitoring, mesh_monitoring, and traceroute own receivers (explicit wiring order: dx → mesh → traceroute).
- `BasePacketService` emits `packet_from_node_processed` before `last_heard` update and `node_last_heard_advanced` after, preserving DX `previous_last_heard` ordering.
- Document the pattern in `docs/features/packet-ingestion/signals.md`.

Closes #256

## Testing performed

- Unit tests for signal emission and receivers (`packets`, `dx_monitoring`, `traceroute`)
- DX ordering regression: `test_packet_from_node_processed_passes_previous_last_heard_before_update`
- `pytest` on `packets/`, `dx_monitoring/tests/`, `mesh_monitoring/tests/`, `traceroute/tests/`