### PR TITLE
fix(nodes): fall back managed node position to default location

### DIFF
--- a/Meshflow/nodes/positioning.py
+++ b/Meshflow/nodes/positioning.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
-from nodes.models import ManagedNode, ObservedNode
+from nodes.models import LocationSource, ManagedNode, ObservedNode
+
+
+def managed_node_default_position_data(managed_node: ManagedNode) -> dict | None:
+    """Position dict for API when no observed telemetry; uses operator-configured default location."""
+    lat = managed_node.default_location_latitude
+    lon = managed_node.default_location_longitude
+    if lat is None or lon is None:
+        return None
+    return {
+        "latitude": lat,
+        "longitude": lon,
+        "altitude": None,
+        "reported_time": None,
+        "logged_time": None,
+        "heading": None,
+        "meshtastic_location_source": LocationSource.MANUAL,
+        "meshtastic_precision_bits": None,
+        "ground_speed": None,
+        "ground_track": None,
+        "sats_in_view": None,
+        "pdop": None,
+    }
 
 
 def managed_node_lat_lon(managed_node: ManagedNode) -> tuple[float, float] | None:

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -31,6 +31,7 @@ from .permission_helpers import (
     user_can_edit_observed_node_environment_settings,
     user_can_edit_observed_node_rf_profile,
 )
+from .positioning import managed_node_default_position_data
 
 
 class ObservedNodeEnvironmentSettingsSerializer(serializers.Serializer):
@@ -496,14 +497,15 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
                 "last_sats_in_view",
                 "last_pdop",
             ]
-            if all(data[k] is None for k in real_fields):
-                return None
-            return PositionSerializer(data).data
-        # Fallback to latest Position instance
+            if not all(data[k] is None for k in real_fields):
+                return PositionSerializer(data).data
         latest = (
             Position.objects.filter(node__meshtastic_node_id=obj.meshtastic_node_id).order_by("-reported_time").first()
         )
-        return PositionSerializer(latest).data if latest else None
+        if latest:
+            return PositionSerializer(latest).data
+        default_data = managed_node_default_position_data(obj)
+        return PositionSerializer(default_data).data if default_data else None
 
     def get_device_metrics(self, obj):
         annotation_keys = [

--- a/Meshflow/nodes/tests/test_managed_node_position_fallback.py
+++ b/Meshflow/nodes/tests/test_managed_node_position_fallback.py
@@ -1,0 +1,73 @@
+"""ManagedNode API position falls back to default_location when no observed position."""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from nodes.models import NodeLatestStatus
+
+
+@pytest.mark.django_db
+def test_managed_node_position_falls_back_to_default_location(create_managed_node, create_user):
+    user = create_user()
+    managed = create_managed_node(
+        owner=user,
+        meshtastic_node_id=123450100,
+        default_location_latitude=55.95,
+        default_location_longitude=-3.19,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    list_url = reverse("managed-nodes-list")
+    list_resp = client.get(list_url)
+    assert list_resp.status_code == status.HTTP_200_OK
+    row = next(r for r in list_resp.data["results"] if r["meshtastic_node_id"] == managed.meshtastic_node_id)
+    assert row["position"] is not None
+    assert row["position"]["latitude"] == 55.95
+    assert row["position"]["longitude"] == -3.19
+
+    detail_url = reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id})
+    detail_resp = client.get(detail_url)
+    assert detail_resp.status_code == status.HTTP_200_OK
+    assert detail_resp.data["position"]["latitude"] == 55.95
+    assert detail_resp.data["position"]["longitude"] == -3.19
+
+
+@pytest.mark.django_db
+def test_managed_node_position_prefers_observed_over_default(create_managed_node, create_observed_node, create_user):
+    user = create_user()
+    managed = create_managed_node(
+        owner=user,
+        meshtastic_node_id=123450101,
+        default_location_latitude=55.0,
+        default_location_longitude=-4.0,
+    )
+    observed = create_observed_node(meshtastic_node_id=managed.meshtastic_node_id)
+    NodeLatestStatus.objects.create(
+        node=observed,
+        latitude=56.1,
+        longitude=-3.5,
+        position_reported_time=None,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id}))
+    assert detail_resp.status_code == status.HTTP_200_OK
+    assert detail_resp.data["position"]["latitude"] == 56.1
+    assert detail_resp.data["position"]["longitude"] == -3.5
+
+
+@pytest.mark.django_db
+def test_managed_node_position_null_without_observed_or_default(create_managed_node, create_user):
+    user = create_user()
+    managed = create_managed_node(owner=user, meshtastic_node_id=123450102)
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id}))
+    assert detail_resp.status_code == status.HTTP_200_OK
+    assert detail_resp.data["position"] is None

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1885,7 +1885,10 @@ components:
                 enum: [intra_zone, dx_across, dx_same_side]
         position:
           type: object
-          description: The latest known position of the node
+          description: >
+            Latest known position from observed telemetry (NodeLatestStatus or position history).
+            When none exists, falls back to the operator-configured default location on the managed node
+            (stored as default_location_latitude/longitude in the API; not exposed as separate fields).
           readOnly: true
           properties:
             latitude:


### PR DESCRIPTION
# Summary

`ManagedNodeSerializer.position` now falls back to `default_location_latitude/longitude` when there is no observed position (NodeLatestStatus annotations or position history). Fixes MeshCore feeders missing from the map when the feeder does not report its own packets but has an operator-configured site location.

Observed telemetry still wins when present. ObservedNode responses are unchanged.

Fixes pskillen/meshflow-ui#282

## Testing performed

* `python -m pytest Meshflow/nodes/tests/test_managed_node_position_fallback.py -v` (3 tests: fallback, observed wins, still null)
