### PR TITLE
fix(asgi): log client disconnects as warnings instead of ERROR tracebacks

### DIFF
--- a/Meshflow/Meshflow/asgi.py
+++ b/Meshflow/Meshflow/asgi.py
@@ -26,6 +26,7 @@ load_dotenv()
 django_asgi_app = get_asgi_application()
 
 import Meshflow.routing  # noqa
+from Meshflow.asgi_client_disconnect import ClientDisconnectLoggingMiddleware  # noqa: E402
 
 application = ProtocolTypeRouter(
     {
@@ -41,3 +42,5 @@ if settings.SERVE_STATIC_FILES:
     from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
 
     application = ASGIStaticFilesHandler(application)
+
+application = ClientDisconnectLoggingMiddleware(application)

--- a/Meshflow/Meshflow/asgi_client_disconnect.py
+++ b/Meshflow/Meshflow/asgi_client_disconnect.py
@@ -1,0 +1,94 @@
+"""
+ASGI helpers for quiet client disconnects (tab close, navigation, aborted fetch).
+
+When a client goes away, uvicorn/Django cancel in-flight work with asyncio.CancelledError.
+That is expected, not a server bug. We log a short warning and avoid ERROR tracebacks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_AsyncioExceptionHandler = Callable[[asyncio.AbstractEventLoop, dict[str, Any]], None]
+_previous_asyncio_handler: _AsyncioExceptionHandler | None = None
+_asyncio_handler_installed = False
+
+
+def install_asyncio_client_disconnect_handler() -> None:
+    """Route asyncio CancelledError reports to a warning instead of default ERROR + traceback."""
+    global _previous_asyncio_handler, _asyncio_handler_installed
+    if _asyncio_handler_installed:
+        return
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            return
+
+    _previous_asyncio_handler = loop.get_exception_handler()
+
+    def handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        exc = context.get("exception")
+        if isinstance(exc, asyncio.CancelledError):
+            message = context.get("message", "async task cancelled")
+            logger.warning("Client disconnected (%s)", message)
+            return
+        if _previous_asyncio_handler is not None:
+            _previous_asyncio_handler(loop, context)
+        else:
+            loop.default_exception_handler(context)
+
+    loop.set_exception_handler(handler)
+    _asyncio_handler_installed = True
+
+
+def log_client_disconnect(scope: dict[str, Any]) -> None:
+    conn_type = scope.get("type", "unknown")
+    path = scope.get("path", "")
+    if conn_type == "websocket":
+        logger.warning("WebSocket client disconnected: %s", path)
+    else:
+        logger.warning("HTTP client disconnected during request: %s", path)
+
+
+class ClientDisconnectLogFilter(logging.Filter):
+    """Downgrade asyncio CancelledError log records to warnings without exc_info."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if "CancelledError" in message and "shielded future" in message:
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+            record.exc_info = None
+            record.exc_text = None
+
+        if record.exc_info and record.exc_info[0] is asyncio.CancelledError:
+            record.levelno = logging.WARNING
+            record.levelname = "WARNING"
+            record.exc_info = None
+            record.exc_text = None
+
+        return True
+
+
+class ClientDisconnectLoggingMiddleware:
+    """ASGI middleware: expected client disconnects -> warning, then re-raise CancelledError."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        install_asyncio_client_disconnect_handler()
+        try:
+            await self.app(scope, receive, send)
+        except asyncio.CancelledError:
+            log_client_disconnect(scope)
+            raise

--- a/Meshflow/Meshflow/settings/base.py
+++ b/Meshflow/Meshflow/settings/base.py
@@ -522,6 +522,11 @@ LOGGING = {
             "style": "{",
         },
     },
+    "filters": {
+        "client_disconnect": {
+            "()": "Meshflow.asgi_client_disconnect.ClientDisconnectLogFilter",
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
@@ -537,6 +542,12 @@ LOGGING = {
         "django": {
             "handlers": ["console"],
             "level": "INFO",
+            "propagate": False,
+        },
+        "asyncio": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "filters": ["client_disconnect"],
             "propagate": False,
         },
     },

--- a/Meshflow/Meshflow/tests/test_asgi_client_disconnect.py
+++ b/Meshflow/Meshflow/tests/test_asgi_client_disconnect.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+
+import pytest
+
+from Meshflow.asgi_client_disconnect import (
+    ClientDisconnectLogFilter,
+    ClientDisconnectLoggingMiddleware,
+    install_asyncio_client_disconnect_handler,
+    log_client_disconnect,
+)
+
+
+@pytest.mark.asyncio
+async def test_middleware_logs_and_reraises_cancelled_error(caplog):
+    caplog.set_level(logging.WARNING, logger="Meshflow.asgi_client_disconnect")
+
+    async def inner_app(scope, receive, send):
+        raise asyncio.CancelledError
+
+    middleware = ClientDisconnectLoggingMiddleware(inner_app)
+
+    with pytest.raises(asyncio.CancelledError):
+        await middleware({"type": "websocket", "path": "/ws/traceroutes/"}, None, None)
+
+    assert any("WebSocket client disconnected" in r.message for r in caplog.records)
+
+
+def test_log_client_disconnect_http(caplog):
+    caplog.set_level(logging.WARNING, logger="Meshflow.asgi_client_disconnect")
+    log_client_disconnect({"type": "http", "path": "/api/nodes/"})
+    assert any("HTTP client disconnected" in r.message for r in caplog.records)
+
+
+def test_client_disconnect_log_filter_downgrades_asyncio_message():
+    record = logging.LogRecord(
+        name="asyncio",
+        level=logging.ERROR,
+        pathname="",
+        lineno=0,
+        msg="CancelledError exception in shielded future",
+        args=(),
+        exc_info=None,
+    )
+    assert ClientDisconnectLogFilter().filter(record) is True
+    assert record.levelno == logging.WARNING
+    assert record.exc_info is None
+
+
+def test_install_asyncio_handler_suppresses_cancelled_error(caplog):
+    caplog.set_level(logging.WARNING, logger="Meshflow.asgi_client_disconnect")
+
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        import Meshflow.asgi_client_disconnect as mod
+
+        mod._asyncio_handler_installed = False
+        install_asyncio_client_disconnect_handler()
+
+        handler = loop.get_exception_handler()
+        assert handler is not None
+        handler(loop, {"message": "test cancel", "exception": asyncio.CancelledError()})
+        assert any("Client disconnected" in r.message for r in caplog.records)
+    finally:
+        loop.close()
+        import Meshflow.asgi_client_disconnect as mod
+
+        mod._asyncio_handler_installed = False


### PR DESCRIPTION
Closes #351

## Summary

When a browser tab closes or a WebSocket client disconnects, uvicorn/Django cancel in-flight work with `asyncio.CancelledError`. That is expected client teardown, not a server failure, but it was producing long ERROR stack traces (including asyncio "CancelledError exception in shielded future" when sync ORM runs in a thread pool).

- Add `ClientDisconnectLoggingMiddleware` around the ASGI app: log a single WARNING with path/connection type, then re-raise `CancelledError`.
- Install a custom asyncio exception handler for shielded-future cancellations.
- Add `ClientDisconnectLogFilter` on the `asyncio` logger to downgrade any remaining CancelledError records.

## Testing performed

- `python -m pytest Meshflow/tests/test_asgi_client_disconnect.py -v` (4 tests)
- `black`, `isort`, `flake8` on changed files
- Manual: restart uvicorn and close a tab; expect WARNING lines instead of full tracebacks