### PR TITLE
feat(nodes): MeshCore observed node claims and claim WebSocket

### DIFF
--- a/Meshflow/Meshflow/routing.py
+++ b/Meshflow/Meshflow/routing.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from ws.consumers import NodeConsumer, TextMessageConsumer, TracerouteConsumer
+from ws.consumers import NodeClaimConsumer, NodeConsumer, TextMessageConsumer, TracerouteConsumer
 
 websocket_urlpatterns = [
     path("ws/messages/", TextMessageConsumer.as_asgi()),
     path("ws/nodes/", NodeConsumer.as_asgi()),
     path("ws/traceroutes/", TracerouteConsumer.as_asgi()),
+    path("ws/claims/", NodeClaimConsumer.as_asgi()),
 ]

--- a/Meshflow/common/ws_groups.py
+++ b/Meshflow/common/ws_groups.py
@@ -9,3 +9,8 @@ def managed_node_ws_group(managed_node: ManagedNode) -> str:
     if managed_node.protocol == Protocol.MESHCORE:
         return f"node_mc_{managed_node.internal_id}"
     return f"node_{managed_node.meshtastic_node_id}"
+
+
+def user_claims_ws_group(user_id: int) -> str:
+    """Group name for pushing node-claim acceptance events to a logged-in user."""
+    return f"user_claims_{user_id}"

--- a/Meshflow/meshcore_packets/services/text_message.py
+++ b/Meshflow/meshcore_packets/services/text_message.py
@@ -5,6 +5,7 @@ import logging
 from common.meshcore_node_helpers import resolve_or_create_mc_observed_node
 from common.protocol import Protocol
 from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
+from nodes.claim_authorization import try_accept_node_claim
 from packets.signals import text_message_received
 from text_messages.models import TextMessage
 
@@ -21,7 +22,7 @@ class MeshCoreTextMessageService:
         if packet.payload_type == MeshCorePayloadType.CHANNEL_TEXT:
             return self._create_channel_message(packet, observation)
         if packet.payload_type == MeshCorePayloadType.CONTACT_TEXT:
-            return self._create_contact_message(packet)
+            return self._create_contact_message(packet, observer)
         return None
 
     def _create_channel_message(self, packet: MeshCoreTextPacket, observation) -> TextMessage | None:
@@ -38,7 +39,7 @@ class MeshCoreTextMessageService:
         text_message_received.send(sender=self, message=message, observer=observation.observer)
         return message
 
-    def _create_contact_message(self, packet: MeshCoreTextPacket) -> TextMessage | None:
+    def _create_contact_message(self, packet: MeshCoreTextPacket, observer) -> TextMessage | None:
         prefix = packet.from_pubkey_prefix
         if not prefix and packet.from_pubkey:
             prefix = packet.from_pubkey[:12]
@@ -51,7 +52,7 @@ class MeshCoreTextMessageService:
                 last_heard=packet.rx_time,
             )
 
-        return TextMessage.objects.create(
+        message = TextMessage.objects.create(
             protocol=Protocol.MESHCORE,
             original_mc_packet=packet,
             sender=sender,
@@ -61,6 +62,16 @@ class MeshCoreTextMessageService:
             message_text=packet.text,
             is_emoji=False,
         )
+
+        if sender is not None:
+            try_accept_node_claim(
+                sender=sender,
+                message_text=packet.text,
+                observer=observer,
+                sender_service=self,
+            )
+
+        return message
 
 
 def handle_meshcore_text_packet(sender, packet, observer, observation, **kwargs):

--- a/Meshflow/meshcore_packets/tests/test_text_message_service.py
+++ b/Meshflow/meshcore_packets/tests/test_text_message_service.py
@@ -8,7 +8,9 @@ from common.protocol import Protocol
 from meshcore_packets.models import MeshCorePayloadType, MeshCoreTextPacket
 from meshcore_packets.services.channel_sync import reconcile_mc_channels
 from meshcore_packets.services.text_message import MeshCoreTextMessageService
+from nodes.models import NodeOwnerClaim, ObservedNode
 from text_messages.models import TextMessage
+from users.tests.conftest import create_user  # noqa: F401
 
 
 @pytest.mark.django_db
@@ -66,3 +68,79 @@ def test_contact_text_stores_with_sender_prefix(meshcore_feeder):
     msg = MeshCoreTextMessageService().process_packet(packet, node, obs)
     assert msg.sender_id is not None
     assert msg.channel_id is None
+
+
+@pytest.mark.django_db
+def test_contact_text_accepts_node_claim(meshcore_feeder, create_user):
+    user = create_user()
+    prefix = "aabbccddeeff"
+    sender = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey_prefix=prefix,
+        long_name="Claim Me",
+        short_name="CLM",
+        last_heard=timezone.now(),
+    )
+    claim_key = "word word 42"
+    NodeOwnerClaim.objects.create(node=sender, user=user, claim_key=claim_key, accepted_at=None)
+
+    feeder = meshcore_feeder["node"]
+    now = timezone.now()
+    packet = MeshCoreTextPacket.objects.create(
+        observer=feeder,
+        payload_type=MeshCorePayloadType.CONTACT_TEXT,
+        event_type="contact_message",
+        from_pubkey_prefix=prefix,
+        rx_time=now,
+        raw_json={},
+        text=claim_key,
+    )
+    from meshcore_packets.models import MeshCorePacketObservation
+
+    obs = MeshCorePacketObservation.objects.create(packet=packet, observer=feeder, rx_time=now)
+    MeshCoreTextMessageService().process_packet(packet, feeder, obs)
+
+    sender.refresh_from_db()
+    assert sender.claimed_by_id == user.id
+
+
+@pytest.mark.django_db
+def test_channel_text_does_not_accept_node_claim(meshcore_feeder, create_user, create_observed_node):
+    user = create_user()
+    node = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey_prefix="bbccddeeff00",
+        last_heard=timezone.now(),
+    )
+    claim_key = "word word 99"
+    NodeOwnerClaim.objects.create(node=node, user=user, claim_key=claim_key, accepted_at=None)
+
+    feeder_node = meshcore_feeder["node"]
+    reconcile_mc_channels(
+        feeder_node,
+        [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}],
+    )
+    now = timezone.now()
+    packet = MeshCoreTextPacket.objects.create(
+        observer=feeder_node,
+        payload_type=MeshCorePayloadType.CHANNEL_TEXT,
+        event_type="channel_message",
+        rx_time=now,
+        raw_json={},
+        text=claim_key,
+        channel=feeder_node.mc_channels.first(),
+    )
+    from meshcore_packets.models import MeshCorePacketObservation
+
+    obs = MeshCorePacketObservation.objects.create(
+        packet=packet,
+        observer=feeder_node,
+        channel=packet.channel,
+        rx_time=now,
+    )
+    MeshCoreTextMessageService().process_packet(packet, feeder_node, obs)
+
+    node.refresh_from_db()
+    assert node.claimed_by_id is None

--- a/Meshflow/meshcore_packets/tests/test_text_message_service.py
+++ b/Meshflow/meshcore_packets/tests/test_text_message_service.py
@@ -10,7 +10,6 @@ from meshcore_packets.services.channel_sync import reconcile_mc_channels
 from meshcore_packets.services.text_message import MeshCoreTextMessageService
 from nodes.models import NodeOwnerClaim, ObservedNode
 from text_messages.models import TextMessage
-from users.tests.conftest import create_user  # noqa: F401
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/claim_authorization.py
+++ b/Meshflow/nodes/claim_authorization.py
@@ -1,0 +1,59 @@
+"""Shared logic for accepting node ownership claims from mesh text/DM proof."""
+
+import logging
+import re
+
+from django.utils import timezone
+
+from nodes.models import NodeOwnerClaim, ObservedNode
+from packets.signals import node_claim_authorized
+
+logger = logging.getLogger(__name__)
+
+# Claim key: 2–3 words and 2–3 digits (same as legacy TextMessagePacketService).
+CLAIM_KEY_REGEX = r"^\s*(\w+\s+){2,3}\d{2,3}\s*$"
+
+
+def normalize_claim_key(message_text: str) -> str:
+    return " ".join(message_text.strip().split()).lower()
+
+
+def try_accept_node_claim(*, sender: ObservedNode, message_text: str, observer, sender_service) -> bool:
+    """
+    If message_text matches a pending NodeOwnerClaim for sender, accept ownership.
+
+    Emits node_claim_authorized on success. Returns True when a claim was accepted.
+    """
+    if not re.match(CLAIM_KEY_REGEX, message_text):
+        return False
+
+    claim_key = normalize_claim_key(message_text)
+    logger.info("Checking node claim for %s: %s", sender.node_id_str, claim_key)
+
+    claim = NodeOwnerClaim.objects.filter(
+        node=sender,
+        claim_key=claim_key,
+        accepted_at__isnull=True,
+    ).first()
+    if claim is None:
+        return False
+
+    logger.info(
+        "Authorizing node claim for %s by %s",
+        sender.node_id_str,
+        claim.user.username,
+    )
+
+    sender.claimed_by = claim.user
+    sender.save(update_fields=["claimed_by"])
+
+    claim.accepted_at = timezone.now()
+    claim.save(update_fields=["accepted_at"])
+
+    node_claim_authorized.send(
+        sender=sender_service,
+        node=sender,
+        claim=claim,
+        observer=observer,
+    )
+    return True

--- a/Meshflow/nodes/tests/test_claim_authorization.py
+++ b/Meshflow/nodes/tests/test_claim_authorization.py
@@ -1,0 +1,125 @@
+"""Tests for nodes.claim_authorization."""
+
+from django.test import override_settings
+from django.utils import timezone
+
+import pytest
+
+from nodes.claim_authorization import normalize_claim_key, try_accept_node_claim
+from nodes.models import NodeOwnerClaim
+from packets.signals import node_claim_authorized
+
+
+@pytest.mark.django_db
+def test_normalize_claim_key_collapses_whitespace():
+    assert normalize_claim_key("  Word   Word   42  ") == "word word 42"
+
+
+@pytest.mark.django_db
+def test_try_accept_node_claim_rejects_non_matching_text(create_observed_node, create_user, create_managed_node):
+    user = create_user()
+    node = create_observed_node()
+    observer = create_managed_node()
+    NodeOwnerClaim.objects.create(node=node, user=user, claim_key="word word 99", accepted_at=None)
+
+    captured = []
+
+    def handler(sender, node, claim, observer, **kwargs):
+        captured.append((node, claim))
+
+    node_claim_authorized.connect(handler)
+
+    try:
+        assert (
+            try_accept_node_claim(
+                sender=node,
+                message_text="not a claim key at all",
+                observer=observer,
+                sender_service=object(),
+            )
+            is False
+        )
+        assert len(captured) == 0
+        node.refresh_from_db()
+        assert node.claimed_by_id is None
+    finally:
+        node_claim_authorized.disconnect(handler)
+
+
+@pytest.mark.django_db
+def test_try_accept_node_claim_success(create_observed_node, create_user, create_managed_node):
+    user = create_user()
+    node = create_observed_node()
+    observer = create_managed_node()
+    claim = NodeOwnerClaim.objects.create(
+        node=node,
+        user=user,
+        claim_key="word word 123",
+        accepted_at=None,
+    )
+
+    captured = []
+
+    def handler(sender, node, claim, observer, **kwargs):
+        captured.append((sender, node, claim, observer))
+
+    node_claim_authorized.connect(handler)
+
+    try:
+        assert (
+            try_accept_node_claim(
+                sender=node,
+                message_text="word word 123",
+                observer=observer,
+                sender_service=object(),
+            )
+            is True
+        )
+        assert len(captured) == 1
+        claim.refresh_from_db()
+        node.refresh_from_db()
+        assert claim.accepted_at is not None
+        assert node.claimed_by_id == user.id
+    finally:
+        node_claim_authorized.disconnect(handler)
+
+
+@pytest.mark.django_db
+@override_settings(CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}})
+def test_try_accept_triggers_ws_receiver(create_observed_node, create_user, create_managed_node):
+    from asgiref.sync import async_to_sync
+    from channels.layers import get_channel_layer
+
+    from common.ws_groups import user_claims_ws_group
+
+    user = create_user()
+    node = create_observed_node()
+    observer = create_managed_node()
+    NodeOwnerClaim.objects.create(
+        node=node,
+        user=user,
+        claim_key="alpha beta 55",
+        accepted_at=None,
+    )
+
+    channel_layer = get_channel_layer()
+    group = user_claims_ws_group(user.id)
+
+    async def collect():
+        channel = await channel_layer.new_channel()
+        await channel_layer.group_add(group, channel)
+        return channel
+
+    channel = async_to_sync(collect)()
+
+    try_accept_node_claim(
+        sender=node,
+        message_text="alpha beta 55",
+        observer=observer,
+        sender_service=object(),
+    )
+
+    msg = async_to_sync(channel_layer.receive)(channel)
+    assert msg["type"] == "node_claim_update"
+    assert msg["payload"]["event"] == "node_claim_accepted"
+    assert msg["payload"]["node_internal_id"] == str(node.internal_id)

--- a/Meshflow/nodes/tests/test_claim_authorization.py
+++ b/Meshflow/nodes/tests/test_claim_authorization.py
@@ -1,7 +1,6 @@
 """Tests for nodes.claim_authorization."""
 
 from django.test import override_settings
-from django.utils import timezone
 
 import pytest
 

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -301,7 +301,7 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         """
         nodes = (
             ObservedNode.objects.filter(claimed_by=request.user)
-            .order_by("meshtastic_node_id")
+            .order_by("protocol", "-last_heard", "node_id_str")
             .select_related("latest_status")
         )
 

--- a/Meshflow/nodes/ws_notify.py
+++ b/Meshflow/nodes/ws_notify.py
@@ -1,0 +1,38 @@
+"""Push node-claim acceptance events to the claiming user's WebSocket clients."""
+
+import logging
+
+from django.utils import timezone
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from common.ws_groups import user_claims_ws_group
+from nodes.models import NodeOwnerClaim, ObservedNode
+
+logger = logging.getLogger(__name__)
+
+
+def notify_node_claim_accepted(*, claim: NodeOwnerClaim, node: ObservedNode) -> None:
+    """Notify the claiming user that their ownership proof was accepted."""
+    try:
+        channel_layer = get_channel_layer()
+        accepted_at = claim.accepted_at or timezone.now()
+        payload = {
+            "event": "node_claim_accepted",
+            "node_internal_id": str(node.internal_id),
+            "node_id_str": node.node_id_str,
+            "protocol": node.protocol,
+            "accepted_at": accepted_at.isoformat(),
+        }
+        async_to_sync(channel_layer.group_send)(
+            user_claims_ws_group(claim.user_id),
+            {"type": "node_claim_update", "payload": payload},
+        )
+        logger.debug(
+            "Sent node_claim_accepted to user_id=%s node=%s",
+            claim.user_id,
+            node.node_id_str,
+        )
+    except Exception as e:
+        logger.warning("Failed to send node_claim_accepted WebSocket: %s", e)

--- a/Meshflow/packets/services/text_message.py
+++ b/Meshflow/packets/services/text_message.py
@@ -1,16 +1,13 @@
 """Service for processing message packets."""
 
 import logging
-import re
-
-from django.utils import timezone
 
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
 from common.protocol import Protocol
-from nodes.models import NodeOwnerClaim
+from nodes.claim_authorization import try_accept_node_claim
 from packets.models import MessagePacket
 from packets.services.base import BasePacketService
-from packets.signals import node_claim_authorized, text_message_received
+from packets.signals import text_message_received
 from text_messages.models import TextMessage
 
 logger = logging.getLogger(__name__)
@@ -18,9 +15,6 @@ logger = logging.getLogger(__name__)
 
 class TextMessagePacketService(BasePacketService):
     """Service for processing message packets."""
-
-    # regex for a claim key (2-3 words and 2-3 digits)
-    _CLAIM_KEY_REGEX = r"^\s*(\w+\s+){2,3}\d{2,3}\s*$"
 
     def _process_packet(self) -> None:
         """Process the message packet and create a Message record."""
@@ -56,38 +50,12 @@ class TextMessagePacketService(BasePacketService):
 
     def _authorize_node_claim(self) -> None:
         """Authorize a user's claim to a node via the claim key in the message."""
-
-        # Only accept claims via direct messages
         if self.packet.to_int == MESHTASTIC_BROADCAST_ID:
             return
 
-        # check whether this looks like a claim key (2-3 words and 2-3 digits)
-        # reduces unnecessary database queries
-        if not re.match(self._CLAIM_KEY_REGEX, self.packet.message_text):
-            return
-
-        # remove whitespace from the claim key
-        claim_key = " ".join(self.packet.message_text.strip().split()).lower()
-        logger.info(f"Checking node claim for {self.from_node.node_id_str}: {claim_key}")
-
-        # check if this key matches a claim
-        claim = NodeOwnerClaim.objects.filter(
-            node=self.from_node,
-            claim_key=claim_key,
-            accepted_at__isnull=True,
-        ).first()
-        if claim is None:
-            return
-
-        logger.info(f"Authorizing node claim for {self.from_node.node_id_str} by {claim.user.username}")
-
-        # update the node's owner
-        self.from_node.claimed_by = claim.user
-        self.from_node.save(update_fields=["claimed_by"])
-
-        # delete the claim
-        claim.accepted_at = timezone.now()
-        claim.save(update_fields=["accepted_at"])
-
-        # send the node claim authorized signal
-        node_claim_authorized.send(sender=self, node=self.from_node, claim=claim, observer=self.observer)
+        try_accept_node_claim(
+            sender=self.from_node,
+            message_text=self.packet.message_text,
+            observer=self.observer,
+            sender_service=self,
+        )

--- a/Meshflow/ws/consumers.py
+++ b/Meshflow/ws/consumers.py
@@ -269,3 +269,68 @@ class TracerouteConsumer(AsyncWebsocketConsumer):
             return User.objects.get(id=user_id)
         except User.DoesNotExist:
             return AnonymousUser()
+
+
+class NodeClaimConsumer(AsyncWebsocketConsumer):
+    """
+    WebSocket consumer for node-claim acceptance (ownership proof).
+
+    Authenticated users connect with JWT via query param: ws/claims/?token=<jwt>
+    On connect, join group user_claims_{user_id}. Receive node_claim_update when
+    a pending claim is accepted via mesh DM proof.
+    """
+
+    async def connect(self):
+        self.user = self.scope.get("user", AnonymousUser())
+
+        query_string = self.scope.get("query_string", b"").decode("utf-8")
+        query_params = dict(param.split("=", 1) for param in query_string.split("&") if "=" in param)
+        token = query_params.get("token")
+
+        if token:
+            try:
+                access_token = AccessToken(token)
+                user_id = access_token.get("user_id")
+                if user_id:
+                    self.user = await self.get_user_from_id(user_id)
+            except (TokenError, InvalidToken) as e:
+                logger.warning("NodeClaimConsumer: invalid token: %s", e)
+                await self.close()
+                return
+
+        if self.user.is_anonymous:
+            logger.warning("NodeClaimConsumer: anonymous user tried to connect")
+            await self.close()
+            return
+
+        from common.ws_groups import user_claims_ws_group
+
+        self.claims_group = user_claims_ws_group(self.user.id)
+        await self.channel_layer.group_add(self.claims_group, self.channel_name)
+        await self.accept()
+        logger.info("NodeClaimConsumer: user %s connected", self.user.username)
+
+    async def disconnect(self, close_code):
+        if hasattr(self, "claims_group"):
+            await self.channel_layer.group_discard(self.claims_group, self.channel_name)
+        logger.info(
+            "NodeClaimConsumer: user %s disconnected",
+            getattr(self.user, "username", "unknown"),
+        )
+
+    async def receive(self, text_data):
+        pass
+
+    async def node_claim_update(self, event):
+        """Handle node_claim_update from channel layer."""
+        await self.send(text_data=json.dumps(event["payload"]))
+
+    @database_sync_to_async
+    def get_user_from_id(self, user_id):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        try:
+            return User.objects.get(id=user_id)
+        except User.DoesNotExist:
+            return AnonymousUser()

--- a/Meshflow/ws/receivers.py
+++ b/Meshflow/ws/receivers.py
@@ -2,9 +2,16 @@
 
 from django.dispatch import receiver
 
-from packets.signals import text_message_received
+from nodes.ws_notify import notify_node_claim_accepted
+from packets.signals import node_claim_authorized, text_message_received
 
 from .services.text_message import TextMessageWebSocketNotifier
+
+
+@receiver(node_claim_authorized)
+def send_node_claim_websocket_event(sender, node, claim, observer, **kwargs):
+    """Push claim acceptance to the claiming user's WebSocket clients."""
+    notify_node_claim_accepted(claim=claim, node=node)
 
 
 @receiver(text_message_received)

--- a/Meshflow/ws/tests/test_node_claim_consumer.py
+++ b/Meshflow/ws/tests/test_node_claim_consumer.py
@@ -1,0 +1,62 @@
+"""Tests for NodeClaimConsumer WebSocket."""
+
+import json
+
+from django.test import override_settings
+
+import pytest
+from channels.db import database_sync_to_async
+from channels.layers import get_channel_layer
+from channels.routing import URLRouter
+from channels.testing import WebsocketCommunicator
+from rest_framework_simplejwt.tokens import AccessToken
+
+import Meshflow.routing  # noqa: F401
+
+application = URLRouter(Meshflow.routing.websocket_urlpatterns)
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+@override_settings(CHANNEL_LAYERS={"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}})
+async def test_node_claim_consumer_receives_accepted_event(create_user):
+    user = await database_sync_to_async(create_user)()
+    token = AccessToken.for_user(user)
+    url = f"/ws/claims/?token={str(token)}"
+
+    communicator = WebsocketCommunicator(application, url)
+    connected, _ = await communicator.connect()
+    assert connected is True
+
+    channel_layer = get_channel_layer()
+    from common.ws_groups import user_claims_ws_group
+
+    await channel_layer.group_send(
+        user_claims_ws_group(user.id),
+        {
+            "type": "node_claim_update",
+            "payload": {
+                "event": "node_claim_accepted",
+                "node_internal_id": "00000000-0000-0000-0000-000000000001",
+                "node_id_str": "mc:aabbccddeeff",
+                "protocol": 2,
+                "accepted_at": "2026-05-25T12:00:00+00:00",
+            },
+        },
+    )
+
+    response = await communicator.receive_from()
+    data = json.loads(response)
+    assert data["event"] == "node_claim_accepted"
+    assert data["node_id_str"] == "mc:aabbccddeeff"
+
+    await communicator.disconnect()
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_node_claim_consumer_rejects_anonymous():
+    communicator = WebsocketCommunicator(application, "/ws/claims/")
+    connected, _ = await communicator.connect()
+    assert connected is False
+    await communicator.disconnect()

--- a/docs/REDIS.md
+++ b/docs/REDIS.md
@@ -15,6 +15,7 @@ Configuration lives in [`Meshflow/Meshflow/settings/base.py`](../Meshflow/Meshfl
     - **`NodeConsumer`** (`ws/nodes/?api_key=…`) — feeder bots join group `node_{meshtastic_node_id}` or **`node_mc_{managed_node.internal_id}`** (MeshCore); receives **`node_command`** events (e.g. traceroute, `apply_mc_channel_config`). Any API/ASGI worker can `group_send`; membership is cluster-wide in Redis DB 0. Emitters include traceroute views/tasks, `meshcore_packets` apply-channel, and management commands.
     - **`TextMessageConsumer`** — authenticated UI clients join group **`text_messages`**; receives **`text_message`** events for mesh text broadcasts ([`Meshflow/ws/services/text_message.py`](../Meshflow/ws/services/text_message.py)).
     - **`TracerouteConsumer`** (`ws/traceroutes/?token=…`) — clients join group **`traceroutes`**; receives **`traceroute_update`** events ([`Meshflow/traceroute/ws_notify.py`](../Meshflow/traceroute/ws_notify.py)).
+    - **`NodeClaimConsumer`** (`ws/claims/?token=…`) — clients join group **`user_claims_{user_id}`**; receives **`node_claim_update`** / `node_claim_accepted` when ownership proof succeeds ([`Meshflow/nodes/ws_notify.py`](../Meshflow/nodes/ws_notify.py), signal `node_claim_authorized`).
   - **TTL:** Connection/session lifetime; Channels manages internal keys.
 
 - **DB 1 — Celery broker + result backend**  

--- a/docs/features/meshcore/README.md
+++ b/docs/features/meshcore/README.md
@@ -14,6 +14,7 @@ Cross-repo MeshCore work is tracked on GitHub epics [#264](https://github.com/ps
 
 - [feeder-bootstrap.md](./feeder-bootstrap.md) — first MC feeder + API key + `mc_pubkey`
 - [text-message-channels.md](./text-message-channels.md) — Phase 2.2 text + channels (device → API sync, apply-to-radio, ops troubleshooting)
+- [../node-lifecycle/node-claims-meshcore.md](../node-lifecycle/node-claims-meshcore.md) — ownership claims via contact/DM proof
 
 **Recent follow-up (post–#295 / staging):** see [phase-2-progress.md](./phase-2-progress.md) § “Feeder identity & apply fixes” and [phase-2-outstanding.md](./phase-2-outstanding.md) § “Phase 2.2 — staging & ops”.
 

--- a/docs/features/meshcore/text-message-channels.md
+++ b/docs/features/meshcore/text-message-channels.md
@@ -141,6 +141,8 @@ It does **not** include channel name, hashtag string, sender full pubkey, or des
 
 ### `contact_message` → DM / private text
 
+Contact DMs are also used for **node ownership claims**: the user sends only the UI-generated claim key to a feeder ([node-claims-meshcore.md](../node-lifecycle/node-claims-meshcore.md)).
+
 - `pubkey_prefix` — 12 hex chars (6-byte sender prefix)
 - `text`, `channel_idx` (often `0` in samples; DMs are not a channel in the ADR sense)
 

--- a/docs/features/node-lifecycle/README.md
+++ b/docs/features/node-lifecycle/README.md
@@ -1,9 +1,9 @@
 # Node Lifecycle
 
-This feature area describes how Meshtastic radio nodes move through Meshflow:
+This feature area describes how mesh radio nodes (Meshtastic and MeshCore) move through Meshflow:
 
 1. An observed node is discovered from ingested packets.
-2. A user proves ownership by claiming the observed node.
+2. A user proves ownership by claiming the observed node (protocol-specific proof message).
 3. The owner can convert that node into a managed node so it can feed packets into Meshflow.
 4. The owner can later release the claim or remove the managed-node role without deleting the observed node.
 
@@ -13,13 +13,15 @@ On **first** creation of an `ObservedNode`, the API may queue one **new-node bas
 
 ## Lifecycle Documents
 
-- [Node claims](node-claims.md): how users prove ownership of an observed node.
+- [Node claims](node-claims.md): shared claim model, permissions, WebSocket push.
+- [Meshtastic claims](node-claims-meshtastic.md): DM proof via Meshtastic feeders.
+- [MeshCore claims](node-claims-meshcore.md): contact/DM proof via MeshCore feeders.
 - [Managed nodes](managed-nodes.md): how claimed nodes become feeder nodes.
 - [Removal](removal.md): how ownership and managed-node status are removed.
 
 ## Core Models
 
-- `ObservedNode`: a Meshtastic radio node seen on the mesh.
+- `ObservedNode`: a Meshtastic or MeshCore radio node seen on the mesh (`protocol` discriminates).
 - `NodeLatestStatus`: denormalized latest position and metrics for an observed node.
 - `NodeOwnerClaim`: a pending or accepted ownership proof for an observed node.
 - `ManagedNode`: a Meshflow feeder node operated by a user.

--- a/docs/features/node-lifecycle/node-claims-meshcore.md
+++ b/docs/features/node-lifecycle/node-claims-meshcore.md
@@ -1,0 +1,28 @@
+# MeshCore node claims
+
+Node claims let a user prove that they control a MeshCore radio represented by an `ObservedNode` (`protocol=meshcore`, `mc:` / pubkey identity).
+
+## Claim flow
+
+1. The user signs in and opens an unclaimed MeshCore observed node in the UI.
+2. The frontend calls `POST /api/nodes/observed-nodes/{internal_id}/claim/` (same endpoint as Meshtastic; lookup accepts `mc:` prefixes and UUIDs).
+3. The API returns a `claim_key` (same word+digit format as Meshtastic).
+4. From the **physical MeshCore device**, the user sends a **contact/DM** (not a channel/broadcast message) to a MeshCore **feeder** (`ManagedNode` with `protocol=meshcore`). The message body must be **only** the claim key.
+5. The feeder bot uploads `contact_text` to `POST /api/meshcore/feeders/{prefix}/packets/ingest/`.
+6. [`MeshCoreTextMessageService`](../../../Meshflow/meshcore_packets/services/text_message.py) resolves the sender `ObservedNode` from `from_pubkey` / `from_pubkey_prefix` and calls [`try_accept_node_claim`](../../../Meshflow/nodes/claim_authorization.py).
+7. On match, `claimed_by` is set, `accepted_at` is recorded, `node_claim_authorized` fires, and the UI receives **`node_claim_accepted`** on `ws/claims/`.
+
+Channel (`CHANNEL_TEXT`) messages are **not** accepted for claims (same security model as ignoring Meshtastic broadcasts).
+
+## Identity notes
+
+- Start the claim against the same observed-node row the feeder will attribute to the DM (usually `mc:{12-hex-prefix}` until a full `mc_pubkey` is known).
+- Prefix-only nodes are valid; the DM’s `from_pubkey_prefix` must match the claimed node.
+
+## Operator steps (bot)
+
+See [meshflow-bot `docs/MESHCORE.md`](https://github.com/pskillen/meshflow-bot/blob/main/docs/MESHCORE.md) — “Claiming a node”.
+
+## Shared concepts
+
+See [node-claims.md](node-claims.md) for `NodeOwnerClaim` fields, permissions, and signals.

--- a/docs/features/node-lifecycle/node-claims-meshtastic.md
+++ b/docs/features/node-lifecycle/node-claims-meshtastic.md
@@ -1,0 +1,22 @@
+# Meshtastic node claims
+
+Node claims let a user prove that they control a Meshtastic radio represented by an `ObservedNode` (`protocol=meshtastic`).
+
+## Claim flow
+
+1. The user signs in to the frontend.
+2. The user finds an unclaimed observed node.
+3. The frontend calls `POST /api/nodes/observed-nodes/{internal_id}/claim/`.
+4. The API creates a `NodeOwnerClaim` with a generated `claim_key`.
+5. The user sends the claim key as a **direct Meshtastic message** (not broadcast) from their node to a Meshflow managed (feeder) node.
+6. Packet ingestion receives that text message.
+7. [`Meshflow/packets/services/text_message.py`](../../../Meshflow/packets/services/text_message.py) calls [`try_accept_node_claim`](../../../Meshflow/nodes/claim_authorization.py).
+8. The API sets `ObservedNode.claimed_by` and `NodeOwnerClaim.accepted_at`, emits `node_claim_authorized`, and pushes **`node_claim_accepted`** to the claimant over `ws/claims/`.
+
+The claim page uses the WebSocket event for near-real-time success; it falls back to slow HTTP polling if the socket is unavailable.
+
+Accepted claims do not create the observed node. The observed node must already exist, usually from packet ingestion.
+
+## Shared concepts
+
+See [node-claims.md](node-claims.md) for `NodeOwnerClaim` fields, permissions, constellation access, retention, and the `node_claim_authorized` signal.

--- a/docs/features/node-lifecycle/node-claims.md
+++ b/docs/features/node-lifecycle/node-claims.md
@@ -1,21 +1,15 @@
-# Node Claims
+# Node claims
 
-Node claims let a user prove that they control a Meshtastic radio represented by an `ObservedNode`.
+Node claims let authenticated users prove they control a radio represented by an `ObservedNode`. Proof is always an out-of-band message containing a server-generated **claim key**; the API never trusts UI assertions alone.
 
-## Claim Flow
+## Protocol-specific flows
 
-1. The user signs in to the frontend.
-2. The user finds an unclaimed observed node.
-3. The frontend calls `POST /api/nodes/observed-nodes/{node_id}/claim/`.
-4. The API creates a `NodeOwnerClaim` with a generated `claim_key`.
-5. The user sends the claim key as a direct Meshtastic message from their node to a Meshflow managed node.
-6. Packet ingestion receives that text message.
-7. `Meshflow/packets/services/text_message.py` matches the message body to the claim key.
-8. The API sets `ObservedNode.claimed_by` to the claiming user and marks `NodeOwnerClaim.accepted_at`.
+| Protocol | Proof | Doc |
+|----------|--------|-----|
+| Meshtastic | Direct message to any Meshtastic feeder | [node-claims-meshtastic.md](node-claims-meshtastic.md) |
+| MeshCore | Contact/DM to a MeshCore feeder | [node-claims-meshcore.md](node-claims-meshcore.md) |
 
-Accepted claims do not create the observed node. The observed node must already exist, usually because it was discovered from packet ingestion.
-
-## Claim Records
+## Claim records
 
 `NodeOwnerClaim` represents an attempt to claim a node. A claim row is not ownership by itself.
 
@@ -23,23 +17,31 @@ Accepted claims do not create the observed node. The observed node must already 
 - `user`: the user attempting the claim.
 - `claim_key`: the proof string the radio must send.
 - `created_at`: when the claim was started.
-- `accepted_at`: when the proof was received.
+- `accepted_at`: when the proof was received (null while pending).
 
 `ObservedNode.claimed_by` is the authoritative owner field once the claim is accepted.
 
+Implementation: [`Meshflow/nodes/claim_authorization.py`](../../../Meshflow/nodes/claim_authorization.py).
+
+## Real-time UI (`node_claim_authorized`)
+
+When proof succeeds, the API emits Django signal **`node_claim_authorized`** (`packets.signals`) with kwargs:
+
+- `node` — the observed node that was claimed
+- `claim` — the `NodeOwnerClaim` row (with `accepted_at` set)
+- `observer` — the `ManagedNode` feeder that received the proof message
+
+The `ws` app listens and sends **`node_claim_accepted`** JSON to the claiming user’s channel group `user_claims_{user_id}` ([`NodeClaimConsumer`](../../../Meshflow/ws/consumers.py) at `ws/claims/?token=<jwt>`). No other built-in receivers exist today; the signal remains an extension point for notifications or audit.
+
 ## Permissions
 
-An authenticated user can start a claim for an unclaimed node. If `ObservedNode.claimed_by` is already set to another user, the API must reject the claim.
+An authenticated user can start a claim for an unclaimed node. If `ObservedNode.claimed_by` is already set to another user, the API rejects the claim.
 
-Only the user who owns a claim can see or cancel that claim through the claim endpoint.
+Only the claim owner can see or cancel their claim through the claim endpoint.
 
-When claim removal is implemented:
-
-- The claim owner can delete their own pending claim.
-- The claim owner can release their own accepted claim.
-- Releasing an accepted claim clears `ObservedNode.claimed_by` when it points at the current user.
-- Django staff do not get a REST endpoint to release another user's valid claim.
-- If an administrator needs to correct ownership, they can use Django Admin or a future purpose-built admin flow.
+- The claim owner can delete a pending claim.
+- The claim owner can release an accepted claim (`DELETE …/claim/`), clearing `claimed_by` when it matches.
+- Django staff do not get a REST shortcut to release another user’s claim.
 
 ## Constellation access
 
@@ -47,6 +49,6 @@ Constellations are **public for read** (no membership required). Claiming a node
 
 Managed-node setup requires the **feeder** role for API key creation (see [API_KEYS.md](../../API_KEYS.md) and [permissions/README.md](../../permissions/README.md)).
 
-## Observed Node Retention
+## Observed node retention
 
-Releasing a claim never deletes the `ObservedNode`. If the radio is still active, future packets continue to update it. If it is no longer active, it naturally falls out of recent-node views according to the same time-window behavior as any other observed node.
+Releasing a claim never deletes the `ObservedNode`. If the radio is still active, future packets continue to update it.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7087,7 +7087,18 @@ paths:
                 $ref: '#/components/schemas/Error'
     post:
       summary: Create claim for observed node
-      description: Create a claim for the current user for the specified observed node.
+      description: >
+        Create a claim for the current user for the specified observed node. Returns a
+        `claim_key` the user must send from the radio to prove ownership.
+
+        **Meshtastic:** send the claim key as the body of a **direct message** to any
+        Meshflow managed (feeder) node. Broadcast channel messages are ignored.
+
+        **MeshCore:** send the claim key as the body of a **contact/DM** (not channel
+        broadcast) to a MeshCore feeder. On acceptance the API sets `claimed_by` and
+        pushes `node_claim_accepted` to the claimant over `ws/claims/` (JWT).
+
+        The observed node must already exist (discovered via packet ingest).
       tags: [Nodes]
       security:
         - BearerAuth: []


### PR DESCRIPTION
## Summary

- Extract shared `try_accept_node_claim` for Meshtastic DM and MeshCore contact/DM proof.
- Accept MeshCore claims on `CONTACT_TEXT` ingest (not channel broadcast).
- Push `node_claim_accepted` to the claiming user via `ws/claims/` (`NodeClaimConsumer`).
- Split node-lifecycle claim docs (Meshtastic vs MeshCore); update OpenAPI and `GET …/mine` ordering.

## Test plan

- [x] `pytest Meshflow/nodes/tests/test_claim_authorization.py Meshflow/meshcore_packets/tests/test_text_message_service.py Meshflow/ws/tests/test_node_claim_consumer.py -v`
- [ ] Manual: start MC claim in UI (companion PR), send contact DM with claim key to MC feeder, verify WebSocket success

Closes #343. Companion: meshflow-ui #292, meshflow-bot claim docs PR.