### PR TITLE
feat(meshcore): MC text messages and channel sync (Phase 2.2)

### DIFF
--- a/Meshflow/common/feeder_ws.py
+++ b/Meshflow/common/feeder_ws.py
@@ -1,0 +1,38 @@
+"""Helpers for managed-node feeder bot WebSocket presence and command dispatch."""
+
+from __future__ import annotations
+
+import logging
+
+from channels.layers import get_channel_layer
+
+logger = logging.getLogger(__name__)
+
+FEEDER_BOT_NOT_CONNECTED = "feeder_bot_not_connected"
+COMMAND_DISPATCH_UNAVAILABLE = "command_dispatch_unavailable"
+
+
+async def feeder_ws_group_has_subscribers(group: str) -> bool:
+    """Return True if at least one bot WebSocket is subscribed to ``group``."""
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return False
+    if not hasattr(channel_layer, "group_channels"):
+        logger.warning("Channel layer does not support group_channels; assuming feeder offline")
+        return False
+    channels = await channel_layer.group_channels(group)
+    return bool(channels)
+
+
+async def dispatch_node_command(group: str, command: dict) -> None:
+    """Send a command to feeder bots on ``group``; raises on Redis/channel errors."""
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        raise RuntimeError("Channel layer is not configured")
+    await channel_layer.group_send(
+        group,
+        {
+            "type": "node_command",
+            "command": command,
+        },
+    )

--- a/Meshflow/common/ws_groups.py
+++ b/Meshflow/common/ws_groups.py
@@ -1,0 +1,11 @@
+"""Channel layer group names for managed-node bot WebSockets."""
+
+from common.protocol import Protocol
+from nodes.models import ManagedNode
+
+
+def managed_node_ws_group(managed_node: ManagedNode) -> str:
+    """Group name for pushing commands to a connected feeder bot."""
+    if managed_node.protocol == Protocol.MESHCORE:
+        return f"node_mc_{managed_node.internal_id}"
+    return f"node_{managed_node.meshtastic_node_id}"

--- a/Meshflow/constellations/migrations/0009_messagechannel_mc_type_hashtag.py
+++ b/Meshflow/constellations/migrations/0009_messagechannel_mc_type_hashtag.py
@@ -1,0 +1,41 @@
+# Generated manually for Phase 2.2 MC channels
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("constellations", "0008_rename_constellation_bot_meshtastic_defaults"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="messagechannel",
+            name="mc_channel_type",
+            field=models.PositiveSmallIntegerField(
+                blank=True,
+                choices=[(1, "PUBLIC"), (2, "HASHTAG")],
+                help_text="MeshCore channel type when protocol is MeshCore.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="messagechannel",
+            name="mc_hashtag",
+            field=models.CharField(
+                blank=True,
+                help_text="Hashtag string when mc_channel_type is HASHTAG (no leading #).",
+                max_length=64,
+                null=True,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="messagechannel",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("mc_channel_idx__isnull", False), ("protocol", 2)),
+                fields=("constellation", "protocol", "mc_channel_idx"),
+                name="messagechannel_mc_idx_constellation_unique",
+            ),
+        ),
+    ]

--- a/Meshflow/constellations/models.py
+++ b/Meshflow/constellations/models.py
@@ -50,6 +50,13 @@ class ConstellationUserMembership(models.Model):
         return f"{self.user.username} - {self.constellation.name}"
 
 
+class MeshCoreChannelType(models.IntegerChoices):
+    """MeshCore companion channel type (device config; not on wire)."""
+
+    PUBLIC = 1, _("PUBLIC")
+    HASHTAG = 2, _("HASHTAG")
+
+
 class MessageChannel(models.Model):
     """Message channel within a constellation (protocol-specific PSK/name; see ADR-0002)."""
 
@@ -66,10 +73,29 @@ class MessageChannel(models.Model):
         blank=True,
         help_text=_("MeshCore channel index when protocol is MeshCore; null for Meshtastic."),
     )
+    mc_channel_type = models.PositiveSmallIntegerField(
+        choices=MeshCoreChannelType.choices,
+        null=True,
+        blank=True,
+        help_text=_("MeshCore channel type when protocol is MeshCore."),
+    )
+    mc_hashtag = models.CharField(
+        max_length=64,
+        null=True,
+        blank=True,
+        help_text=_("Hashtag string when mc_channel_type is HASHTAG (no leading #)."),
+    )
 
     class Meta:
         verbose_name = _("Message channel")
         verbose_name_plural = _("Message channels")
+        constraints = [
+            models.UniqueConstraint(
+                fields=["constellation", "protocol", "mc_channel_idx"],
+                condition=models.Q(protocol=Protocol.MESHCORE, mc_channel_idx__isnull=False),
+                name="messagechannel_mc_idx_constellation_unique",
+            ),
+        ]
 
     def __str__(self):
         return self.name

--- a/Meshflow/meshcore_packets/serializers_channel.py
+++ b/Meshflow/meshcore_packets/serializers_channel.py
@@ -56,9 +56,7 @@ class McChannelApplySerializer(serializers.Serializer):
             if entry.get("mc_channel_type") == MeshCoreChannelType.HASHTAG.label:
                 tag = (entry.get("mc_hashtag") or entry.get("name") or "").strip().lstrip("#")
                 if not tag:
-                    raise serializers.ValidationError(
-                        {"channels": "Hashtag channels require a non-empty hashtag."}
-                    )
+                    raise serializers.ValidationError({"channels": "Hashtag channels require a non-empty hashtag."})
                 entry["mc_hashtag"] = tag[:64]
                 entry["name"] = tag[:100]
         return attrs

--- a/Meshflow/meshcore_packets/serializers_channel.py
+++ b/Meshflow/meshcore_packets/serializers_channel.py
@@ -1,0 +1,51 @@
+"""Serializers for MeshCore channel sync and UI apply."""
+
+from rest_framework import serializers
+
+from constellations.models import MeshCoreChannelType, MessageChannel
+
+
+class McChannelSnapshotEntrySerializer(serializers.Serializer):
+    mc_channel_idx = serializers.IntegerField(min_value=0, max_value=63)
+    name = serializers.CharField(max_length=100)
+    mc_channel_type = serializers.ChoiceField(
+        choices=[(c.label, c.label) for c in MeshCoreChannelType],
+    )
+    mc_hashtag = serializers.CharField(max_length=64, required=False, allow_null=True, allow_blank=True)
+
+
+class McChannelSyncSerializer(serializers.Serializer):
+    channels = McChannelSnapshotEntrySerializer(many=True)
+    synced_at = serializers.DateTimeField(required=False, allow_null=True)
+
+
+class MessageChannelMcSerializer(serializers.ModelSerializer):
+    mc_channel_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = MessageChannel
+        fields = [
+            "id",
+            "name",
+            "mc_channel_idx",
+            "mc_channel_type",
+            "mc_hashtag",
+        ]
+
+    def get_mc_channel_type(self, obj):
+        if obj.mc_channel_type is None:
+            return None
+        return MeshCoreChannelType(obj.mc_channel_type).label
+
+
+class McChannelApplyEntrySerializer(serializers.Serializer):
+    mc_channel_idx = serializers.IntegerField(min_value=0, max_value=63, required=False)
+    name = serializers.CharField(max_length=100)
+    mc_channel_type = serializers.ChoiceField(
+        choices=[(c.label, c.label) for c in MeshCoreChannelType],
+    )
+    mc_hashtag = serializers.CharField(max_length=64, required=False, allow_null=True, allow_blank=True)
+
+
+class McChannelApplySerializer(serializers.Serializer):
+    channels = McChannelApplyEntrySerializer(many=True)

--- a/Meshflow/meshcore_packets/serializers_channel.py
+++ b/Meshflow/meshcore_packets/serializers_channel.py
@@ -49,3 +49,16 @@ class McChannelApplyEntrySerializer(serializers.Serializer):
 
 class McChannelApplySerializer(serializers.Serializer):
     channels = McChannelApplyEntrySerializer(many=True)
+
+    def validate(self, attrs):
+        channels = attrs.get("channels") or []
+        for entry in channels:
+            if entry.get("mc_channel_type") == MeshCoreChannelType.HASHTAG.label:
+                tag = (entry.get("mc_hashtag") or entry.get("name") or "").strip().lstrip("#")
+                if not tag:
+                    raise serializers.ValidationError(
+                        {"channels": "Hashtag channels require a non-empty hashtag."}
+                    )
+                entry["mc_hashtag"] = tag[:64]
+                entry["name"] = tag[:100]
+        return attrs

--- a/Meshflow/meshcore_packets/services/channel.py
+++ b/Meshflow/meshcore_packets/services/channel.py
@@ -1,21 +1,34 @@
 """Resolve MeshCore MessageChannel rows per ADR-0002."""
 
 from common.protocol import Protocol
-from constellations.models import MessageChannel
+from constellations.models import MeshCoreChannelType, MessageChannel
 from nodes.models import ManagedNode
+
+MC_CHANNEL_IDX_MAX = 63
 
 
 def resolve_mc_channel(observer: ManagedNode, channel_idx: int | None) -> MessageChannel | None:
-    """Map (observer constellation, mc_channel_idx) to a MessageChannel; auto-create placeholder."""
+    """Map (observer constellation, mc_channel_idx) to a MessageChannel; prefer feeder M2M."""
     if channel_idx is None:
         return None
+    channel_idx = int(channel_idx)
+    if channel_idx < 0 or channel_idx > MC_CHANNEL_IDX_MAX:
+        return None
+
+    existing = observer.mc_channels.filter(mc_channel_idx=channel_idx).first()
+    if existing:
+        return existing
+
     constellation = observer.constellation
     channel, created = MessageChannel.objects.get_or_create(
         constellation=constellation,
         protocol=Protocol.MESHCORE,
         mc_channel_idx=channel_idx,
-        defaults={"name": f"MC channel {channel_idx}"},
+        defaults={
+            "name": f"MC channel {channel_idx}",
+            "mc_channel_type": MeshCoreChannelType.PUBLIC,
+        },
     )
     if created:
-        pass
+        observer.mc_channels.add(channel)
     return channel

--- a/Meshflow/meshcore_packets/services/channel_sync.py
+++ b/Meshflow/meshcore_packets/services/channel_sync.py
@@ -1,0 +1,89 @@
+"""Reconcile API MessageChannel mirror from MeshCore device snapshot."""
+
+from __future__ import annotations
+
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from common.protocol import Protocol
+from constellations.models import MeshCoreChannelType, MessageChannel
+from nodes.models import ManagedNode
+
+MC_CHANNEL_IDX_MAX = 63
+
+
+def _parse_channel_type(value: str | int | None) -> int | None:
+    if value is None:
+        return MeshCoreChannelType.PUBLIC
+    if isinstance(value, int):
+        if value in MeshCoreChannelType.values:
+            return value
+        return None
+    key = str(value).strip().upper()
+    if key in MeshCoreChannelType.names:
+        return MeshCoreChannelType[key]
+    return None
+
+
+def reconcile_mc_channels(
+    managed_node: ManagedNode,
+    channels: list[dict],
+    synced_at=None,
+) -> list[MessageChannel]:
+    """
+    Upsert constellation MC MessageChannel rows and set managed_node.mc_channels to match snapshot.
+
+    Each channel dict: mc_channel_idx, name, mc_channel_type (PUBLIC|HASHTAG), mc_hashtag (optional).
+    """
+    if managed_node.protocol != Protocol.MESHCORE:
+        raise ValueError("mc-channel-sync is only valid for MeshCore managed nodes")
+
+    constellation = managed_node.constellation
+    synced_dt = synced_at
+    if synced_at is not None and not hasattr(synced_at, "isoformat"):
+        synced_dt = parse_datetime(str(synced_at)) or timezone.now()
+    elif synced_at is None:
+        synced_dt = timezone.now()
+
+    attached: list[MessageChannel] = []
+
+    with transaction.atomic():
+        for entry in channels:
+            idx = entry.get("mc_channel_idx")
+            if idx is None:
+                continue
+            idx = int(idx)
+            if idx < 0 or idx > MC_CHANNEL_IDX_MAX:
+                raise ValueError(f"mc_channel_idx out of range: {idx}")
+
+            name = str(entry.get("name") or f"MC channel {idx}")[:100]
+            ch_type = _parse_channel_type(entry.get("mc_channel_type"))
+            if ch_type is None:
+                raise ValueError(f"invalid mc_channel_type: {entry.get('mc_channel_type')}")
+
+            hashtag = entry.get("mc_hashtag")
+            if hashtag is not None:
+                hashtag = str(hashtag).strip().lstrip("#")[:64] or None
+
+            if ch_type == MeshCoreChannelType.HASHTAG and not hashtag:
+                name_for_hash = name if name.startswith("#") else f"#{name}"
+                hashtag = name_for_hash.lstrip("#")[:64]
+
+            channel, _created = MessageChannel.objects.update_or_create(
+                constellation=constellation,
+                protocol=Protocol.MESHCORE,
+                mc_channel_idx=idx,
+                defaults={
+                    "name": name,
+                    "mc_channel_type": ch_type,
+                    "mc_hashtag": hashtag if ch_type == MeshCoreChannelType.HASHTAG else None,
+                },
+            )
+            attached.append(channel)
+
+        managed_node.mc_channels.set(attached)
+        managed_node.mc_channels_synced_at = synced_dt
+        managed_node.save(update_fields=["mc_channels_synced_at"])
+
+    return attached

--- a/Meshflow/meshcore_packets/services/text_message.py
+++ b/Meshflow/meshcore_packets/services/text_message.py
@@ -1,0 +1,72 @@
+"""Normalize MeshCore text packets into TextMessage rows."""
+
+import logging
+
+from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
+from common.meshcore_node_helpers import resolve_or_create_mc_observed_node
+from common.protocol import Protocol
+from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
+from meshcore_packets.signals import meshcore_text_packet_received
+from packets.signals import text_message_received
+from text_messages.models import TextMessage
+
+logger = logging.getLogger(__name__)
+
+
+class MeshCoreTextMessageService:
+    """Create TextMessage from ingested MeshCoreTextPacket."""
+
+    def process_packet(self, packet: MeshCoreTextPacket, observer, observation) -> TextMessage | None:
+        if TextMessage.objects.filter(original_mc_packet=packet).exists():
+            return None
+
+        if packet.payload_type == MeshCorePayloadType.CHANNEL_TEXT:
+            return self._create_channel_message(packet, observation)
+        if packet.payload_type == MeshCorePayloadType.CONTACT_TEXT:
+            return self._create_contact_message(packet)
+        return None
+
+    def _create_channel_message(self, packet: MeshCoreTextPacket, observation) -> TextMessage | None:
+        message = TextMessage.objects.create(
+            protocol=Protocol.MESHCORE,
+            original_mc_packet=packet,
+            sender=None,
+            recipient_meshtastic_node_id=None,
+            channel=packet.channel or observation.channel,
+            sent_at=packet.rx_time,
+            message_text=packet.text,
+            is_emoji=False,
+        )
+        text_message_received.send(sender=self, message=message, observer=observation.observer)
+        return message
+
+    def _create_contact_message(self, packet: MeshCoreTextPacket) -> TextMessage | None:
+        prefix = packet.from_pubkey_prefix
+        if not prefix and packet.from_pubkey:
+            prefix = packet.from_pubkey[:12]
+
+        sender = None
+        if prefix:
+            sender = resolve_or_create_mc_observed_node(
+                mc_pubkey=packet.from_pubkey,
+                mc_pubkey_prefix=prefix if not packet.from_pubkey else None,
+                last_heard=packet.rx_time,
+            )
+
+        return TextMessage.objects.create(
+            protocol=Protocol.MESHCORE,
+            original_mc_packet=packet,
+            sender=sender,
+            recipient_meshtastic_node_id=None,
+            channel=None,
+            sent_at=packet.rx_time,
+            message_text=packet.text,
+            is_emoji=False,
+        )
+
+
+def handle_meshcore_text_packet(sender, packet, observer, observation, **kwargs):
+    """Signal receiver: meshcore_text_packet_received → TextMessage."""
+    if not isinstance(packet, MeshCoreTextPacket):
+        return
+    MeshCoreTextMessageService().process_packet(packet, observer, observation)

--- a/Meshflow/meshcore_packets/services/text_message.py
+++ b/Meshflow/meshcore_packets/services/text_message.py
@@ -2,11 +2,9 @@
 
 import logging
 
-from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
 from common.meshcore_node_helpers import resolve_or_create_mc_observed_node
 from common.protocol import Protocol
 from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
-from meshcore_packets.signals import meshcore_text_packet_received
 from packets.signals import text_message_received
 from text_messages.models import TextMessage
 

--- a/Meshflow/meshcore_packets/tests/test_apply_channel.py
+++ b/Meshflow/meshcore_packets/tests/test_apply_channel.py
@@ -1,0 +1,129 @@
+"""Tests for apply-mc-channel-config API."""
+
+from unittest.mock import AsyncMock, patch
+
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+import pytest
+
+from common.feeder_ws import COMMAND_DISPATCH_UNAVAILABLE, FEEDER_BOT_NOT_CONNECTED
+from common.protocol import Protocol
+
+
+@pytest.mark.django_db
+def test_apply_returns_503_when_feeder_not_connected(create_user, create_managed_node):
+    user = create_user()
+    node = create_managed_node(
+        owner=user,
+        meshtastic_node_id=0,
+        protocol=Protocol.MESHCORE,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("meshcore-apply-mc-channel-config", kwargs={"internal_id": node.internal_id})
+
+    with patch(
+        "meshcore_packets.views.feeder_ws_group_has_subscribers",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        response = client.post(
+            url,
+            {
+                "channels": [
+                    {
+                        "mc_channel_idx": 0,
+                        "name": "galloway",
+                        "mc_channel_type": "HASHTAG",
+                        "mc_hashtag": "galloway",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+    assert response.status_code == 503
+    assert response.data["code"] == FEEDER_BOT_NOT_CONNECTED
+    assert "not connected" in response.data["detail"].lower()
+
+
+@pytest.mark.django_db
+def test_apply_returns_503_when_dispatch_fails(create_user, create_managed_node):
+    user = create_user()
+    node = create_managed_node(
+        owner=user,
+        meshtastic_node_id=0,
+        protocol=Protocol.MESHCORE,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("meshcore-apply-mc-channel-config", kwargs={"internal_id": node.internal_id})
+
+    with patch(
+        "meshcore_packets.views.feeder_ws_group_has_subscribers",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "meshcore_packets.views.dispatch_node_command",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("TCPTransport closed"),
+    ):
+        response = client.post(
+            url,
+            {
+                "channels": [
+                    {
+                        "mc_channel_idx": 0,
+                        "name": "Public",
+                        "mc_channel_type": "PUBLIC",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+    assert response.status_code == 503
+    assert response.data["code"] == COMMAND_DISPATCH_UNAVAILABLE
+
+
+@pytest.mark.django_db
+def test_apply_dispatches_when_feeder_connected(create_user, create_managed_node):
+    user = create_user()
+    node = create_managed_node(
+        owner=user,
+        meshtastic_node_id=0,
+        protocol=Protocol.MESHCORE,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("meshcore-apply-mc-channel-config", kwargs={"internal_id": node.internal_id})
+
+    with patch(
+        "meshcore_packets.views.feeder_ws_group_has_subscribers",
+        new_callable=AsyncMock,
+        return_value=True,
+    ), patch(
+        "meshcore_packets.views.dispatch_node_command",
+        new_callable=AsyncMock,
+    ) as dispatch_mock:
+        response = client.post(
+            url,
+            {
+                "channels": [
+                    {
+                        "mc_channel_idx": 1,
+                        "name": "tag",
+                        "mc_channel_type": "HASHTAG",
+                        "mc_hashtag": "#galloway",
+                    }
+                ]
+            },
+            format="json",
+        )
+
+    assert response.status_code == 202
+    dispatch_mock.assert_awaited_once()
+    sent_channels = dispatch_mock.await_args[0][1]["channels"]
+    assert sent_channels[0]["mc_hashtag"] == "galloway"
+    assert sent_channels[0]["name"] == "galloway"

--- a/Meshflow/meshcore_packets/tests/test_apply_channel.py
+++ b/Meshflow/meshcore_packets/tests/test_apply_channel.py
@@ -3,9 +3,9 @@
 from unittest.mock import AsyncMock, patch
 
 from django.urls import reverse
-from rest_framework.test import APIClient
 
 import pytest
+from rest_framework.test import APIClient
 
 from common.feeder_ws import COMMAND_DISPATCH_UNAVAILABLE, FEEDER_BOT_NOT_CONNECTED
 from common.protocol import Protocol
@@ -60,14 +60,17 @@ def test_apply_returns_503_when_dispatch_fails(create_user, create_managed_node)
     client.force_authenticate(user=user)
     url = reverse("meshcore-apply-mc-channel-config", kwargs={"internal_id": node.internal_id})
 
-    with patch(
-        "meshcore_packets.views.feeder_ws_group_has_subscribers",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "meshcore_packets.views.dispatch_node_command",
-        new_callable=AsyncMock,
-        side_effect=RuntimeError("TCPTransport closed"),
+    with (
+        patch(
+            "meshcore_packets.views.feeder_ws_group_has_subscribers",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "meshcore_packets.views.dispatch_node_command",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("TCPTransport closed"),
+        ),
     ):
         response = client.post(
             url,
@@ -99,14 +102,17 @@ def test_apply_dispatches_when_feeder_connected(create_user, create_managed_node
     client.force_authenticate(user=user)
     url = reverse("meshcore-apply-mc-channel-config", kwargs={"internal_id": node.internal_id})
 
-    with patch(
-        "meshcore_packets.views.feeder_ws_group_has_subscribers",
-        new_callable=AsyncMock,
-        return_value=True,
-    ), patch(
-        "meshcore_packets.views.dispatch_node_command",
-        new_callable=AsyncMock,
-    ) as dispatch_mock:
+    with (
+        patch(
+            "meshcore_packets.views.feeder_ws_group_has_subscribers",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "meshcore_packets.views.dispatch_node_command",
+            new_callable=AsyncMock,
+        ) as dispatch_mock,
+    ):
         response = client.post(
             url,
             {

--- a/Meshflow/meshcore_packets/tests/test_channel_sync.py
+++ b/Meshflow/meshcore_packets/tests/test_channel_sync.py
@@ -1,15 +1,15 @@
 """Tests for MC channel sync and resolve_mc_channel."""
 
-import pytest
 from django.urls import reverse
 from django.utils import timezone
+
+import pytest
 from rest_framework.test import APIClient
 
 from common.protocol import Protocol
 from constellations.models import MeshCoreChannelType, MessageChannel
 from meshcore_packets.services.channel import resolve_mc_channel
 from meshcore_packets.services.channel_sync import reconcile_mc_channels
-from nodes.models import NodeAuth
 
 
 @pytest.fixture

--- a/Meshflow/meshcore_packets/tests/test_channel_sync.py
+++ b/Meshflow/meshcore_packets/tests/test_channel_sync.py
@@ -1,0 +1,105 @@
+"""Tests for MC channel sync and resolve_mc_channel."""
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from common.protocol import Protocol
+from constellations.models import MeshCoreChannelType, MessageChannel
+from meshcore_packets.services.channel import resolve_mc_channel
+from meshcore_packets.services.channel_sync import reconcile_mc_channels
+from nodes.models import NodeAuth
+
+
+@pytest.fixture
+def sync_client(meshcore_feeder):
+    client = APIClient()
+    client.credentials(HTTP_X_API_KEY=meshcore_feeder["api_key"].key)
+    return client
+
+
+@pytest.mark.django_db
+def test_reconcile_mc_channels_creates_and_links(meshcore_feeder):
+    node = meshcore_feeder["node"]
+    channels = reconcile_mc_channels(
+        node,
+        [
+            {
+                "mc_channel_idx": 0,
+                "name": "Public",
+                "mc_channel_type": "PUBLIC",
+                "mc_hashtag": None,
+            },
+            {
+                "mc_channel_idx": 1,
+                "name": "Galloway",
+                "mc_channel_type": "HASHTAG",
+                "mc_hashtag": "galloway",
+            },
+        ],
+    )
+    assert len(channels) == 2
+    node.refresh_from_db()
+    assert node.mc_channels.count() == 2
+    assert node.mc_channels_synced_at is not None
+    ch0 = MessageChannel.objects.get(
+        constellation=node.constellation,
+        protocol=Protocol.MESHCORE,
+        mc_channel_idx=0,
+    )
+    assert ch0.mc_channel_type == MeshCoreChannelType.PUBLIC
+
+
+@pytest.mark.django_db
+def test_reconcile_updates_name_on_resync(meshcore_feeder):
+    node = meshcore_feeder["node"]
+    reconcile_mc_channels(
+        node,
+        [{"mc_channel_idx": 0, "name": "Old", "mc_channel_type": "PUBLIC"}],
+    )
+    reconcile_mc_channels(
+        node,
+        [{"mc_channel_idx": 0, "name": "Renamed", "mc_channel_type": "PUBLIC"}],
+    )
+    ch = MessageChannel.objects.get(
+        constellation=node.constellation,
+        protocol=Protocol.MESHCORE,
+        mc_channel_idx=0,
+    )
+    assert ch.name == "Renamed"
+
+
+@pytest.mark.django_db
+def test_mc_channel_sync_endpoint(sync_client, meshcore_feeder):
+    url = reverse("meshcore-mc-channel-sync")
+    response = sync_client.post(
+        url,
+        {
+            "channels": [
+                {
+                    "mc_channel_idx": 0,
+                    "name": "Public",
+                    "mc_channel_type": "PUBLIC",
+                }
+            ],
+            "synced_at": timezone.now().isoformat(),
+        },
+        format="json",
+    )
+    assert response.status_code == 200
+    assert len(response.data["mc_channels"]) == 1
+    meshcore_feeder["node"].refresh_from_db()
+    assert meshcore_feeder["node"].mc_channels.count() == 1
+
+
+@pytest.mark.django_db
+def test_resolve_mc_channel_prefers_m2m(meshcore_feeder):
+    node = meshcore_feeder["node"]
+    reconcile_mc_channels(
+        node,
+        [{"mc_channel_idx": 2, "name": "Synced", "mc_channel_type": "PUBLIC"}],
+    )
+    ch = resolve_mc_channel(node, 2)
+    assert ch.name == "Synced"
+    assert ch in node.mc_channels.all()

--- a/Meshflow/meshcore_packets/tests/test_ingest.py
+++ b/Meshflow/meshcore_packets/tests/test_ingest.py
@@ -10,7 +10,9 @@ from rest_framework.test import APIClient
 
 from common.protocol import Protocol
 from meshcore_packets.models import MeshCoreRawPacket
+from meshcore_packets.services.channel_sync import reconcile_mc_channels
 from nodes.models import MeshCoreLocationSource, NodeAuth, ObservedNode, Position
+from text_messages.models import TextMessage
 
 FULL_PUBKEY = "b" * 64
 PREFIX = "b" * 12
@@ -174,6 +176,31 @@ def test_meshcore_advertisement_without_coords_no_position(ingest_client, meshco
     assert node.latest_status.latitude == 55.0
     assert node.latest_status.longitude == -4.0
     assert Position.objects.filter(node=node).count() == 1
+
+
+@pytest.mark.django_db
+def test_meshcore_channel_text_creates_text_message(ingest_client, meshcore_feeder):
+    reconcile_mc_channels(
+        meshcore_feeder["node"],
+        [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}],
+    )
+    now = timezone.now()
+    payload = {
+        "event_type": "channel_message",
+        "payload_type": "channel_text",
+        "channel_idx": 0,
+        "pkt_hash": 4242,
+        "rx_time": now.timestamp(),
+        "text": "mesh hello",
+        "raw": {},
+    }
+    url = reverse("meshcore-packet-ingest")
+    response = ingest_client.post(url, payload, format="json")
+    assert response.status_code == 201
+    assert TextMessage.objects.filter(message_text="mesh hello").exists()
+    tm = TextMessage.objects.get(message_text="mesh hello")
+    assert tm.sender_id is None
+    assert tm.channel_id is not None
 
 
 @pytest.mark.django_db

--- a/Meshflow/meshcore_packets/tests/test_text_message_service.py
+++ b/Meshflow/meshcore_packets/tests/test_text_message_service.py
@@ -1,0 +1,69 @@
+"""Tests for MeshCoreTextMessageService."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from common.protocol import Protocol
+from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
+from meshcore_packets.services.text_message import MeshCoreTextMessageService
+from meshcore_packets.services.channel_sync import reconcile_mc_channels
+from text_messages.models import TextMessage
+
+
+@pytest.mark.django_db
+def test_channel_text_creates_broadcast_message(meshcore_feeder):
+    node = meshcore_feeder["node"]
+    reconcile_mc_channels(
+        node,
+        [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}],
+    )
+    now = timezone.now()
+    packet = MeshCoreTextPacket.objects.create(
+        observer=node,
+        payload_type=MeshCorePayloadType.CHANNEL_TEXT,
+        event_type="channel_message",
+        rx_time=now,
+        raw_json={},
+        text="hello mesh",
+        channel=node.mc_channels.first(),
+    )
+    from meshcore_packets.models import MeshCorePacketObservation
+
+    obs = MeshCorePacketObservation.objects.create(
+        packet=packet,
+        observer=node,
+        channel=packet.channel,
+        rx_time=now,
+    )
+    msg = MeshCoreTextMessageService().process_packet(packet, node, obs)
+    assert msg is not None
+    assert msg.protocol == Protocol.MESHCORE
+    assert msg.sender_id is None
+    assert msg.message_text == "hello mesh"
+    assert TextMessage.objects.filter(original_mc_packet=packet).count() == 1
+
+    dup = MeshCoreTextMessageService().process_packet(packet, node, obs)
+    assert dup is None
+
+
+@pytest.mark.django_db
+def test_contact_text_stores_with_sender_prefix(meshcore_feeder):
+    node = meshcore_feeder["node"]
+    now = timezone.now()
+    packet = MeshCoreTextPacket.objects.create(
+        observer=node,
+        payload_type=MeshCorePayloadType.CONTACT_TEXT,
+        event_type="contact_message",
+        from_pubkey_prefix="aabbccddeeff",
+        rx_time=now,
+        raw_json={},
+        text="dm hello",
+    )
+    from meshcore_packets.models import MeshCorePacketObservation
+
+    obs = MeshCorePacketObservation.objects.create(packet=packet, observer=node, rx_time=now)
+    msg = MeshCoreTextMessageService().process_packet(packet, node, obs)
+    assert msg.sender_id is not None
+    assert msg.channel_id is None

--- a/Meshflow/meshcore_packets/tests/test_text_message_service.py
+++ b/Meshflow/meshcore_packets/tests/test_text_message_service.py
@@ -1,14 +1,13 @@
 """Tests for MeshCoreTextMessageService."""
 
-from datetime import timedelta
+from django.utils import timezone
 
 import pytest
-from django.utils import timezone
 
 from common.protocol import Protocol
 from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
-from meshcore_packets.services.text_message import MeshCoreTextMessageService
 from meshcore_packets.services.channel_sync import reconcile_mc_channels
+from meshcore_packets.services.text_message import MeshCoreTextMessageService
 from text_messages.models import TextMessage
 
 

--- a/Meshflow/meshcore_packets/urls.py
+++ b/Meshflow/meshcore_packets/urls.py
@@ -1,8 +1,19 @@
 from django.urls import path
 
-from meshcore_packets.views import MeshCorePacketIngestView, MeshCorePacketListView
+from meshcore_packets.views import (
+    ManagedNodeMcChannelApplyView,
+    MeshCoreMcChannelSyncView,
+    MeshCorePacketIngestView,
+    MeshCorePacketListView,
+)
 
 urlpatterns = [
     path("packets/ingest/", MeshCorePacketIngestView.as_view(), name="meshcore-packet-ingest"),
     path("packets/", MeshCorePacketListView.as_view(), name="meshcore-packet-list"),
+    path("feeder/mc-channel-sync/", MeshCoreMcChannelSyncView.as_view(), name="meshcore-mc-channel-sync"),
+    path(
+        "managed-nodes/<uuid:internal_id>/apply-mc-channel-config/",
+        ManagedNodeMcChannelApplyView.as_view(),
+        name="meshcore-apply-mc-channel-config",
+    ),
 ]

--- a/Meshflow/meshcore_packets/views.py
+++ b/Meshflow/meshcore_packets/views.py
@@ -1,11 +1,18 @@
 """MeshCore packet API views."""
 
+import logging
+
 from asgiref.sync import async_to_sync
-from channels.layers import get_channel_layer
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from common.feeder_ws import (
+    COMMAND_DISPATCH_UNAVAILABLE,
+    FEEDER_BOT_NOT_CONNECTED,
+    dispatch_node_command,
+    feeder_ws_group_has_subscribers,
+)
 from common.ws_groups import managed_node_ws_group
 from meshcore_packets.models import MeshCoreRawPacket, MeshCoreTextPacket
 from meshcore_packets.permissions import MeshCoreFeederPermission
@@ -19,6 +26,8 @@ from meshcore_packets.services.channel_sync import reconcile_mc_channels
 from meshcore_packets.signals import meshcore_packet_received, meshcore_text_packet_received
 from nodes.authentication import NodeAPIKeyAuthentication
 from nodes.models import ManagedNode
+
+logger = logging.getLogger(__name__)
 
 
 class MeshCorePacketIngestView(APIView):
@@ -117,22 +126,32 @@ class MeshCoreMcChannelSyncView(APIView):
         )
 
 
-def _dispatch_mc_channel_apply(managed_node: ManagedNode, channels: list[dict]) -> bool:
-    channel_layer = get_channel_layer()
-    if channel_layer is None:
-        return False
+def _dispatch_mc_channel_apply(managed_node: ManagedNode, channels: list[dict]) -> str:
+    """Dispatch apply_mc_channel_config. Returns ``sent`` or an error code string."""
     group = managed_node_ws_group(managed_node)
-    async_to_sync(channel_layer.group_send)(
-        group,
-        {
-            "type": "node_command",
-            "command": {
-                "type": "apply_mc_channel_config",
-                "channels": channels,
-            },
-        },
-    )
-    return True
+
+    async def _check_and_send() -> str:
+        try:
+            if not await feeder_ws_group_has_subscribers(group):
+                return FEEDER_BOT_NOT_CONNECTED
+        except Exception as exc:
+            logger.exception("MC channel apply: feeder presence check failed: %s", exc)
+            return COMMAND_DISPATCH_UNAVAILABLE
+
+        try:
+            await dispatch_node_command(
+                group,
+                {
+                    "type": "apply_mc_channel_config",
+                    "channels": channels,
+                },
+            )
+        except Exception as exc:
+            logger.exception("MC channel apply: group_send failed: %s", exc)
+            return COMMAND_DISPATCH_UNAVAILABLE
+        return "sent"
+
+    return async_to_sync(_check_and_send)()
 
 
 class ManagedNodeMcChannelApplyView(APIView):
@@ -154,10 +173,26 @@ class ManagedNodeMcChannelApplyView(APIView):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         channels = serializer.validated_data["channels"]
-        sent = _dispatch_mc_channel_apply(managed_node, channels)
-        if not sent:
+        result = _dispatch_mc_channel_apply(managed_node, channels)
+        if result == FEEDER_BOT_NOT_CONNECTED:
             return Response(
-                {"detail": "WebSocket channel layer unavailable."},
+                {
+                    "detail": (
+                        "Feeder bot is not connected via WebSocket. "
+                        "Start the bot with MESHCORE_UPLOAD_ENABLED and MESHFLOW_WS_URL configured."
+                    ),
+                    "code": FEEDER_BOT_NOT_CONNECTED,
+                },
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        if result == COMMAND_DISPATCH_UNAVAILABLE:
+            return Response(
+                {
+                    "detail": (
+                        "Could not dispatch command to the feeder (channel layer / Redis unavailable)."
+                    ),
+                    "code": COMMAND_DISPATCH_UNAVAILABLE,
+                },
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 

--- a/Meshflow/meshcore_packets/views.py
+++ b/Meshflow/meshcore_packets/views.py
@@ -188,9 +188,7 @@ class ManagedNodeMcChannelApplyView(APIView):
         if result == COMMAND_DISPATCH_UNAVAILABLE:
             return Response(
                 {
-                    "detail": (
-                        "Could not dispatch command to the feeder (channel layer / Redis unavailable)."
-                    ),
+                    "detail": ("Could not dispatch command to the feeder (channel layer / Redis unavailable)."),
                     "code": COMMAND_DISPATCH_UNAVAILABLE,
                 },
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/Meshflow/meshcore_packets/views.py
+++ b/Meshflow/meshcore_packets/views.py
@@ -1,14 +1,24 @@
 """MeshCore packet API views."""
 
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from common.ws_groups import managed_node_ws_group
 from meshcore_packets.models import MeshCoreRawPacket, MeshCoreTextPacket
 from meshcore_packets.permissions import MeshCoreFeederPermission
 from meshcore_packets.serializers import MeshCorePacketIngestSerializer, MeshCorePacketListSerializer
+from meshcore_packets.serializers_channel import (
+    McChannelApplySerializer,
+    McChannelSyncSerializer,
+    MessageChannelMcSerializer,
+)
+from meshcore_packets.services.channel_sync import reconcile_mc_channels
 from meshcore_packets.signals import meshcore_packet_received, meshcore_text_packet_received
 from nodes.authentication import NodeAPIKeyAuthentication
+from nodes.models import ManagedNode
 
 
 class MeshCorePacketIngestView(APIView):
@@ -73,3 +83,88 @@ class MeshCorePacketListView(generics.ListAPIView):
         if observer_id:
             qs = qs.filter(observer__internal_id=observer_id)
         return qs
+
+
+class MeshCoreMcChannelSyncView(APIView):
+    """POST device channel snapshot from feeder bot; reconciles API mirror."""
+
+    authentication_classes = [NodeAPIKeyAuthentication]
+    permission_classes = [MeshCoreFeederPermission]
+
+    def post(self, request, format=None):
+        managed_node = request.auth.node
+        serializer = McChannelSyncSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            channels = reconcile_mc_channels(
+                managed_node,
+                serializer.validated_data["channels"],
+                synced_at=serializer.validated_data.get("synced_at"),
+            )
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        managed_node.refresh_from_db()
+        return Response(
+            {
+                "status": "success",
+                "synced_at": managed_node.mc_channels_synced_at,
+                "mc_channels": MessageChannelMcSerializer(channels, many=True).data,
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+def _dispatch_mc_channel_apply(managed_node: ManagedNode, channels: list[dict]) -> bool:
+    channel_layer = get_channel_layer()
+    if channel_layer is None:
+        return False
+    group = managed_node_ws_group(managed_node)
+    async_to_sync(channel_layer.group_send)(
+        group,
+        {
+            "type": "node_command",
+            "command": {
+                "type": "apply_mc_channel_config",
+                "channels": channels,
+            },
+        },
+    )
+    return True
+
+
+class ManagedNodeMcChannelApplyView(APIView):
+    """POST desired MC channels; pushes apply_mc_channel_config to connected feeder bot."""
+
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, internal_id, format=None):
+        managed_node = ManagedNode.objects.filter(
+            internal_id=internal_id,
+            deleted_at__isnull=True,
+            owner=request.user,
+        ).first()
+        if not managed_node:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = McChannelApplySerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        channels = serializer.validated_data["channels"]
+        sent = _dispatch_mc_channel_apply(managed_node, channels)
+        if not sent:
+            return Response(
+                {"detail": "WebSocket channel layer unavailable."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return Response(
+            {
+                "status": "dispatched",
+                "message": "apply_mc_channel_config sent to connected bot; device sync updates API mirror.",
+            },
+            status=status.HTTP_202_ACCEPTED,
+        )

--- a/Meshflow/nodes/migrations/0046_managednode_mc_channels.py
+++ b/Meshflow/nodes/migrations/0046_managednode_mc_channels.py
@@ -1,0 +1,33 @@
+# Generated manually for Phase 2.2 MC channels
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("constellations", "0009_messagechannel_mc_type_hashtag"),
+        ("nodes", "0045_position_meshcore_provenance"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="managednode",
+            name="mc_channels_synced_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text="When mc_channels was last reconciled from the device via bot sync.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="managednode",
+            name="mc_channels",
+            field=models.ManyToManyField(
+                blank=True,
+                help_text="MeshCore channels mirrored from the feeder device (protocol=MeshCore only).",
+                related_name="managed_nodes_mc",
+                to="constellations.messagechannel",
+            ),
+        ),
+    ]

--- a/Meshflow/nodes/models.py
+++ b/Meshflow/nodes/models.py
@@ -141,6 +141,18 @@ class ManagedNode(models.Model):
         help_text=_("Meshtastic channel slot 7 (PSK-backed MessageChannel)."),
     )
 
+    mc_channels = models.ManyToManyField(
+        "constellations.MessageChannel",
+        related_name="managed_nodes_mc",
+        blank=True,
+        help_text=_("MeshCore channels mirrored from the feeder device (protocol=MeshCore only)."),
+    )
+    mc_channels_synced_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text=_("When mc_channels was last reconciled from the device via bot sync."),
+    )
+
     allow_auto_traceroute = models.BooleanField(
         default=False,
         help_text=_("If True, this node may be used for auto-scheduled traceroutes and manual triggers."),

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -7,9 +7,8 @@ from rest_framework import serializers
 from common.mesh_node_helpers import meshtastic_id_to_hex, observed_node_id_str
 from common.protocol import Protocol
 from constellations.models import Constellation, ConstellationUserMembership, MessageChannel
-from users.models import User
-
 from meshcore_packets.serializers_channel import MessageChannelMcSerializer
+from users.models import User
 
 from .models import (
     AntennaPattern,

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -9,6 +9,8 @@ from common.protocol import Protocol
 from constellations.models import Constellation, ConstellationUserMembership, MessageChannel
 from users.models import User
 
+from meshcore_packets.serializers_channel import MessageChannelMcSerializer
+
 from .models import (
     AntennaPattern,
     DeviceMetrics,
@@ -381,6 +383,7 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ManagedNode
         fields = [
+            "internal_id",
             "meshtastic_node_id",
             "protocol",
             "name",
@@ -395,6 +398,7 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             "allow_auto_traceroute",
             "bot_version",
             "bot_version_reported_at",
+            "mc_channels_synced_at",
             "position",
             "device_metrics",
             "latest_environment_metrics",
@@ -776,11 +780,17 @@ class OwnedManagedNodeSerializer(ManagedNodeSerializer):
         else:
             rep["meshtastic_channel_7"] = None
 
+        rep["mc_channels"] = MessageChannelMcSerializer(
+            instance.mc_channels.order_by("mc_channel_idx"),
+            many=True,
+        ).data
+
         return rep
 
     class Meta:
         model = ManagedNode
         fields = ManagedNodeSerializer.Meta.fields + [
+            "mc_channels",
             "meshtastic_channel_0",
             "meshtastic_channel_1",
             "meshtastic_channel_2",

--- a/Meshflow/packets/services/text_message.py
+++ b/Meshflow/packets/services/text_message.py
@@ -46,7 +46,7 @@ class TextMessagePacketService(BasePacketService):
             message_text=self.packet.message_text,
             is_emoji=self.packet.emoji,
             reply_to_meshtastic_packet_id=self.packet.reply_packet_id,
-            sent_at=self.packet.rx_time or self.packet.first_reported_time,
+            sent_at=getattr(self.observation, "rx_time", None) or self.packet.first_reported_time,
             channel=self.observation.channel,
         )
 

--- a/Meshflow/packets/services/text_message.py
+++ b/Meshflow/packets/services/text_message.py
@@ -6,6 +6,7 @@ import re
 from django.utils import timezone
 
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
+from common.protocol import Protocol
 from nodes.models import NodeOwnerClaim
 from packets.models import MessagePacket
 from packets.services.base import BasePacketService
@@ -38,13 +39,14 @@ class TextMessagePacketService(BasePacketService):
 
         # Create a new Message record
         message = TextMessage.objects.create(
+            protocol=Protocol.MESHTASTIC,
             sender=self.from_node,
             original_packet=self.packet,
             recipient_meshtastic_node_id=self.packet.to_int,
             message_text=self.packet.message_text,
             is_emoji=self.packet.emoji,
             reply_to_meshtastic_packet_id=self.packet.reply_packet_id,
-            # the channel is based on the observer's channel mapping
+            sent_at=self.packet.rx_time or self.packet.first_reported_time,
             channel=self.observation.channel,
         )
 

--- a/Meshflow/packets/tests/test_text_message_service.py
+++ b/Meshflow/packets/tests/test_text_message_service.py
@@ -1,6 +1,9 @@
 import pytest
 
+from django.utils import timezone
+
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
+from common.protocol import Protocol
 from constellations.models import ConstellationUserMembership, MessageChannel
 from nodes.models import NodeOwnerClaim, ObservedNode
 from packets.services.text_message import TextMessagePacketService
@@ -40,11 +43,13 @@ def test_process_packet_already_processed(
 
     # Create a message with the same packet_id to simulate already processed
     TextMessage.objects.create(
+        protocol=Protocol.MESHTASTIC,
         sender=ObservedNode.objects.get_or_create(meshtastic_node_id=packet.from_int)[0],
         original_packet=packet,
         recipient_meshtastic_node_id=packet.to_int,
         message_text=packet.message_text,
         is_emoji=packet.emoji,
+        sent_at=timezone.now(),
     )
 
     # This should not raise an error, but also not create a new message

--- a/Meshflow/packets/tests/test_text_message_service.py
+++ b/Meshflow/packets/tests/test_text_message_service.py
@@ -1,6 +1,6 @@
-import pytest
-
 from django.utils import timezone
+
+import pytest
 
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
 from common.protocol import Protocol

--- a/Meshflow/text_messages/apps.py
+++ b/Meshflow/text_messages/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class TextMessagesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "text_messages"
+
+    def ready(self):
+        import text_messages.receivers  # noqa: F401

--- a/Meshflow/text_messages/migrations/0008_textmessage_mc_provenance.py
+++ b/Meshflow/text_messages/migrations/0008_textmessage_mc_provenance.py
@@ -1,0 +1,82 @@
+# Generated manually for Phase 2.2 MC text messages
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+import common.protocol
+
+
+def backfill_protocol(apps, schema_editor):
+    TextMessage = apps.get_model("text_messages", "TextMessage")
+    TextMessage.objects.filter(original_packet_id__isnull=False).update(protocol=1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("meshcore_packets", "0001_initial"),
+        ("text_messages", "0007_rename_textmessage_meshtastic_fields"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="textmessage",
+            name="protocol",
+            field=models.PositiveSmallIntegerField(
+                choices=[(1, "Meshtastic"), (2, "MeshCore")],
+                db_index=True,
+                default=common.protocol.Protocol.MESHTASTIC,
+                help_text="Mesh protocol for this message row.",
+            ),
+        ),
+        migrations.AddField(
+            model_name="textmessage",
+            name="original_mc_packet",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Provenance: MeshCore text packet.",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="text_messages",
+                to="meshcore_packets.meshcoretextpacket",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="textmessage",
+            name="original_packet",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Provenance: Meshtastic MessagePacket.",
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="text_messages",
+                to="packets.messagepacket",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="textmessage",
+            name="sender",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="nodes.observednode",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="textmessage",
+            name="sent_at",
+            field=models.DateTimeField(),
+        ),
+        migrations.RunPython(backfill_protocol, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="textmessage",
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(original_packet__isnull=False, original_mc_packet__isnull=True)
+                    | models.Q(original_packet__isnull=True, original_mc_packet__isnull=False)
+                ),
+                name="textmessage_single_provenance",
+            ),
+        ),
+    ]

--- a/Meshflow/text_messages/migrations/0008_textmessage_mc_provenance.py
+++ b/Meshflow/text_messages/migrations/0008_textmessage_mc_provenance.py
@@ -75,6 +75,7 @@ class Migration(migrations.Migration):
                 condition=(
                     models.Q(original_packet__isnull=False, original_mc_packet__isnull=True)
                     | models.Q(original_packet__isnull=True, original_mc_packet__isnull=False)
+                    | models.Q(original_packet__isnull=True, original_mc_packet__isnull=True)
                 ),
                 name="textmessage_single_provenance",
             ),

--- a/Meshflow/text_messages/models.py
+++ b/Meshflow/text_messages/models.py
@@ -54,6 +54,7 @@ class TextMessage(models.Model):
                 condition=(
                     Q(original_packet__isnull=False, original_mc_packet__isnull=True)
                     | Q(original_packet__isnull=True, original_mc_packet__isnull=False)
+                    | Q(original_packet__isnull=True, original_mc_packet__isnull=True)
                 ),
                 name="textmessage_single_provenance",
             ),

--- a/Meshflow/text_messages/models.py
+++ b/Meshflow/text_messages/models.py
@@ -1,36 +1,46 @@
 import uuid
 
 from django.db import models
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
+from common.protocol import Protocol
 from nodes.models import ObservedNode
 from packets.models import MessagePacket
 
 
 class TextMessage(models.Model):
-    """Text message on the mesh (Meshtastic-backed storage today).
-
-    Phase 2 is expected to split provenance across ``original_mt_packet`` and
-    ``original_mc_packet`` instead of a single ``original_packet`` FK; fields are
-    unchanged in Phase 1.0.
-    """
+    """Text message on the mesh (Meshtastic or MeshCore provenance)."""
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    protocol = models.PositiveSmallIntegerField(
+        choices=Protocol.choices,
+        default=Protocol.MESHTASTIC,
+        db_index=True,
+        help_text=_("Mesh protocol for this message row."),
+    )
     original_packet = models.ForeignKey(
         MessagePacket,
         null=True,
+        blank=True,
         on_delete=models.CASCADE,
-        help_text=_(
-            "Provenance: Meshtastic ``MessagePacket`` today. Phase 2 may split into "
-            "``original_mt_packet`` / ``original_mc_packet`` FKs without renaming this column."
-        ),
+        related_name="text_messages",
+        help_text=_("Provenance: Meshtastic MessagePacket."),
+    )
+    original_mc_packet = models.ForeignKey(
+        "meshcore_packets.MeshCoreTextPacket",
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name="text_messages",
+        help_text=_("Provenance: MeshCore text packet."),
     )
 
-    sender = models.ForeignKey(ObservedNode, on_delete=models.CASCADE)
+    sender = models.ForeignKey(ObservedNode, on_delete=models.CASCADE, null=True, blank=True)
     recipient_meshtastic_node_id = models.BigIntegerField(null=True, blank=True)
     channel = models.ForeignKey("constellations.MessageChannel", on_delete=models.CASCADE, null=True, blank=True)
 
-    sent_at = models.DateTimeField(auto_now_add=True)
+    sent_at = models.DateTimeField()
 
     message_text = models.TextField(null=False, blank=False)
     is_emoji = models.BooleanField(null=False, default=False)
@@ -39,8 +49,17 @@ class TextMessage(models.Model):
     class Meta:
         verbose_name = _("Text message")
         verbose_name_plural = _("Text messages")
+        constraints = [
+            models.CheckConstraint(
+                condition=(
+                    Q(original_packet__isnull=False, original_mc_packet__isnull=True)
+                    | Q(original_packet__isnull=True, original_mc_packet__isnull=False)
+                ),
+                name="textmessage_single_provenance",
+            ),
+        ]
 
     def __str__(self):
-        return (
-            f"{self.sender.node_id_str} -> {self.recipient_meshtastic_node_id or '^all'}: {self.message_text[:10]}..."
-        )
+        sender_label = self.sender.node_id_str if self.sender_id else "?"
+        recipient = self.recipient_meshtastic_node_id or "^all"
+        return f"{sender_label} -> {recipient}: {self.message_text[:10]}..."

--- a/Meshflow/text_messages/receivers.py
+++ b/Meshflow/text_messages/receivers.py
@@ -2,8 +2,8 @@
 
 from django.dispatch import receiver
 
-from meshcore_packets.signals import meshcore_text_packet_received
 from meshcore_packets.services.text_message import handle_meshcore_text_packet
+from meshcore_packets.signals import meshcore_text_packet_received
 
 
 @receiver(meshcore_text_packet_received)

--- a/Meshflow/text_messages/receivers.py
+++ b/Meshflow/text_messages/receivers.py
@@ -1,0 +1,11 @@
+"""Text message signal receivers."""
+
+from django.dispatch import receiver
+
+from meshcore_packets.signals import meshcore_text_packet_received
+from meshcore_packets.services.text_message import handle_meshcore_text_packet
+
+
+@receiver(meshcore_text_packet_received)
+def on_meshcore_text_packet_received(sender, packet, observer, observation, **kwargs):
+    handle_meshcore_text_packet(sender, packet=packet, observer=observer, observation=observation, **kwargs)

--- a/Meshflow/text_messages/serializers.py
+++ b/Meshflow/text_messages/serializers.py
@@ -1,37 +1,47 @@
 from rest_framework import serializers
 
+from common.protocol import Protocol
 from constellations.models import MessageChannel
+from meshcore_packets.models import MeshCorePacketObservation
 from nodes.models import ObservedNode
+from packets.models import PacketObservation
 from packets.serializers import PrefetchedPacketObservationSerializer
 
 from .models import TextMessage
 
 
 class TextMessageSerializer(serializers.ModelSerializer):
-    """Mesh text message (Meshtastic-backed storage today).
-
-    ``original_packet`` / ``packet_id`` reference a Meshtastic ``MessagePacket``; Phase 2
-    may add MeshCore provenance without changing JSON field names in Phase 1.
-    """
+    """Mesh text message (Meshtastic or MeshCore)."""
 
     class ObservedNodeSerializer(serializers.ModelSerializer):
         class Meta:
             model = ObservedNode
             fields = ["node_id_str", "long_name", "short_name"]
 
-    sender = ObservedNodeSerializer(read_only=True)
+    sender = ObservedNodeSerializer(read_only=True, allow_null=True)
     channel = serializers.PrimaryKeyRelatedField(queryset=MessageChannel.objects.all())
     heard = serializers.SerializerMethodField()
     packet_id = serializers.SerializerMethodField()
+    protocol = serializers.SerializerMethodField()
+
+    def get_protocol(self, obj):
+        return Protocol(obj.protocol).label.lower()
 
     def get_packet_id(self, obj):
-        return obj.original_packet.packet_id if obj.original_packet else None
+        if obj.original_packet_id:
+            return obj.original_packet.packet_id
+        if obj.original_mc_packet_id:
+            mc = obj.original_mc_packet
+            return mc.pkt_hash if mc.pkt_hash is not None else str(mc.id)
+        return None
 
     class Meta:
         model = TextMessage
         fields = [
             "id",
+            "protocol",
             "original_packet_id",
+            "original_mc_packet_id",
             "packet_id",
             "sender",
             "recipient_meshtastic_node_id",
@@ -42,23 +52,23 @@ class TextMessageSerializer(serializers.ModelSerializer):
             "reply_to_meshtastic_packet_id",
             "heard",
         ]
-        # all fields are read-only (must be a list or tuple)
-        read_only_fields = [
-            "id",
-            "original_packet_id",
-            "packet_id",
-            "sender",
-            "recipient_meshtastic_node_id",
-            "channel",
-            "sent_at",
-            "message_text",
-            "is_emoji",
-            "reply_to_meshtastic_packet_id",
-            "heard",
-        ]
+        read_only_fields = fields
 
     def get_heard(self, obj):
-        # Use prefetched observations if available
+        if obj.protocol == Protocol.MESHCORE and obj.original_mc_packet_id:
+            observations = MeshCorePacketObservation.objects.filter(
+                packet_id=obj.original_mc_packet_id,
+            ).select_related("observer")
+            return [
+                {
+                    "observer": obs.observer.node_id_str,
+                    "rx_time": obs.rx_time,
+                    "rx_rssi": obs.rx_rssi,
+                    "rx_snr": obs.rx_snr,
+                }
+                for obs in observations
+            ]
+
         if hasattr(obj.original_packet, "prefetched_observations"):
             observations = obj.original_packet.prefetched_observations
             return PrefetchedPacketObservationSerializer(observations, many=True, context=self.context).data

--- a/Meshflow/text_messages/serializers.py
+++ b/Meshflow/text_messages/serializers.py
@@ -4,7 +4,6 @@ from common.protocol import Protocol
 from constellations.models import MessageChannel
 from meshcore_packets.models import MeshCorePacketObservation
 from nodes.models import ObservedNode
-from packets.models import PacketObservation
 from packets.serializers import PrefetchedPacketObservationSerializer
 
 from .models import TextMessage

--- a/Meshflow/text_messages/views.py
+++ b/Meshflow/text_messages/views.py
@@ -1,9 +1,12 @@
 from django.db import models
+from django.db.models import Q
 
 from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
 
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
+from common.protocol import Protocol
+from meshcore_packets.models import MeshCorePacketObservation
 from nodes.models import ManagedNode, ObservedNode
 from packets.models import PacketObservation
 
@@ -17,42 +20,49 @@ class TextMessageViewSet(viewsets.ModelViewSet):
     http_method_names = ["get", "delete", "head", "options"]
 
     def get_queryset(self):
-        queryset = TextMessage.objects.select_related("sender", "original_packet").all().order_by("-sent_at")
+        queryset = (
+            TextMessage.objects.select_related(
+                "sender",
+                "original_packet",
+                "original_mc_packet",
+                "channel",
+            )
+            .all()
+            .order_by("-sent_at")
+        )
 
         constellation_id = self.request.query_params.get("constellation_id")
         channel_id = self.request.query_params.get("channel_id")
         sender_node_id = self.request.query_params.get("sender_node_id")
+        protocol_param = self.request.query_params.get("protocol")
+
         if constellation_id:
             queryset = queryset.filter(channel__constellation_id=constellation_id)
         if channel_id:
             queryset = queryset.filter(channel_id=channel_id)
         if sender_node_id:
             queryset = queryset.filter(sender__meshtastic_node_id=int(sender_node_id))
+        if protocol_param:
+            key = protocol_param.strip().lower()
+            if key in ("meshtastic", "mt", "1"):
+                queryset = queryset.filter(protocol=Protocol.MESHTASTIC)
+            elif key in ("meshcore", "mc", "2"):
+                queryset = queryset.filter(protocol=Protocol.MESHCORE)
 
-        # filter out any DMs (i.e. recipient_meshtastic_node_id must be '^all')
-        queryset = queryset.filter(recipient_meshtastic_node_id=MESHTASTIC_BROADCAST_ID)
+        queryset = queryset.filter(
+            Q(protocol=Protocol.MESHTASTIC, recipient_meshtastic_node_id=MESHTASTIC_BROADCAST_ID)
+            | Q(protocol=Protocol.MESHCORE, sender__isnull=True, channel__isnull=False)
+        )
 
-        # Prefetch observations and their observer for each original_packet
         observation_qs = PacketObservation.objects.select_related("observer")
         queryset = queryset.prefetch_related(
             models.Prefetch("original_packet__observations", queryset=observation_qs, to_attr="prefetched_observations")
         )
 
-        # NB: Keeping this prefetch for posterity - it's not needed because we're using the observer_nodes_map
-        #     It also doesn't work because ManagedNode doesn't have a formal FK to ObservedNode
-        # # Prefetch ObservedNode for all observer nodes referenced by PacketObservation
-        # observer_node_ids = PacketObservation.objects.values_list("observer_id", flat=True).distinct()
-        # observed_nodes = ObservedNode.objects.filter(meshtastic_node_id__in=observer_node_ids)
-        # queryset = queryset.prefetch_related(
-        #     models.Prefetch("original_packet__observations__observer__observednode_set",
-        #                     queryset=observed_nodes, to_attr="prefetched_observed_nodes")
-        # )
-
         return queryset
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        # Build a mapping of node_id -> ObservedNode for all relevant nodes
         observer_node_ids = (
             ManagedNode.objects.filter(deleted_at__isnull=True).values_list("meshtastic_node_id", flat=True).distinct()
         )

--- a/Meshflow/text_messages/views.py
+++ b/Meshflow/text_messages/views.py
@@ -6,7 +6,6 @@ from rest_framework.permissions import IsAuthenticated
 
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
 from common.protocol import Protocol
-from meshcore_packets.models import MeshCorePacketObservation
 from nodes.models import ManagedNode, ObservedNode
 from packets.models import PacketObservation
 

--- a/Meshflow/traceroute/dispatch.py
+++ b/Meshflow/traceroute/dispatch.py
@@ -18,6 +18,8 @@ from django.utils import timezone
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 
+from common.ws_groups import managed_node_ws_group
+
 from .models import AutoTraceRoute
 from .trigger_intervals import MONITORING_TRIGGER_MIN_INTERVAL_SEC
 from .ws_notify import notify_traceroute_status_changed
@@ -133,7 +135,7 @@ def _send_and_update(tr: AutoTraceRoute, channel_layer) -> dict:
     now = timezone.now()
     try:
         async_to_sync(channel_layer.group_send)(
-            f"node_{tr.source_node.meshtastic_node_id}",
+            managed_node_ws_group(tr.source_node),
             {
                 "type": "node_command",
                 "command": {"type": "traceroute", "target": tr.target_node.meshtastic_node_id},

--- a/Meshflow/traceroute/views.py
+++ b/Meshflow/traceroute/views.py
@@ -287,8 +287,10 @@ def traceroute_trigger(request):
 
     # Send command via channel layer
     channel_layer = get_channel_layer()
+    from common.ws_groups import managed_node_ws_group
+
     async_to_sync(channel_layer.group_send)(
-        f"node_{source_node.meshtastic_node_id}",
+        managed_node_ws_group(source_node),
         {"type": "node_command", "command": {"type": "traceroute", "target": target_node.meshtastic_node_id}},
     )
 

--- a/Meshflow/ws/consumers.py
+++ b/Meshflow/ws/consumers.py
@@ -37,8 +37,10 @@ class NodeConsumer(AsyncWebsocketConsumer):
             await self.close()
             return
 
+        from common.ws_groups import managed_node_ws_group
+
         self.managed_node = managed_node
-        self.node_group = f"node_{managed_node.meshtastic_node_id}"
+        self.node_group = managed_node_ws_group(managed_node)
 
         await self.channel_layer.group_add(self.node_group, self.channel_name)
         await self.accept()

--- a/docs/features/meshcore/phase-2-outstanding.md
+++ b/docs/features/meshcore/phase-2-outstanding.md
@@ -66,29 +66,29 @@ Items **skipped**, **incomplete**, or **discovered during Phase 2 / rename execu
 
 Design: [text-message-channels.md](./text-message-channels.md) (device = source of truth for channel config; API mirror via sync).
 
-**API**
+**API** (branch `api-296/paddy/mc-text-channels` — merge pending)
 
-- [ ] `MessageChannel`: `mc_channel_type`, `mc_hashtag`; uniqueness `(constellation, protocol, mc_channel_idx)`.
-- [ ] `ManagedNode.mc_channels` M2M; optional `mc_channels_synced_at`.
-- [ ] `POST …/mc-channel-sync/` — reconcile mirror from bot device snapshot.
-- [ ] `resolve_mc_channel` — prefer feeder M2M; placeholder before first sync.
-- [ ] `TextMessage`: `protocol`, `original_mc_packet`, nullable `sender`, provenance CHECK.
-- [ ] `MeshCoreTextMessageService` + `meshcore_text_packet_received` receiver.
-- [ ] History API: `protocol` filter; MC channel broadcast; MC `heard` observations.
-- [ ] WS `apply_mc_channel_config` (UI → device; bot re-syncs after).
-- [ ] OpenAPI + tests.
+- [x] `MessageChannel`: `mc_channel_type`, `mc_hashtag`; uniqueness `(constellation, protocol, mc_channel_idx)`.
+- [x] `ManagedNode.mc_channels` M2M; optional `mc_channels_synced_at`.
+- [x] `POST …/mc-channel-sync/` — reconcile mirror from bot device snapshot.
+- [x] `resolve_mc_channel` — prefer feeder M2M; placeholder before first sync.
+- [x] `TextMessage`: `protocol`, `original_mc_packet`, nullable `sender`, provenance CHECK.
+- [x] `MeshCoreTextMessageService` + `meshcore_text_packet_received` receiver.
+- [x] History API: `protocol` filter; MC channel broadcast; MC `heard` observations.
+- [x] WS `apply_mc_channel_config` (UI → device; bot re-syncs after).
+- [x] OpenAPI + tests.
 
-**Bot (child #297)**
+**Bot (child #297)** (branch `api-296/paddy/mc-text-channels` — merge pending)
 
-- [ ] Read device channel table on connect; `POST mc-channel-sync`.
-- [ ] WS handler: apply config → write device → re-sync.
-- [ ] Enable MC WebSocket when storage API configured.
-- [ ] meshcore_py channel read/write spike.
+- [x] Read device channel table on connect; `POST mc-channel-sync`.
+- [x] WS handler: apply config → write device → re-sync.
+- [x] Enable MC WebSocket when storage API configured.
+- [x] meshcore_py channel read/write spike.
 
-**UI (child #297)**
+**UI (child #297)** (branch `api-296/paddy/mc-channel-settings` — merge pending)
 
-- [ ] Display synced `mc_channels`; apply-to-radio (not API-only save).
-- [ ] Sync status / bot offline messaging.
+- [x] Display synced `mc_channels`; apply-to-radio (not API-only save).
+- [ ] Sync status / bot offline messaging (basic toasts only; richer UX deferred).
 
 **Deferred (2.2)**
 

--- a/docs/features/meshcore/phase-2-progress.md
+++ b/docs/features/meshcore/phase-2-progress.md
@@ -82,23 +82,25 @@ Deploy api #325 before bot fleet upgrade.
 
 ## Phase 2.2 — text messages & channels
 
-**Status:** Not started (design only). **Guide:** [text-message-channels.md](./text-message-channels.md). **Plan:** `.cursor/plans/mc_text_textmessage_pipeline_2c3e9fb8.plan.md`. **Issues:** [#296](https://github.com/pskillen/meshflow-api/issues/296), [#297](https://github.com/pskillen/meshflow-api/issues/297).
+**Status:** Implemented on branch `api-296/paddy/mc-text-channels` (API + bot + ui); PRs pending. **Guide:** [text-message-channels.md](./text-message-channels.md). **Issues:** [#296](https://github.com/pskillen/meshflow-api/issues/296), [#297](https://github.com/pskillen/meshflow-api/issues/297).
 
-**Design (2026-05-20): channel config**
+**meshflow-api — delivered**
 
-- **Source of truth:** MeshCore **device** channel table (names, types, indices), not API-first CRUD.
-- **On bot connect:** read device → `POST mc-channel-sync` → API reconciles `MessageChannel` + `ManagedNode.mc_channels`.
-- **UI edits:** push to radio via WebSocket `apply_mc_channel_config`; bot re-reads device and syncs again.
-- **Drift:** connect sync overwrites API from device (no three-way merge in v1).
-- **Ingest:** `resolve_mc_channel` uses synced M2M; placeholder only before first sync.
+- `MessageChannel.mc_channel_type` / `mc_hashtag`; `ManagedNode.mc_channels` M2M + `mc_channels_synced_at`.
+- `POST /api/meshcore/feeder/mc-channel-sync/`; `POST …/apply-mc-channel-config/` (WS dispatch).
+- `MeshCoreTextMessageService` + `text_messages` receiver; `TextMessage.protocol` + `original_mc_packet`.
+- History API `protocol` query; MC `heard` from `MeshCorePacketObservation`.
+- `managed_node_ws_group` for MC feeder WebSocket (`node_mc_{internal_id}`).
+- Tests: `test_channel_sync.py`, `test_text_message_service.py`.
 
-**Planned deliverables**
+**meshflow-bot — delivered**
 
-| Area | #296 | #297 |
-| --- | --- | --- |
-| API | `TextMessage.protocol`, `original_mc_packet`, `MeshCoreTextMessageService`, history filter | `mc_channels` M2M, `mc-channel-sync`, WS apply |
-| Bot | (upload unchanged) | connect sync + WS apply + re-sync |
-| UI | — | mirror display + apply-to-radio |
+- `read_device_channels` / `apply_device_channels` via meshcore_py; `post_mc_channel_sync` on connect.
+- WS `apply_mc_channel_config`; MC feeders enable WebSocket when storage API configured.
+
+**meshflow-ui — delivered**
+
+- MeshCore channel panel on Node Settings (mirror + apply-to-radio).
 
 ---
 

--- a/docs/features/meshcore/text-message-channels.md
+++ b/docs/features/meshcore/text-message-channels.md
@@ -304,7 +304,7 @@ Identity receiver **skips** channel text (no `from_pubkey` / prefix). Contact te
 - **Meshtastic feeders:** [Node Settings](https://github.com/pskillen/meshflow-ui/blob/main/src/pages/user/NodeSettings.tsx) maps **slots 0–7** to constellation `MessageChannel` rows via `meshtastic_channel_*` PATCH fields.
 - **MeshCore feeders:** no channel editor; MC map/nodes views do not configure channels.
 
-### Planned (#297)
+### Implemented (#297)
 
 When `ManagedNode.protocol === MESHCORE`:
 
@@ -322,9 +322,9 @@ When `ManagedNode.protocol === MESHCORE`:
 1. Create MC **constellation** and **ManagedNode** feeder ([feeder-bootstrap.md](feeder-bootstrap.md)).
 2. Link **Node API key** via `NodeAuth` (one key per feeder recommended).
 3. Configure bot env (`MESHCORE_UPLOAD_ENABLED`, storage API).
-4. **(Planned #297)** Start bot with upload enabled; on connect it syncs device channels to API. Optionally use UI to apply changes **to the radio**, then wait for re-sync.
+4. Start bot with upload enabled; on connect it syncs device channels to API. Optionally use UI to apply changes **to the radio**, then wait for re-sync.
 5. Confirm `channel_message` ingest: `MeshCoreTextPacket` rows with `channel` FK and matching `mc_channel_idx`.
-6. **(Planned #296)** Confirm `TextMessage` rows appear on `GET /api/messages/?protocol=2` (or mixed list) for channel traffic.
+6. Confirm `TextMessage` rows appear on `GET /api/messages/text/?protocol=meshcore` for channel traffic.
 
 ---
 
@@ -334,13 +334,13 @@ When `ManagedNode.protocol === MESHCORE`:
 |------------|--------|
 | Bot upload `channel_text` / `contact_text` | **Done** (Phase 1) |
 | API store `MeshCoreTextPacket` + observation | **Done** |
-| `resolve_mc_channel` placeholder `MessageChannel` | **Done** (partial ADR-0002) |
-| `ManagedNode.mc_channels` + channel types | **Planned** [#297](https://github.com/pskillen/meshflow-api/issues/297) |
-| Bot device → API `mc-channel-sync` on connect | **Planned** [#297](https://github.com/pskillen/meshflow-bot/issues/297) (child) |
-| Bot WS apply + re-sync after UI push | **Planned** [#297](https://github.com/pskillen/meshflow-bot/issues/297) (child) |
-| API `POST mc-channel-sync` reconcile | **Planned** [#297](https://github.com/pskillen/meshflow-api/issues/297) |
-| UI MC channel mirror + apply-to-radio | **Planned** [#297](https://github.com/pskillen/meshflow-ui/issues/297) (child) |
-| `TextMessage` + `protocol` field | **Planned** [#296](https://github.com/pskillen/meshflow-api/issues/296) |
+| `resolve_mc_channel` via feeder `mc_channels` | **Done** (API branch `api-296/paddy/mc-text-channels`) |
+| `ManagedNode.mc_channels` + channel types | **Done** (API) |
+| API `POST /api/meshcore/feeder/mc-channel-sync/` | **Done** (API) |
+| `TextMessage` + `protocol` field + history filter | **Done** (API) [#296](https://github.com/pskillen/meshflow-api/issues/296) |
+| Bot device → API `mc-channel-sync` on connect | **Done** (bot, same branch family) |
+| Bot WS apply + re-sync after UI push | **Done** (bot) |
+| UI MC channel mirror + apply-to-radio | **Done** (ui) |
 | MC message history in UI | **Deferred** (epic #266 UI) |
 
 ---

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3723,7 +3723,19 @@ paths:
         '404':
           description: Managed node not found or not owned
         '503':
-          description: WebSocket channel layer unavailable
+          description: Feeder bot not connected or command dispatch unavailable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                  code:
+                    type: string
+                    enum:
+                      - feeder_bot_not_connected
+                      - command_dispatch_unavailable
 
   /meshcore/packets/:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1687,6 +1687,11 @@ components:
         Managed nodes submit data to the API (or a bot process does), and a managed node often has an
         associated ObservedNode.
       properties:
+        internal_id:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Stable UUID for this managed node (use for MC WebSocket paths)
         meshtastic_node_id:
           type: integer
           format: int64
@@ -1853,6 +1858,16 @@ components:
               $ref: '#/components/schemas/MessageChannel'
             meshtastic_channel_7:
               $ref: '#/components/schemas/MessageChannel'
+            mc_channels:
+              type: array
+              description: MeshCore channels mirrored from device (protocol=MeshCore only)
+              items:
+                $ref: '#/components/schemas/MessageChannel'
+            mc_channels_synced_at:
+              type: string
+              format: date-time
+              nullable: true
+              readOnly: true
 
     PaginatedResponse:
       type: object
@@ -2470,21 +2485,36 @@ components:
     TextMessage:
       type: object
       description: >
-        A text message on the mesh (Meshtastic-backed storage today). packet_id references the
-        Meshtastic MessagePacket; Phase 2 may add MeshCore provenance without renaming JSON keys.
+        A text message on the mesh (Meshtastic or MeshCore). packet_id is Meshtastic MessagePacket.packet_id
+        or MeshCore pkt_hash / packet UUID for MC rows.
       properties:
         id:
           description: The internal ID of the text message
           type: string
           readOnly: true
           format: uuid
-        packet_id:
-          description: Meshtastic MessagePacket.packet_id for the ingested message (provenance)
+        protocol:
+          $ref: '#/components/schemas/MeshProtocol'
+          readOnly: true
+        original_packet_id:
           type: integer
+          nullable: true
+          readOnly: true
+        original_mc_packet_id:
+          type: string
+          format: uuid
+          nullable: true
+          readOnly: true
+        packet_id:
+          description: Provenance packet id (MT packet_id or MC pkt_hash / UUID)
+          oneOf:
+            - type: integer
+            - type: string
           readOnly: true
         sender:
           type: object
-          description: The sender node info
+          nullable: true
+          description: The sender node info (null for anonymous MC channel text)
           properties:
             node_id_str:
               type: string
@@ -2544,9 +2574,62 @@ components:
           nullable: true
           minimum: 0
           description: MeshCore channel index when protocol is MeshCore; null for Meshtastic
+        mc_channel_type:
+          type: string
+          nullable: true
+          enum: [PUBLIC, HASHTAG]
+          description: MeshCore channel type when protocol is MeshCore
+        mc_hashtag:
+          type: string
+          nullable: true
+          description: Hashtag string when mc_channel_type is HASHTAG (no leading #)
         constellation:
           type: integer
           description: The ID of the constellation this channel belongs to
+
+    McChannelSyncEntry:
+      type: object
+      required: [mc_channel_idx, name, mc_channel_type]
+      properties:
+        mc_channel_idx:
+          type: integer
+          minimum: 0
+          maximum: 63
+        name:
+          type: string
+        mc_channel_type:
+          type: string
+          enum: [PUBLIC, HASHTAG]
+        mc_hashtag:
+          type: string
+          nullable: true
+
+    McChannelSyncRequest:
+      type: object
+      required: [channels]
+      properties:
+        channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/McChannelSyncEntry'
+        synced_at:
+          type: string
+          format: date-time
+          nullable: true
+
+    McChannelSyncResponse:
+      type: object
+      properties:
+        status:
+          type: string
+        synced_at:
+          type: string
+          format: date-time
+          nullable: true
+        mc_channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/MessageChannel'
 
     ConstellationMember:
       type: object
@@ -3580,6 +3663,67 @@ paths:
           description: Invalid payload
         '403':
           description: API key not linked to a MeshCore feeder
+
+  /meshcore/feeder/mc-channel-sync/:
+    post:
+      summary: Sync MeshCore channels from device snapshot
+      description: >
+        Feeder bot POSTs the full channel table read from the companion device. API reconciles
+        MessageChannel rows and ManagedNode.mc_channels (device is source of truth).
+      tags: [MeshCore packets]
+      security:
+        - NodeApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/McChannelSyncRequest'
+      responses:
+        '200':
+          description: Mirror updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/McChannelSyncResponse'
+        '400':
+          description: Invalid payload
+
+  /meshcore/managed-nodes/{internal_id}/apply-mc-channel-config/:
+    post:
+      summary: Push channel config to connected feeder radio
+      description: >
+        Dispatches apply_mc_channel_config to the feeder's WebSocket. Bot writes the device then
+        re-syncs via mc-channel-sync. Requires bot online.
+      tags: [MeshCore packets]
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: internal_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [channels]
+              properties:
+                channels:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/McChannelSyncEntry'
+      responses:
+        '202':
+          description: Command dispatched to bot
+        '404':
+          description: Managed node not found or not owned
+        '503':
+          description: WebSocket channel layer unavailable
 
   /meshcore/packets/:
     get:
@@ -6869,6 +7013,13 @@ paths:
           schema:
             type: integer
           description: Filter messages by sender node ID (for "By Node" view)
+        - name: protocol
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [meshtastic, meshcore, mt, mc, 1, 2]
+          description: Filter by mesh protocol (Meshtastic or MeshCore)
       responses:
         '200':
           description: List of text messages


### PR DESCRIPTION
## Summary

Implements Phase 2.2 for MeshCore text messages and channel configuration ([#296](https://github.com/pskillen/meshflow-api/issues/296), [#297](https://github.com/pskillen/meshflow-api/issues/297), epic [#266](https://github.com/pskillen/meshflow-api/issues/266)).

- **Channels:** `MessageChannel` MC metadata, `ManagedNode.mc_channels` M2M, device-driven `POST /api/meshcore/feeder/mc-channel-sync/`, `resolve_mc_channel` prefers feeder mirror.
- **Text:** `TextMessage.protocol`, `original_mc_packet`, nullable sender; `MeshCoreTextMessageService` on ingest; history API `protocol` filter and MC heard observations.
- **WS:** `apply_mc_channel_config` on MC feeder group; `POST …/apply-mc-channel-config/` for UI.
- **OpenAPI** and unit/ingest tests updated.

Design: [text-message-channels.md](docs/features/meshcore/text-message-channels.md) (device = source of truth).

Companion PRs: [meshflow-bot](https://github.com/pskillen/meshflow-bot/compare/main...api-296/paddy/mc-text-channels), [meshflow-ui](https://github.com/pskillen/meshflow-ui/compare/main...api-296/paddy/mc-channel-settings).

Closes #296.

## Testing performed

- `python -m pytest meshcore_packets/tests/ packets/tests/test_text_message_service.py -v` (35 passed)
- Migrations: `constellations/0009`, `nodes/0046`, `text_messages/0008`

## Deploy notes

Deploy **api first**, then bot + ui. Run migrations and `run_deploy_tasks`. MC feeders need `MESHCORE_UPLOAD_ENABLED` and storage API for channel sync + WS.