### PR TITLE
fix(constellations): return all protocol constellations by default

### DIFF
--- a/Meshflow/common/protocol.py
+++ b/Meshflow/common/protocol.py
@@ -9,3 +9,26 @@ class Protocol(models.IntegerChoices):
 
     MESHTASTIC = 1, _("Meshtastic")
     MESHCORE = 2, _("MeshCore")
+
+
+_PROTOCOL_QUERY_ALIASES = {
+    "meshtastic": Protocol.MESHTASTIC,
+    "meshcore": Protocol.MESHCORE,
+    "mt": Protocol.MESHTASTIC,
+    "mc": Protocol.MESHCORE,
+    "1": Protocol.MESHTASTIC,
+    "2": Protocol.MESHCORE,
+}
+
+
+def protocol_from_query_param(value):
+    """
+    Parse ?protocol= from list endpoints (meshtastic, meshcore, mt, mc, 1, 2).
+    Returns None when absent or unrecognized (no filter).
+    """
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    return _PROTOCOL_QUERY_ALIASES.get(text)

--- a/Meshflow/common/tests/test_protocol_query.py
+++ b/Meshflow/common/tests/test_protocol_query.py
@@ -1,0 +1,18 @@
+import pytest
+
+from common.protocol import Protocol, protocol_from_query_param
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, None),
+        ("", None),
+        ("meshtastic", Protocol.MESHTASTIC),
+        ("meshcore", Protocol.MESHCORE),
+        ("2", Protocol.MESHCORE),
+        ("bogus", None),
+    ],
+)
+def test_protocol_from_query_param(raw, expected):
+    assert protocol_from_query_param(raw) == expected

--- a/Meshflow/constellations/serializers.py
+++ b/Meshflow/constellations/serializers.py
@@ -1,6 +1,22 @@
 from rest_framework import serializers
 
-from .models import Constellation, ConstellationUserMembership, MessageChannel
+from constellations.models import Constellation, ConstellationUserMembership, MeshCoreChannelType, MessageChannel
+
+
+def message_channel_payload(channel: MessageChannel) -> dict:
+    """Nested channel dict for Constellation list/detail (matches MessageChannel schema)."""
+    mc_type = None
+    if channel.mc_channel_type is not None:
+        mc_type = MeshCoreChannelType(channel.mc_channel_type).label
+    return {
+        "id": channel.id,
+        "name": channel.name,
+        "protocol": channel.protocol,
+        "mc_channel_idx": channel.mc_channel_idx,
+        "mc_channel_type": mc_type,
+        "mc_hashtag": channel.mc_hashtag,
+        "constellation": channel.constellation_id,
+    }
 
 
 class ConstellationSerializer(serializers.ModelSerializer):
@@ -24,16 +40,11 @@ class ConstellationSerializer(serializers.ModelSerializer):
         read_only_fields = ["created_by"]
 
     def get_channels(self, obj):
-        channels = MessageChannel.objects.filter(constellation=obj)
-        return [
-            {
-                "id": channel.id,
-                "name": channel.name,
-                "protocol": channel.protocol,
-                "mc_channel_idx": channel.mc_channel_idx,
-            }
-            for channel in channels
-        ]
+        channels = MessageChannel.objects.filter(constellation=obj).order_by("id")
+        protocol_filter = self.context.get("channel_protocol_filter")
+        if protocol_filter is not None:
+            channels = channels.filter(protocol=protocol_filter)
+        return [message_channel_payload(ch) for ch in channels]
 
     def create(self, validated_data):
         """Create a new constellation."""

--- a/Meshflow/constellations/tests/test_constellation_views.py
+++ b/Meshflow/constellations/tests/test_constellation_views.py
@@ -4,6 +4,7 @@ import pytest
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from common.protocol import Protocol
 from constellations.models import Constellation, ConstellationUserMembership, MessageChannel
 
 
@@ -27,6 +28,76 @@ def test_constellation_list_view(create_constellation, create_user):
     assert len(results) == 2
     assert results[0]["name"] == constellation1.name
     assert results[1]["name"] == constellation2.name
+
+
+@pytest.mark.django_db
+def test_constellation_list_includes_meshcore_and_meshtastic(create_constellation, create_user):
+    """List returns member constellations for every protocol when ?protocol is omitted."""
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+
+    mt = create_constellation(created_by=user, name="MT Region", protocol=Protocol.MESHTASTIC)
+    mc = create_constellation(created_by=user, name="MC Region", protocol=Protocol.MESHCORE)
+    MessageChannel.objects.create(
+        name="MC Public",
+        constellation=mc,
+        protocol=Protocol.MESHCORE,
+        mc_channel_idx=0,
+    )
+
+    response = client.get(reverse("constellation-list"))
+
+    assert response.status_code == status.HTTP_200_OK
+    by_id = {row["id"]: row for row in response.data["results"]}
+    assert mt.id in by_id
+    assert mc.id in by_id
+    assert by_id[mc.id]["protocol"] == Protocol.MESHCORE
+    assert len(by_id[mc.id]["channels"]) == 1
+    assert by_id[mc.id]["channels"][0]["protocol"] == Protocol.MESHCORE
+
+
+@pytest.mark.django_db
+def test_constellation_list_protocol_query_filters_constellations_and_channels(create_constellation, create_user):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+
+    mt = create_constellation(created_by=user, name="MT Only", protocol=Protocol.MESHTASTIC)
+    MessageChannel.objects.create(name="MT Ch", constellation=mt, protocol=Protocol.MESHTASTIC)
+    mc = create_constellation(created_by=user, name="MC Only", protocol=Protocol.MESHCORE)
+    MessageChannel.objects.create(
+        name="MC Ch",
+        constellation=mc,
+        protocol=Protocol.MESHCORE,
+        mc_channel_idx=1,
+    )
+
+    response = client.get(reverse("constellation-list"), {"protocol": "meshcore"})
+
+    assert response.status_code == status.HTTP_200_OK
+    ids = {row["id"] for row in response.data["results"]}
+    assert ids == {mc.id}
+    channels = response.data["results"][0]["channels"]
+    assert len(channels) == 1
+    assert channels[0]["name"] == "MC Ch"
+
+
+@pytest.mark.django_db
+def test_constellation_channels_list_protocol_filter(create_constellation, create_user):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    constellation = create_constellation(created_by=user, protocol=Protocol.MESHCORE)
+    MessageChannel.objects.create(name="MC", constellation=constellation, protocol=Protocol.MESHCORE, mc_channel_idx=0)
+    MessageChannel.objects.create(name="MT stray", constellation=constellation, protocol=Protocol.MESHTASTIC)
+
+    url = reverse("constellation-channels-list-create", kwargs={"constellation_id": constellation.id})
+    response = client.get(url, {"protocol": "meshcore"})
+
+    assert response.status_code == status.HTTP_200_OK
+    names = [row["name"] for row in response.data["results"]]
+    assert names == ["MC"]
 
 
 @pytest.mark.django_db

--- a/Meshflow/constellations/views.py
+++ b/Meshflow/constellations/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.response import Response
 
+from common.protocol import protocol_from_query_param
 from Meshflow.permissions import NoPermission
 
 from .models import Constellation, ConstellationUserMembership, MessageChannel
@@ -31,7 +32,7 @@ class ConstellationViewSet(viewsets.ModelViewSet):
         if self.action == "create":
             return [admin_permission]
         elif self.action == "list":
-            return [permissions.AllowAny()]
+            return [permissions.IsAuthenticated()]
         elif self.action == "retrieve":
             return [permissions.OR(admin_permission, IsConstellationMember())]
         elif self.action in ["update", "partial_update"]:
@@ -41,18 +42,27 @@ class ConstellationViewSet(viewsets.ModelViewSet):
         else:
             return [NoPermission()]
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        if self.action == "list":
+            context["channel_protocol_filter"] = protocol_from_query_param(self.request.query_params.get("protocol"))
+        return context
+
     def get_queryset(self):
         """
-        Return constellations that the user is a member of.
+        Return constellations the user is a member of.
+        Optional ?protocol=meshtastic|meshcore filters by constellation.protocol; omit to return all protocols.
         """
         if self.action == "retrieve":
             # For single object retrieval, return all constellations to let permission classes handle access
             return Constellation.objects.all().order_by("id")
 
-        # For list view, only return constellations the user is a member of
-        return (
-            Constellation.objects.filter(constellationusermembership__user=self.request.user).distinct().order_by("id")
-        )
+        qs = Constellation.objects.filter(constellationusermembership__user=self.request.user).distinct().order_by("id")
+        if self.action == "list":
+            protocol_val = protocol_from_query_param(self.request.query_params.get("protocol"))
+            if protocol_val is not None:
+                qs = qs.filter(protocol=protocol_val)
+        return qs
 
     def perform_create(self, serializer):
         """
@@ -156,7 +166,11 @@ class ConstellationMessageChannelsViewSet(
     def get_queryset(self):
         constellation_id = self.kwargs.get("constellation_id")
         constellation = get_object_or_404(Constellation, pk=constellation_id)
-        return MessageChannel.objects.filter(constellation=constellation).order_by("id")
+        qs = MessageChannel.objects.filter(constellation=constellation).order_by("id")
+        protocol_val = protocol_from_query_param(self.request.query_params.get("protocol"))
+        if protocol_val is not None:
+            qs = qs.filter(protocol=protocol_val)
+        return qs
 
     def get_permissions(self):
         admin_permission = permissions.IsAdminUser()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4086,13 +4086,23 @@ paths:
   /constellations/:
     get:
       summary: List constellations
-      description: Returns a list of any constellation for which the user is a member (regardless of role)
+      description: >
+        Returns constellations the authenticated user is a member of (any role), including both Meshtastic and
+        MeshCore protocol rows. Omit `protocol` to return all protocols; pass `protocol=meshtastic` or
+        `protocol=meshcore` to filter by `Constellation.protocol`. Embedded `channels` respect the same optional
+        filter.
       tags: [Constellations]
       security:
         - BearerAuth: []
       parameters:
         - $ref: '#/components/parameters/PaginationPage'
         - $ref: '#/components/parameters/PaginationPageSize'
+        - name: protocol
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/MeshProtocol'
+          description: Optional filter by mesh protocol (meshtastic or meshcore). Omit to include all protocols.
       responses:
         '200':
           description: List of constellations
@@ -4341,7 +4351,9 @@ paths:
   /constellations/{id}/channels/:
     get:
       summary: List message channels for a constellation
-      description: User must be a member of the constellation (any role)
+      description: >
+        User must be a member of the constellation (any role). Omit `protocol` to return all channel rows; pass
+        `protocol=meshtastic` or `protocol=meshcore` to filter by `MessageChannel.protocol`.
       tags: [Constellations]
       security:
         - BearerAuth: []
@@ -4351,6 +4363,12 @@ paths:
           required: true
           schema:
             type: integer
+        - name: protocol
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/MeshProtocol'
+          description: Optional filter by mesh protocol. Omit to return all channels for the constellation.
       responses:
         '200':
           description: List of message channels for the constellation


### PR DESCRIPTION
# Summary

Constellation list was effectively empty for users without constellation membership, and nested channels omitted some MeshCore fields. This change makes the default list return **all** member constellations (Meshtastic and MeshCore), with an optional `?protocol=` filter on list and channel sub-resources.

- Optional `?protocol=meshtastic|meshcore|1|2` on `GET /constellations/` and `GET /constellations/{id}/channels/`
- Without the param: no protocol filter on constellations (membership filter unchanged)
- Nested `channels` include full MC fields (`mc_channel_type`, `mc_hashtag`, etc.) when context applies
- Constellation **list** requires authentication (`IsAuthenticated`)
- Shared `protocol_from_query_param()` in `common/protocol.py`

**Note:** MeshCore constellations still require the user to be a member and the constellation row to have `protocol=2`. Broader guest/public access is tracked in #346.

Closes meshflow-ui#277 (API side)

## Testing performed

- `python -m pytest Meshflow/constellations/tests/test_constellation_views.py Meshflow/common/tests/test_protocol_query.py -v`
- black / isort / flake8 on touched files
- `openapi.yaml` updated for optional `protocol` query param

## Deploy notes

No migrations. Safe to ship with meshflow-ui PR #287 (client filters by `Constellation.protocol`).