### PR TITLE
fix(admin): use meshtastic_channel_* in ManagedNodeAdmin fieldsets

### DIFF
--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -51,7 +51,7 @@ MANAGED_NODE_COMMON_FIELDS = (
     "allow_auto_traceroute",
     "latlong",
 )
-MANAGED_NODE_CHANNEL_FIELDS = tuple(f"channel_{i}" for i in range(8))
+MANAGED_NODE_CHANNEL_FIELDS = tuple(f"meshtastic_channel_{i}" for i in range(8))
 
 
 class ProtocolListFilter(admin.SimpleListFilter):

--- a/Meshflow/nodes/tests/test_managed_node_admin_form.py
+++ b/Meshflow/nodes/tests/test_managed_node_admin_form.py
@@ -1,7 +1,8 @@
 import pytest
 
 from common.protocol import Protocol
-from nodes.admin import ManagedNodeAdminForm
+from nodes.admin import MANAGED_NODE_CHANNEL_FIELDS, ManagedNodeAdmin, ManagedNodeAdminForm
+from nodes.models import ManagedNode
 
 
 @pytest.mark.django_db
@@ -22,3 +23,18 @@ def test_managed_node_admin_form_meshcore_node_id_defaults_to_zero(create_user, 
     )
     assert form.is_valid(), form.errors
     assert form.cleaned_data["meshtastic_node_id"] == 0
+
+
+def test_managed_node_channel_admin_fields_match_model():
+    model_fields = {f.name for f in ManagedNode._meta.get_fields()}
+    assert MANAGED_NODE_CHANNEL_FIELDS == tuple(f"meshtastic_channel_{i}" for i in range(8))
+    assert set(MANAGED_NODE_CHANNEL_FIELDS).issubset(model_fields)
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_fieldsets_include_meshtastic_channels(create_managed_node):
+    node = create_managed_node()
+    admin = ManagedNodeAdmin(ManagedNode, None)
+    fieldsets = admin.get_fieldsets(request=None, obj=node)
+    channel_section = next(fs for fs in fieldsets if fs[0] == "Meshtastic channels")
+    assert channel_section[1]["fields"] == MANAGED_NODE_CHANNEL_FIELDS


### PR DESCRIPTION
## Summary

- Update `MANAGED_NODE_CHANNEL_FIELDS` to `meshtastic_channel_0`…`meshtastic_channel_7` after migration `0040_rename_managednode_meshtastic_channels`.
- Fixes `FieldError` on Django admin change page for Meshtastic managed nodes (`Unknown field(s) channel_0, …`).

## Test plan

- [x] `python -m pytest Meshflow/nodes/tests/test_managed_node_admin_form.py -v`
- [ ] Open `/admin/nodes/managednode/<uuid>/change/` for a Meshtastic feeder and confirm the Meshtastic channels fieldset loads