### PR TITLE
feat(nodes): flexible observed-node detail lookup (#280)

### DIFF
--- a/Meshflow/common/mesh_node_helpers.py
+++ b/Meshflow/common/mesh_node_helpers.py
@@ -15,8 +15,24 @@ if TYPE_CHECKING:
 
 MESHTASTIC_BROADCAST_ID = 0xFFFFFFFF
 
+MT_NODE_ID_STR_PREFIX = "mt:"
+
 # Deprecated alias — prefer MESHTASTIC_BROADCAST_ID; remove once all call sites are migrated.
 BROADCAST_ID = MESHTASTIC_BROADCAST_ID
+
+
+def normalize_meshtastic_lookup_hex(token: str) -> str | None:
+    """Extract 8-char Meshtastic hex from ``!…``, ``mt:…``, or bare suffix."""
+    t = token.strip()
+    lower = t.lower()
+    if lower.startswith(MT_NODE_ID_STR_PREFIX):
+        t = t[len(MT_NODE_ID_STR_PREFIX) :]
+    elif t.startswith("!"):
+        t = t[1:]
+    t = t.lower().replace("0x", "")
+    if len(t) == 8 and all(c in "0123456789abcdef" for c in t):
+        return t
+    return None
 
 
 def meshtastic_id_to_hex(meshtastic_id: int) -> str:

--- a/Meshflow/common/observed_node_lookup.py
+++ b/Meshflow/common/observed_node_lookup.py
@@ -134,7 +134,8 @@ def resolve_observed_node_lookup(lookup: str) -> ObservedNodeLookupResult:
     """
     Resolve a path/query segment to zero, one, or two (ambiguous) ObservedNode rows.
 
-    Supports UUID, ``mt:`` / ``!`` Meshtastic hex, ``mc:`` prefix, and bare hex.
+    Supports UUID, ``mt:`` / ``!`` Meshtastic hex, ``mc:`` prefix, legacy decimal
+    Meshtastic node id, and bare hex.
     """
     from nodes.models import ObservedNode
 
@@ -163,6 +164,11 @@ def resolve_observed_node_lookup(lookup: str) -> ObservedNodeLookupResult:
         if node is None:
             return ObservedNodeLookupNotFound()
         return ObservedNodeLookupResolved(node=node)
+
+    if raw.isdigit():
+        node = _meshtastic_node_by_id(int(raw))
+        if node is not None:
+            return ObservedNodeLookupResolved(node=node)
 
     hexish = lower.replace("0x", "")
     if hexish and all(c in "0123456789abcdef" for c in hexish):

--- a/Meshflow/common/observed_node_lookup.py
+++ b/Meshflow/common/observed_node_lookup.py
@@ -1,0 +1,207 @@
+"""Resolve ObservedNode detail lookups from URL path segments (UI #280)."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, Union
+
+from common.mesh_node_helpers import (
+    MT_NODE_ID_STR_PREFIX,
+    meshtastic_hex_to_int,
+    normalize_meshtastic_lookup_hex,
+)
+from common.meshcore_node_helpers import MC_NODE_ID_STR_PREFIX, normalize_mc_pubkey_prefix, prefix_match_queryset
+from common.protocol import Protocol
+
+if TYPE_CHECKING:
+    from nodes.models import ObservedNode
+
+
+@dataclass(frozen=True)
+class ObservedNodeLookupResolved:
+    node: ObservedNode
+
+
+@dataclass(frozen=True)
+class ObservedNodeLookupAmbiguous:
+    choices: tuple[ObservedNode, ...]
+
+
+@dataclass(frozen=True)
+class ObservedNodeLookupNotFound:
+    pass
+
+
+ObservedNodeLookupResult = Union[
+    ObservedNodeLookupResolved,
+    ObservedNodeLookupAmbiguous,
+    ObservedNodeLookupNotFound,
+]
+
+_UUID_RE = None  # lazy
+
+
+def _is_uuid(value: str) -> bool:
+    try:
+        uuid.UUID(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _meshtastic_node_by_id(meshtastic_node_id: int) -> Optional[ObservedNode]:
+    from nodes.models import ObservedNode
+
+    return (
+        ObservedNode.objects.filter(protocol=Protocol.MESHTASTIC, meshtastic_node_id=meshtastic_node_id)
+        .order_by("pk")
+        .first()
+    )
+
+
+def _meshtastic_from_hex_token(token: str) -> Optional[ObservedNode]:
+    hex_part = normalize_meshtastic_lookup_hex(token)
+    if not hex_part:
+        return None
+    try:
+        node_id = meshtastic_hex_to_int(f"!{hex_part}")
+    except ValueError:
+        return None
+    return _meshtastic_node_by_id(node_id)
+
+
+def _meshcore_from_mc_token(suffix: str) -> Optional[ObservedNode]:
+    cleaned = suffix.strip().lower().replace("0x", "")
+    if not cleaned or not all(c in "0123456789abcdef" for c in cleaned):
+        return None
+    from nodes.models import ObservedNode
+
+    if len(cleaned) == 12:
+        try:
+            prefix = normalize_mc_pubkey_prefix(cleaned)
+        except ValueError:
+            return None
+        matches = list(prefix_match_queryset(prefix)[:2])
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    qs = ObservedNode.objects.filter(protocol=Protocol.MESHCORE).filter(models_q_mc_hex_substring(cleaned))
+    matches = list(qs.order_by("pk")[:2])
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def models_q_mc_hex_substring(hexish: str):
+    from django.db.models import Q
+
+    return Q(mc_pubkey__icontains=hexish) | Q(mc_pubkey_prefix__icontains=hexish)
+
+
+def _meshcore_bare_hex(hexish: str) -> Optional[ObservedNode]:
+    from nodes.models import ObservedNode
+
+    if len(hexish) == 12:
+        try:
+            prefix = normalize_mc_pubkey_prefix(hexish)
+        except ValueError:
+            return None
+        matches = list(prefix_match_queryset(prefix)[:2])
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    qs = ObservedNode.objects.filter(protocol=Protocol.MESHCORE).filter(models_q_mc_hex_substring(hexish))
+    matches = list(qs.order_by("pk")[:2])
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _combine_bare(mt: Optional[ObservedNode], mc: Optional[ObservedNode]) -> ObservedNodeLookupResult:
+    if mt is not None and mc is not None and mt.pk != mc.pk:
+        return ObservedNodeLookupAmbiguous(choices=(mt, mc))
+    if mt is not None:
+        return ObservedNodeLookupResolved(node=mt)
+    if mc is not None:
+        return ObservedNodeLookupResolved(node=mc)
+    return ObservedNodeLookupNotFound()
+
+
+def resolve_observed_node_lookup(lookup: str) -> ObservedNodeLookupResult:
+    """
+    Resolve a path/query segment to zero, one, or two (ambiguous) ObservedNode rows.
+
+    Supports UUID, ``mt:`` / ``!`` Meshtastic hex, ``mc:`` prefix, and bare hex.
+    """
+    from nodes.models import ObservedNode
+
+    raw = (lookup or "").strip()
+    if not raw:
+        return ObservedNodeLookupNotFound()
+
+    if _is_uuid(raw):
+        try:
+            node = ObservedNode.objects.get(internal_id=raw)
+            return ObservedNodeLookupResolved(node=node)
+        except ObservedNode.DoesNotExist:
+            return ObservedNodeLookupNotFound()
+
+    lower = raw.lower()
+
+    if lower.startswith(MC_NODE_ID_STR_PREFIX):
+        suffix = raw[len(MC_NODE_ID_STR_PREFIX) :]
+        node = _meshcore_from_mc_token(suffix)
+        if node is None:
+            return ObservedNodeLookupNotFound()
+        return ObservedNodeLookupResolved(node=node)
+
+    if raw.startswith("!") or lower.startswith(MT_NODE_ID_STR_PREFIX):
+        node = _meshtastic_from_hex_token(raw)
+        if node is None:
+            return ObservedNodeLookupNotFound()
+        return ObservedNodeLookupResolved(node=node)
+
+    hexish = lower.replace("0x", "")
+    if hexish and all(c in "0123456789abcdef" for c in hexish):
+        mt = None
+        if len(hexish) == 8:
+            mt = _meshtastic_from_hex_token(hexish)
+        mc = _meshcore_bare_hex(hexish)
+        return _combine_bare(mt, mc)
+
+    return ObservedNodeLookupNotFound()
+
+
+def build_ambiguous_lookup_response(choices: tuple) -> dict:
+    return {
+        "detail": "Multiple nodes match this id.",
+        "choices": [observed_node_lookup_choice_payload(n) for n in choices],
+    }
+
+
+def ambiguous_lookup_exception(choices: tuple):
+    """DRF exception for nested detail routes with an ambiguous path id."""
+    from rest_framework.exceptions import APIException
+
+    class ObservedNodeLookupAmbiguousException(APIException):
+        status_code = 300
+        default_code = "ambiguous_node_lookup"
+
+    exc = ObservedNodeLookupAmbiguousException()
+    exc.detail = build_ambiguous_lookup_response(choices)
+    return exc
+
+
+def observed_node_lookup_choice_payload(node: ObservedNode) -> dict:
+    from common.mesh_node_helpers import observed_node_id_str
+
+    return {
+        "internal_id": str(node.internal_id),
+        "protocol": node.protocol,
+        "node_id_str": observed_node_id_str(node),
+        "short_name": node.short_name or "",
+        "long_name": node.long_name or "",
+    }

--- a/Meshflow/common/tests/test_observed_node_lookup.py
+++ b/Meshflow/common/tests/test_observed_node_lookup.py
@@ -54,6 +54,14 @@ def test_lookup_meshcore_mc_prefix(create_observed_node):
 
 
 @pytest.mark.django_db
+def test_lookup_legacy_decimal_meshtastic_id(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=524809444)
+    result = resolve_observed_node_lookup("524809444")
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
 def test_lookup_bare_hex_meshtastic_only(create_observed_node):
     node = create_observed_node(meshtastic_node_id=0xABCDEF01)
     result = resolve_observed_node_lookup("abcdef01")

--- a/Meshflow/common/tests/test_observed_node_lookup.py
+++ b/Meshflow/common/tests/test_observed_node_lookup.py
@@ -1,0 +1,92 @@
+"""Tests for observed node detail path lookup resolution."""
+
+import pytest
+
+from common.observed_node_lookup import (
+    ObservedNodeLookupAmbiguous,
+    ObservedNodeLookupNotFound,
+    ObservedNodeLookupResolved,
+    resolve_observed_node_lookup,
+)
+from common.protocol import Protocol
+
+FULL_PUBKEY = "a" * 12 + "b" * 52
+PREFIX = "a" * 12
+
+
+@pytest.mark.django_db
+def test_lookup_uuid(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=0x11111111)
+    result = resolve_observed_node_lookup(str(node.internal_id))
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
+def test_lookup_meshtastic_bang_hex(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=0x12345678)
+    result = resolve_observed_node_lookup("!12345678")
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
+def test_lookup_meshtastic_mt_prefix(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=0x12345678)
+    result = resolve_observed_node_lookup("mt:12345678")
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
+def test_lookup_meshcore_mc_prefix(create_observed_node):
+    node = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=FULL_PUBKEY,
+        mc_pubkey_prefix=PREFIX,
+        long_name="MC",
+        short_name="MC",
+    )
+    result = resolve_observed_node_lookup(f"mc:{PREFIX}")
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
+def test_lookup_bare_hex_meshtastic_only(create_observed_node):
+    node = create_observed_node(meshtastic_node_id=0xABCDEF01)
+    result = resolve_observed_node_lookup("abcdef01")
+    assert isinstance(result, ObservedNodeLookupResolved)
+    assert result.node.pk == node.pk
+
+
+@pytest.mark.django_db
+def test_lookup_bare_hex_ambiguous(create_observed_node):
+    hex8 = "3ade68b1"
+    mt = create_observed_node(meshtastic_node_id=int(hex8, 16))
+    mc = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey_prefix=hex8 + "cafebabe",
+        mc_pubkey=hex8 + "cafebabe" + "0" * 48,
+        long_name="MC amb",
+        short_name="AMB",
+    )
+    result = resolve_observed_node_lookup(hex8)
+    assert isinstance(result, ObservedNodeLookupAmbiguous)
+    pks = {n.pk for n in result.choices}
+    assert mt.pk in pks
+    assert mc.pk in pks
+
+
+@pytest.mark.django_db
+def test_lookup_not_found():
+    result = resolve_observed_node_lookup("mc:" + "f" * 12)
+    assert isinstance(result, ObservedNodeLookupNotFound)
+
+
+@pytest.mark.django_db
+def test_lookup_unknown_token():
+    result = resolve_observed_node_lookup("not-a-node-id")
+    assert isinstance(result, ObservedNodeLookupNotFound)

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -178,6 +178,17 @@ def test_observed_node_detail_view(create_observed_node, create_user):
 
 
 @pytest.mark.django_db
+def test_observed_node_detail_by_legacy_decimal_id(create_observed_node, create_user):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    node = create_observed_node(meshtastic_node_id=524809444)
+    response = client.get(reverse("observed-node-detail", kwargs={"internal_id": "524809444"}))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["internal_id"] == str(node.internal_id)
+
+
+@pytest.mark.django_db
 def test_observed_node_detail_by_mt_prefix(create_observed_node, create_user):
     client = APIClient()
     user = create_user()

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -178,6 +178,69 @@ def test_observed_node_detail_view(create_observed_node, create_user):
 
 
 @pytest.mark.django_db
+def test_observed_node_detail_by_mt_prefix(create_observed_node, create_user):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    node = create_observed_node(meshtastic_node_id=0x12345678)
+    response = client.get(reverse("observed-node-detail", kwargs={"internal_id": "mt:12345678"}))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["internal_id"] == str(node.internal_id)
+
+
+@pytest.mark.django_db
+def test_observed_node_detail_by_mc_prefix(create_observed_node, create_user):
+    from common.protocol import Protocol
+
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    prefix = "c" * 12
+    node = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=prefix + "d" * 52,
+        mc_pubkey_prefix=prefix,
+        long_name="MC",
+        short_name="MC",
+    )
+    response = client.get(reverse("observed-node-detail", kwargs={"internal_id": f"mc:{prefix}"}))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["internal_id"] == str(node.internal_id)
+
+
+@pytest.mark.django_db
+def test_observed_node_detail_bare_hex_ambiguous(create_observed_node, create_user):
+    from common.protocol import Protocol
+
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    hex8 = "3ade68b1"
+    create_observed_node(meshtastic_node_id=int(hex8, 16))
+    create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey_prefix=hex8 + "cafebabe",
+        mc_pubkey=hex8 + "cafebabe" + "0" * 48,
+        long_name="MC",
+        short_name="MC",
+    )
+    response = client.get(reverse("observed-node-detail", kwargs={"internal_id": hex8}))
+    assert response.status_code == 300
+    assert len(response.data["choices"]) == 2
+
+
+@pytest.mark.django_db
+def test_observed_node_detail_lookup_not_found(create_user):
+    client = APIClient()
+    user = create_user()
+    client.force_authenticate(user=user)
+    response = client.get(reverse("observed-node-detail", kwargs={"internal_id": "mc:" + "f" * 12}))
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.django_db
 def test_node_api_key_list_view(create_node_api_key, create_user):
     """Test node API key list view."""
     client = APIClient()

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -29,6 +29,13 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from common.mesh_node_helpers import observed_node_search_conditions
+from common.observed_node_lookup import (
+    ObservedNodeLookupAmbiguous,
+    ObservedNodeLookupNotFound,
+    ambiguous_lookup_exception,
+    build_ambiguous_lookup_response,
+    resolve_observed_node_lookup,
+)
 from common.protocol import Protocol
 from constellations.models import ConstellationUserMembership
 from meshcore_packets.models import MeshCorePacketObservation
@@ -208,8 +215,9 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
     """Observed nodes across Meshtastic and MeshCore.
 
     List supports ``protocol`` (``meshtastic`` / ``meshcore``) and ``last_heard_after``.
-    Detail lookup uses ``internal_id`` (UUID). Meshtastic bookmarks may use
-    ``GET …/by-meshtastic-id/{meshtastic_node_id}/`` to resolve the canonical URL.
+    Detail path ``{internal_id}`` accepts UUID, ``mt:``/``!`` Meshtastic hex, ``mc:`` prefix,
+    or bare hex (HTTP 300 when both protocols match). Legacy numeric bookmarks:
+    ``GET …/by-meshtastic-id/{meshtastic_node_id}/`` (deprecated).
     """
 
     queryset = ObservedNode.objects.all().order_by("meshtastic_node_id")
@@ -217,6 +225,29 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
     serializer_class = ObservedNodeSerializer
     lookup_field = "internal_id"
     lookup_url_kwarg = "internal_id"
+
+    def _resolve_detail_lookup(self):
+        lookup = self.kwargs.get(self.lookup_url_kwarg, "")
+        return resolve_observed_node_lookup(lookup)
+
+    def get_object(self):
+        result = self._resolve_detail_lookup()
+        if isinstance(result, ObservedNodeLookupAmbiguous):
+            raise ambiguous_lookup_exception(result.choices)
+        if isinstance(result, ObservedNodeLookupNotFound):
+            raise Http404
+        node = result.node
+        self.check_object_permissions(self.request, node)
+        return node
+
+    def retrieve(self, request, *args, **kwargs):
+        result = self._resolve_detail_lookup()
+        if isinstance(result, ObservedNodeLookupAmbiguous):
+            return Response(build_ambiguous_lookup_response(result.choices), status=300)
+        if isinstance(result, ObservedNodeLookupNotFound):
+            raise Http404
+        serializer = self.get_serializer(result.node)
+        return Response(serializer.data)
 
     def get_queryset(self):
         """Filter nodes based on user permissions and prefetch latest status."""
@@ -327,8 +358,14 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         url_path=r"by-meshtastic-id/(?P<meshtastic_node_id>[0-9]+)",
     )
     def by_meshtastic_id(self, request, meshtastic_node_id=None):
-        """Redirect legacy Meshtastic numeric bookmarks to the canonical ``internal_id`` detail URL."""
-        node = get_object_or_404(ObservedNode, meshtastic_node_id=meshtastic_node_id)
+        """Deprecated: redirect numeric Meshtastic id to UUID detail URL. Prefer ``mt:``/``!`` on retrieve."""
+        from common.protocol import Protocol
+
+        node = get_object_or_404(
+            ObservedNode,
+            protocol=Protocol.MESHTASTIC,
+            meshtastic_node_id=meshtastic_node_id,
+        )
         detail_url = reverse(
             "observed-node-detail",
             kwargs={"internal_id": node.internal_id},

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4904,7 +4904,8 @@ paths:
       summary: Get observed node details
       description: >
         Resolve an observed node by path segment: UUID ``internal_id``; Meshtastic ``!{hex8}`` or
-        ``mt:{hex8}``; MeshCore ``mc:{prefix12}``; or bare hex (8+ hex chars). Bare hex matching
+        ``mt:{hex8}``; MeshCore ``mc:{prefix12}``; legacy decimal Meshtastic node id; or bare hex.
+        Bare hex matching
         both Meshtastic and MeshCore returns **300 Multiple Choices** with candidate list.
         Deprecated numeric redirect: ``GET /nodes/observed-nodes/by-meshtastic-id/{id}/``.
       tags: [Nodes]
@@ -4917,7 +4918,7 @@ paths:
           schema:
             type: string
           description: >
-            UUID, ``mt:``/``!`` Meshtastic hex, ``mc:`` MeshCore prefix, or bare hex (may return 300).
+            UUID, ``mt:``/``!`` Meshtastic hex, ``mc:`` MeshCore prefix, decimal MT id, or bare hex (may return 300).
       responses:
         '200':
           description: Node details

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1036,6 +1036,39 @@ components:
           maximum: 7
           description: Default for TR_HOPS_LIMIT and TEXT_MESSAGE_MAX_HOPS env vars in generated docker-compose
 
+    ObservedNodeLookupChoice:
+      type: object
+      description: Candidate node when a bare-hex detail lookup matches multiple protocols (HTTP 300).
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        protocol:
+          $ref: '#/components/schemas/MeshProtocol'
+        node_id_str:
+          type: string
+        short_name:
+          type: string
+        long_name:
+          type: string
+      required:
+        - internal_id
+        - protocol
+        - node_id_str
+
+    ObservedNodeLookupAmbiguous:
+      type: object
+      properties:
+        detail:
+          type: string
+        choices:
+          type: array
+          items:
+            $ref: '#/components/schemas/ObservedNodeLookupChoice'
+      required:
+        - detail
+        - choices
+
     ObservedNode:
       type: object
       description: >
@@ -4870,9 +4903,10 @@ paths:
     get:
       summary: Get observed node details
       description: >
-        Detail lookup by ``ObservedNode.internal_id`` (UUID). Works for Meshtastic and MeshCore.
-        Legacy Meshtastic numeric bookmarks: ``GET /nodes/observed-nodes/by-meshtastic-id/{meshtastic_node_id}/``
-        redirects to this URL.
+        Resolve an observed node by path segment: UUID ``internal_id``; Meshtastic ``!{hex8}`` or
+        ``mt:{hex8}``; MeshCore ``mc:{prefix12}``; or bare hex (8+ hex chars). Bare hex matching
+        both Meshtastic and MeshCore returns **300 Multiple Choices** with candidate list.
+        Deprecated numeric redirect: ``GET /nodes/observed-nodes/by-meshtastic-id/{id}/``.
       tags: [Nodes]
       security:
         - BearerAuth: []
@@ -4882,8 +4916,8 @@ paths:
           required: true
           schema:
             type: string
-            format: uuid
-          description: Meshtastic numeric node id (detail routes); not MeshCore pubkey or ``internal_id``
+          description: >
+            UUID, ``mt:``/``!`` Meshtastic hex, ``mc:`` MeshCore prefix, or bare hex (may return 300).
       responses:
         '200':
           description: Node details
@@ -4891,6 +4925,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ObservedNode'
+        '300':
+          description: Multiple nodes match a bare-hex lookup (pick a protocol-specific id)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObservedNodeLookupAmbiguous'
 
     put:
       summary: Update observed node

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,17 +111,22 @@ def api_client(api_base_url, wait_for_api, jwt_token):
             return isinstance(node_id, str) and bool(_OBSERVED_NODE_UUID_RE.match(node_id))
 
         def resolve_internal_id(self, node_id):
-            """Map meshtastic_node_id (int) to ObservedNode.internal_id (UUID string)."""
+            """Map any observed-node lookup segment to ObservedNode.internal_id (UUID string)."""
             if self._is_internal_id(node_id):
                 return node_id
-            if self._is_meshtastic_node_id(node_id):
-                r = self.get_observed_node(int(node_id))
-                if r.status_code != 200:
-                    raise AssertionError(
-                        f"Could not resolve meshtastic_node_id {node_id}: {r.status_code} {r.text}"
-                    )
+            r = self.get_observed_node(node_id)
+            if r.status_code == 200:
                 return r.json()["internal_id"]
-            raise ValueError(f"Not a meshtastic_node_id or internal_id: {node_id!r}")
+            if r.status_code == 300:
+                choices = r.json().get("choices") or []
+                if len(choices) == 1:
+                    return choices[0]["internal_id"]
+                raise AssertionError(
+                    f"Ambiguous observed node lookup {node_id!r}: {len(choices)} choices"
+                )
+            raise AssertionError(
+                f"Could not resolve observed node {node_id!r}: {r.status_code} {r.text}"
+            )
 
         def post_ingest(self, payload, observer_node_id=OBSERVER_NODE_ID):
             url = f"{self.base}/api/packets/{observer_node_id}/ingest/"
@@ -136,15 +141,10 @@ def api_client(api_base_url, wait_for_api, jwt_token):
             )
 
         def get_observed_node(self, node_id):
-            if self._is_meshtastic_node_id(node_id):
-                url = f"{self.base}/api/nodes/observed-nodes/by-meshtastic-id/{int(node_id)}/"
-                return requests.get(
-                    url,
-                    headers=self._auth_headers(),
-                    allow_redirects=True,
-                    timeout=INTEGRATION_HTTP_TIMEOUT,
-                )
-            url = f"{self.base}/api/nodes/observed-nodes/{node_id}/"
+            from urllib.parse import quote
+
+            segment = quote(str(node_id), safe="")
+            url = f"{self.base}/api/nodes/observed-nodes/{segment}/"
             return requests.get(
                 url,
                 headers=self._auth_headers(),


### PR DESCRIPTION
# Summary

Implements [meshflow-ui #280](https://github.com/pskillen/meshflow-ui/issues/280) API half: `GET /nodes/observed-nodes/{id}/` accepts UUID, `mt:`/`!` Meshtastic hex, `mc:` MeshCore prefix, and bare hex. Bare hex matching both protocols returns **300 Multiple Choices** with candidate nodes.

- Shared resolver: `Meshflow/common/observed_node_lookup.py`
- `mt:` prefix helper on `mesh_node_helpers`
- `ObservedNodeViewSet.retrieve` / `get_object` wired; `by-meshtastic-id` marked deprecated
- OpenAPI: `ObservedNodeLookupAmbiguous` schema + 300 response
- Integration client uses unified detail URL with URL-encoded path segments

## Testing performed

- `python -m pytest Meshflow/common/tests/test_observed_node_lookup.py Meshflow/nodes/tests/test_node_views.py` (lookup + detail cases)
- black / isort / flake8 on touched files

## Deploy notes

No migrations. Pair with meshflow-ui PR for `/nodes/:id` routes and link audit.