### PR TITLE
fix(nodes): order observed-nodes/mine by DB identity fields

### DIFF
--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -145,6 +145,25 @@ def test_managed_nodes_status_fields_meshcore_feeder(create_managed_node, create
 
 
 @pytest.mark.django_db
+def test_observed_node_mine_returns_claimed_nodes(create_observed_node, create_user):
+    """GET observed-nodes/mine/ must not order_by computed node_id_str (removed DB column)."""
+    client = APIClient()
+    owner = create_user()
+    other = create_user()
+    client.force_authenticate(user=owner)
+
+    claimed = create_observed_node(claimed_by=owner, meshtastic_node_id=11111111)
+    create_observed_node(claimed_by=other, meshtastic_node_id=22222222)
+    create_observed_node(claimed_by=None, meshtastic_node_id=33333333)
+
+    response = client.get(reverse("observed-node-mine"))
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["meshtastic_node_id"] == claimed.meshtastic_node_id
+    assert response.data["results"][0]["node_id_str"] == claimed.node_id_str
+
+
+@pytest.mark.django_db
 def test_observed_node_list_view(create_observed_node, create_user):
     """Test observed node list view."""
     client = APIClient()

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -301,7 +301,7 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         """
         nodes = (
             ObservedNode.objects.filter(claimed_by=request.user)
-            .order_by("protocol", "-last_heard", "node_id_str")
+            .order_by("protocol", "-last_heard", "meshtastic_node_id", "mc_pubkey_prefix")
             .select_related("latest_status")
         )
 


### PR DESCRIPTION
## Summary

Fixes `FieldError` on `GET /api/nodes/observed-nodes/mine/` (My Nodes in the UI) after `node_id_str` was removed as a DB column ([#294](https://github.com/pskillen/meshflow-api/issues/294)). The `mine` action was still ordering by `node_id_str`, which is now a computed property only.

Order by `meshtastic_node_id` and `mc_pubkey_prefix` instead, matching other observed-node list queries.

## Testing performed

* Added `test_observed_node_mine_returns_claimed_nodes`
* `python -m pytest Meshflow/nodes/tests/test_node_views.py::test_observed_node_mine_returns_claimed_nodes -v`