### PR TITLE
fix(traceroutes): stats endpoint handles legacy integer route hops

### DIFF
--- a/Meshflow/traceroute_analytics/tests/test_views.py
+++ b/Meshflow/traceroute_analytics/tests/test_views.py
@@ -361,6 +361,35 @@ class TestTracerouteStats:
         sources = {s["trigger_type"]: s["count"] for s in body["sources"]}
         assert sources.get(AutoTraceRoute.TRIGGER_TYPE_EXTERNAL) == 1
 
+    def test_stats_top_routers_accepts_legacy_integer_route_hops(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        """Regression: legacy rows store route hops as bare ints, not {node_id, snr} dicts."""
+        user = create_user()
+        mn = create_managed_node(meshtastic_node_id=999_999_901)
+        on = create_observed_node(meshtastic_node_id=999_999_902)
+        relay_id = 0xABCD0001
+        api_client.force_authenticate(user=user)
+
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+            route=[relay_id],
+            route_back=[relay_id],
+        )
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        top = resp.json()["top_routers"]
+        assert any(r["meshtastic_node_id"] == relay_id and r["count"] == 2 for r in top)
+
 
 @pytest.mark.django_db
 class TestFeederReach:

--- a/Meshflow/traceroute_analytics/tests/test_views.py
+++ b/Meshflow/traceroute_analytics/tests/test_views.py
@@ -10,6 +10,7 @@ from rest_framework.test import APIClient
 import nodes.tests.conftest  # noqa: F401
 import packets.tests.conftest  # noqa: F401
 import users.tests.conftest  # noqa: F401
+from common.protocol import Protocol
 from traceroute.models import AutoTraceRoute
 
 
@@ -389,6 +390,49 @@ class TestTracerouteStats:
         assert resp.status_code == 200
         top = resp.json()["top_routers"]
         assert any(r["meshtastic_node_id"] == relay_id and r["count"] == 2 for r in top)
+
+    def test_stats_by_target_skips_meshcore_targets_without_meshtastic_id(
+        self,
+        api_client,
+        create_user,
+        create_managed_node,
+        create_observed_node,
+        create_auto_traceroute,
+    ):
+        """Regression: MeshCore ObservedNode targets must not call meshtastic_id_to_hex(None)."""
+        user = create_user()
+        mn = create_managed_node(meshtastic_node_id=888_888_901)
+        on_mt = create_observed_node(meshtastic_node_id=888_888_902, short_name="MTTG")
+        on_mc = create_observed_node(
+            protocol=Protocol.MESHCORE,
+            meshtastic_node_id=None,
+            mc_pubkey_prefix="aabbccddeeff",
+            mac_addr=None,
+            meshtastic_hw_model=None,
+            short_name="MCTG",
+            long_name="MeshCore target",
+        )
+        api_client.force_authenticate(user=user)
+
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on_mc,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+        create_auto_traceroute(
+            source_node=mn,
+            target_node=on_mt,
+            triggered_by=user,
+            status=AutoTraceRoute.STATUS_COMPLETED,
+        )
+
+        resp = api_client.get("/api/traceroutes/stats/")
+        assert resp.status_code == 200
+        by_target = resp.json()["by_target"]
+        assert len(by_target) == 1
+        assert by_target[0]["meshtastic_node_id"] == on_mt.meshtastic_node_id
+        assert by_target[0]["short_name"] == "MTTG"
 
 
 @pytest.mark.django_db

--- a/Meshflow/traceroute_analytics/views.py
+++ b/Meshflow/traceroute_analytics/views.py
@@ -21,6 +21,25 @@ from nodes.models import ManagedNode, ObservedNode
 from traceroute.models import AutoTraceRoute
 
 
+def _route_hop_node_id(entry) -> int | None:
+    """Meshtastic hop id from a route list item (``{node_id, snr}`` dict or legacy bare int)."""
+    if entry is None:
+        return None
+    if isinstance(entry, dict):
+        nid = entry.get("node_id")
+    else:
+        try:
+            nid = int(entry)
+        except TypeError, ValueError:
+            return None
+    if nid is None:
+        return None
+    try:
+        return int(nid)
+    except TypeError, ValueError:
+        return None
+
+
 def _traceroute_stats_by_strategy(qs):
     """Aggregate counts per coalesced target_strategy for a queryset."""
     legacy_label = AutoTraceRoute.TARGET_STRATEGY_LEGACY
@@ -402,7 +421,7 @@ def traceroute_stats(request):
         tgt_id = tr.target_node.meshtastic_node_id if tr.target_node else None
         exclude_ids = {src_id, tgt_id, UNKNOWN_NODE_ID}
         for item in (tr.route or []) + (tr.route_back or []):
-            nid = item.get("node_id")
+            nid = _route_hop_node_id(item)
             if nid is not None and nid not in exclude_ids:
                 router_counts[nid] += 1
 

--- a/Meshflow/traceroute_analytics/views.py
+++ b/Meshflow/traceroute_analytics/views.py
@@ -505,7 +505,8 @@ def traceroute_stats(request):
     by_target = []
     for row in by_target_rows:
         on = observed_by_internal_id.get(row["target_node_id"])
-        if on is None:
+        if on is None or on.meshtastic_node_id is None:
+            # MeshCore targets have no Meshtastic numeric id; stats UI links by meshtastic_node_id.
             continue
         completed_n = row["completed"]
         failed_n = row["failed"]
@@ -514,7 +515,7 @@ def traceroute_stats(request):
         by_target.append(
             {
                 "meshtastic_node_id": on.meshtastic_node_id,
-                "node_id_str": meshtastic_id_to_hex(on.meshtastic_node_id),
+                "node_id_str": on.node_id_str,
                 "short_name": on.short_name,
                 "long_name": on.long_name,
                 "total": row["total"],


### PR DESCRIPTION
## Summary

- Fix HTTP 500 on `GET /api/traceroutes/stats/` when completed traceroutes store relay hops as bare integers (legacy format) instead of `{node_id, snr}` dicts.
- Add `_route_hop_node_id()` helper (same semantics as dx monitoring) and a regression test.

Closes #342

## Testing performed

- `python -m pytest Meshflow/traceroute_analytics/tests/test_views.py::TestTracerouteStats -v`
- black / isort / flake8 on changed files