### PR TITLE
feat(nodes): ManagedNode protocol identity (#362)

### DIFF
--- a/.cursor/skills/progress-tracking/SKILL.md
+++ b/.cursor/skills/progress-tracking/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: progress-tracking
+description: >-
+  Maintains progress and outstanding markdown logs for multi-step Meshflow plans
+  and epics. Use when executing a Cursor plan, a multi-repo feature, or when the
+  user asks to update progress/outstanding docs, hand off between agents, or
+  before opening a PR for a large initiative.
+---
+
+# Progress tracking (Meshflow plans)
+
+Persistent **progress** and **outstanding** files preserve execution state when context is lost, agents switch, or work spans multiple PRs. Follow this skill whenever a Cursor plan or epic has non-trivial scope (multi-commit, multi-repo, or high coordination risk).
+
+**Reference examples (large epic):** [docs/features/meshcore/phase-2-progress.md](../../docs/features/meshcore/phase-2-progress.md), [phase-2-outstanding.md](../../docs/features/meshcore/phase-2-outstanding.md).
+
+---
+
+## Two files — distinct roles
+
+| File | Purpose | Put here | Do **not** put here |
+|------|---------|----------|---------------------|
+| **`*-progress.md`** | What **shipped** or is **in flight** | Merged PRs, deploy notes, verification commands, env vars, concrete file paths | Future plan steps not started; raw checklists copied from the plan |
+| **`*-outstanding.md`** | **Debt discovered during execution** | Skipped scope, incomplete merges, bugs found, follow-ups that block verification, doc drift | The plan’s upcoming phases; epic backlog that was never in scope for this initiative |
+
+**Outstanding is not a second plan.** If work is scheduled but not started, it stays in the Cursor plan (or GitHub issue). Move an item to outstanding only when execution revealed it (missed, deferred mid-flight, or needs a later ticket).
+
+---
+
+## Where files live
+
+Default under **`docs/features/<topic>/`** in the repo that owns most of the work (usually **meshflow-api** for API-heavy initiatives).
+
+| Initiative | Progress | Outstanding |
+|------------|----------|-------------|
+| MeshCore phase epics | `phase-N-progress.md` | `phase-N-outstanding.md` |
+| Focused plan (e.g. #362, enrollment) | `<slug>-progress.md` | `<slug>-outstanding.md` |
+
+**Slug:** kebab-case from the plan name (e.g. `managed-node-identity`, `enrollment`).
+
+For **multi-repo** work, one progress pair in meshflow-api is enough unless UI-only work needs `meshflow-ui/docs/...` (rare). Link sibling PRs from the api progress file.
+
+Add a row to [docs/features/meshcore/README.md](../../docs/features/meshcore/README.md) when the work is MeshCore-related.
+
+---
+
+## When to read and update
+
+### At plan start (required)
+
+1. Read the linked **progress** and **outstanding** files if they exist.
+2. If missing, create both from the templates below (initial progress = tracking issue, plan link, status **Not started** or **In progress**).
+3. In the Cursor plan, add a **Progress tracking** section pointing at both files (see plan template).
+
+### During execution (at logical breakpoints)
+
+Update **progress** when:
+
+- A commit or PR lands a coherent slice (match [meshflow-git-workflow](../meshflow-git-workflow/SKILL.md) atomic commits).
+- Deploy order or env prerequisites change.
+- A phase flips to **Complete** with PR/issue links.
+
+Update **outstanding** when:
+
+- You skip or narrow scope and need a follow-up ticket later.
+- You discover a bug, doc error, or missing test during the ticket (not pre-planned work).
+- Production verification is blocked on something outside the current PR.
+
+**Cadence (use judgment):**
+
+| Plan size | Typical updates |
+|-----------|-----------------|
+| Small (1 PR, &lt;5 files) | Once before opening PR |
+| Medium (2–4 atomic commits) | After migration/API contract; before PR |
+| Large / multi-repo | Per plan phase + before each PR |
+
+**Always update progress before opening a PR** for initiatives that use this skill.
+
+### At handoff
+
+Leave progress with accurate **Status** lines, open PR URLs, branch names, and “**Next:**” for the successor agent.
+
+---
+
+## Progress file template
+
+```markdown
+# <Title> — progress
+
+**Tracking:** [meshflow-api#NNN](https://github.com/pskillen/meshflow-api/issues/NNN) (and cross-links)
+**Plan:** `.cursor/plans/<plan-file>.plan.md` or GitHub issue
+**Repos:** meshflow-api, …
+
+---
+
+## Overall status
+
+**Status:** Not started | In progress | Complete (pending deploy) | Complete
+
+**Branch:** `api-NNN/<author>/<slug>` (per repo if applicable)
+
+---
+
+## <Phase or slice name>
+
+**Status:** …
+**PR:** …
+
+**Delivered**
+
+- …
+
+**Deploy / verify**
+
+- …
+
+---
+
+## Next
+
+- …
+```
+
+Use checkboxes in **outstanding** only; progress sections use **Status** + bullet lists (see phase-2 examples).
+
+---
+
+## Outstanding file template
+
+```markdown
+# <Title> — outstanding
+
+Items **skipped**, **incomplete**, or **discovered during execution** — not the plan’s future phases.
+
+**Tracking:** same as progress file
+
+---
+
+## <area>
+
+- [ ] …
+- [x] … (closed when fixed; keep brief note or link to PR)
+
+```
+
+---
+
+## Cursor plan integration
+
+Every plan that uses progress tracking must include near the top:
+
+```markdown
+## Progress tracking
+
+Read and update (per [progress-tracking](meshflow-api/.cursor/skills/progress-tracking/SKILL.md)):
+
+- **Progress:** [docs/features/.../<slug>-progress.md](path)
+- **Outstanding:** [docs/features/.../<slug>-outstanding.md](path)
+
+Update both at logical breakpoints and **before each PR**.
+```
+
+When a plan depends on another (e.g. enrollment after #362), the dependent plan’s progress file should note **Prerequisite:** link to the other progress file and required merge/deploy state.
+
+---
+
+## GitHub issues
+
+- Link progress/outstanding paths in the tracking issue body or a comment at kickoff.
+- Do not duplicate the full progress log in the issue; the markdown files are canonical for agent handoff.
+- Close outstanding items by linking the fixing PR or moving to a new issue if scope grew.
+
+---
+
+## Anti-patterns
+
+- Copying the plan’s full todo list into outstanding.
+- Marking plan phases “done” in progress without PR/commit evidence.
+- Creating phase-0/1/2-style files for a single small ticket (one progress pair is enough).
+- Letting progress go stale across multiple PRs without a **Next** section.

--- a/Meshflow/meshcore_packets/tests/conftest.py
+++ b/Meshflow/meshcore_packets/tests/conftest.py
@@ -13,7 +13,7 @@ FEEDER_B_MC_PUBKEY_PREFIX = "c" * 12
 def meshcore_feeder(create_managed_node, create_node_api_key):
     """MC ManagedNode + API key + NodeAuth for ingest tests."""
     node = create_managed_node(
-        meshtastic_node_id=0,
+        meshtastic_node_id=None,
         protocol=Protocol.MESHCORE,
         name="MC Feeder",
         mc_pubkey=FEEDER_MC_PUBKEY,

--- a/Meshflow/meshcore_packets/tests/test_feeder_auth_resolver.py
+++ b/Meshflow/meshcore_packets/tests/test_feeder_auth_resolver.py
@@ -1,5 +1,7 @@
 """Unit tests for MeshCore feeder resolution."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from common.meshcore_feeder_auth import MeshCoreFeederResolutionError, resolve_meshcore_feeder
@@ -45,8 +47,8 @@ def test_resolve_pubkey_mismatch(meshcore_feeder):
 
 
 @pytest.mark.django_db
-def test_shared_key_two_feeders(create_managed_node, create_node_api_key):
-    constellation = create_managed_node(protocol=Protocol.MESHCORE).constellation
+def test_shared_key_two_feeders(create_managed_node, create_constellation, create_node_api_key):
+    constellation = create_constellation(protocol=Protocol.MESHCORE)
     node_a = create_managed_node(
         meshtastic_node_id=0,
         protocol=Protocol.MESHCORE,
@@ -82,27 +84,31 @@ def test_shared_key_two_feeders(create_managed_node, create_node_api_key):
 
 
 @pytest.mark.django_db
-def test_shared_key_missing_mc_pubkey(create_managed_node, create_node_api_key):
-    constellation = create_managed_node(protocol=Protocol.MESHCORE).constellation
+def test_shared_key_missing_mc_pubkey(create_managed_node, create_constellation, create_node_api_key):
+    """Resolver rejects ambiguous shared keys when a linked feeder lacks mc_pubkey (in-memory)."""
+    constellation = create_constellation(protocol=Protocol.MESHCORE)
     node_a = create_managed_node(
-        meshtastic_node_id=0,
         protocol=Protocol.MESHCORE,
         constellation=constellation,
         mc_pubkey=FEEDER_MC_PUBKEY,
     )
     node_b = create_managed_node(
-        meshtastic_node_id=0,
         protocol=Protocol.MESHCORE,
         constellation=constellation,
-        mc_pubkey=None,
+        mc_pubkey=FEEDER_B_MC_PUBKEY,
     )
     api_key = create_node_api_key(constellation=constellation)
-    NodeAuth.objects.create(api_key=api_key, node=node_a)
-    NodeAuth.objects.create(api_key=api_key, node=node_b)
+    auth_a = NodeAuth.objects.create(api_key=api_key, node=node_a)
+    auth_b = NodeAuth.objects.create(api_key=api_key, node=node_b)
+    auth_b.node.mc_pubkey = None
 
-    with pytest.raises(MeshCoreFeederResolutionError) as exc:
-        resolve_meshcore_feeder(
-            api_key=api_key,
-            feeder_pubkey_prefix=FEEDER_MC_PUBKEY_PREFIX,
-        )
+    mock_qs = MagicMock()
+    mock_qs.select_related.return_value = [auth_a, auth_b]
+
+    with patch.object(NodeAuth.objects, "filter", return_value=mock_qs):
+        with pytest.raises(MeshCoreFeederResolutionError) as exc:
+            resolve_meshcore_feeder(
+                api_key=api_key,
+                feeder_pubkey_prefix=FEEDER_MC_PUBKEY_PREFIX,
+            )
     assert exc.value.code == "feeder_pubkey_not_configured"

--- a/Meshflow/meshcore_packets/tests/test_feeder_identity.py
+++ b/Meshflow/meshcore_packets/tests/test_feeder_identity.py
@@ -15,8 +15,8 @@ from nodes.models import NodeAuth
 
 
 @pytest.fixture
-def shared_key_two_feeders(create_managed_node, create_node_api_key):
-    constellation = create_managed_node(protocol=Protocol.MESHCORE).constellation
+def shared_key_two_feeders(create_managed_node, create_constellation, create_node_api_key):
+    constellation = create_constellation(protocol=Protocol.MESHCORE)
     node_a = create_managed_node(
         meshtastic_node_id=0,
         protocol=Protocol.MESHCORE,

--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -371,21 +371,18 @@ class ManagedNodeAdminForm(forms.ModelForm):
         self.initial["latlong"] = [lat, lng]
 
         self.fields["protocol"].help_text = _(
-            "MeshCore feeders use protocol MeshCore and node id 0; Meshtastic feeders use Meshtastic."
+            "Meshtastic feeders require a radio node ID. MeshCore feeders require mc_pubkey (no Meshtastic node ID)."
         )
 
         if self._submitted_protocol() == Protocol.MESHCORE:
-            initial = self.instance.meshtastic_node_id if not self.instance._state.adding else 0
-            self.fields["meshtastic_node_id"] = forms.IntegerField(
-                label=_("Node ID (placeholder)"),
-                required=False,
-                initial=initial,
-                min_value=0,
-                help_text=_(
-                    "Use 0 for MeshCore feeders (not used on the wire). "
-                    "Display id is mc:feeder:<internal id> after save."
-                ),
-            )
+            if "meshtastic_node_id" in self.fields:
+                self.fields["meshtastic_node_id"].widget = forms.HiddenInput()
+                self.fields["meshtastic_node_id"].required = False
+            if "mc_pubkey" in self.fields:
+                self.fields["mc_pubkey"].required = True
+                self.fields["mc_pubkey"].help_text = _(
+                    "64-char lowercase hex from bot connect logs (SELF_INFO). Required before save."
+                )
         elif not self.instance._state.adding and self.instance.protocol == Protocol.MESHTASTIC:
             self.fields["meshtastic_node_id"].initial = meshtastic_id_to_hex(self.instance.meshtastic_node_id)
 
@@ -413,12 +410,7 @@ class ManagedNodeAdminForm(forms.ModelForm):
         protocol = self._protocol_from_form()
 
         if protocol == Protocol.MESHCORE:
-            if raw in (None, ""):
-                return 0
-            try:
-                return int(raw)
-            except TypeError, ValueError:
-                raise forms.ValidationError(_("Enter 0 for MeshCore feeders."))
+            return None
 
         text = str(raw).strip() if raw is not None else ""
         if not text:
@@ -455,6 +447,8 @@ class ManagedNodeAdminForm(forms.ModelForm):
         if latlong:
             cleaned_data["default_location_latitude"] = latlong[0]
             cleaned_data["default_location_longitude"] = latlong[1]
+        if self._protocol_from_form() == Protocol.MESHCORE and not cleaned_data.get("mc_pubkey"):
+            raise forms.ValidationError({"mc_pubkey": _("mc_pubkey is required for MeshCore feeders.")})
         return cleaned_data
 
     def save(self, commit=True):

--- a/Meshflow/nodes/migrations/0050_managednode_protocol_identity.py
+++ b/Meshflow/nodes/migrations/0050_managednode_protocol_identity.py
@@ -1,0 +1,51 @@
+# ManagedNode protocol identity (#362): NULL meshtastic_node_id for MeshCore, CHECK constraints
+
+from django.db import migrations, models
+
+
+def _backfill_mc_placeholder_zero(apps, schema_editor):
+    ManagedNode = apps.get_model("nodes", "ManagedNode")
+    bad_mc = ManagedNode.objects.filter(protocol=2, meshtastic_node_id=0, mc_pubkey__isnull=True)
+    if bad_mc.exists():
+        raise RuntimeError(
+            "Cannot migrate: MeshCore ManagedNode rows have meshtastic_node_id=0 without mc_pubkey. "
+            "Set mc_pubkey in Django admin, then re-run migrate."
+        )
+    bad_mt = ManagedNode.objects.filter(protocol=1, meshtastic_node_id__isnull=True)
+    if bad_mt.exists():
+        raise RuntimeError(
+            "Cannot migrate: Meshtastic ManagedNode rows have NULL meshtastic_node_id."
+        )
+    ManagedNode.objects.filter(protocol=2, meshtastic_node_id=0).update(meshtastic_node_id=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nodes", "0049_managednode_mc_flood_advert_interval"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="managednode",
+            name="meshtastic_node_id",
+            field=models.BigIntegerField(blank=True, db_index=True, null=True),
+        ),
+        migrations.RunPython(_backfill_mc_placeholder_zero, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="managednode",
+            constraint=models.CheckConstraint(
+                condition=models.Q(protocol=1, meshtastic_node_id__isnull=False, mc_pubkey__isnull=True)
+                | models.Q(protocol=2, meshtastic_node_id__isnull=True, mc_pubkey__isnull=False),
+                name="managednode_protocol_identity",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="managednode",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(protocol=1, deleted_at__isnull=True),
+                fields=("meshtastic_node_id",),
+                name="managednode_unique_meshtastic_node_id_active",
+            ),
+        ),
+    ]

--- a/Meshflow/nodes/models.py
+++ b/Meshflow/nodes/models.py
@@ -58,7 +58,7 @@ class ManagedNode(models.Model):
     """User-owned feeder / infrastructure node (Meshtastic today; MeshCore in a later phase)."""
 
     internal_id = models.UUIDField(primary_key=True, null=False, default=uuid.uuid4, editable=False)
-    meshtastic_node_id = models.BigIntegerField(null=False, db_index=True)
+    meshtastic_node_id = models.BigIntegerField(null=True, blank=True, db_index=True)
     protocol = models.PositiveSmallIntegerField(
         choices=Protocol.choices,
         default=Protocol.MESHTASTIC,
@@ -203,6 +203,22 @@ class ManagedNode(models.Model):
         verbose_name = _("Managed node")
         verbose_name_plural = _("Managed nodes")
         constraints = [
+            models.CheckConstraint(
+                condition=(
+                    models.Q(protocol=Protocol.MESHTASTIC, meshtastic_node_id__isnull=False, mc_pubkey__isnull=True)
+                    | models.Q(
+                        protocol=Protocol.MESHCORE,
+                        meshtastic_node_id__isnull=True,
+                        mc_pubkey__isnull=False,
+                    )
+                ),
+                name="managednode_protocol_identity",
+            ),
+            models.UniqueConstraint(
+                fields=["meshtastic_node_id"],
+                condition=models.Q(protocol=Protocol.MESHTASTIC, deleted_at__isnull=True),
+                name="managednode_unique_meshtastic_node_id_active",
+            ),
             models.UniqueConstraint(
                 fields=["constellation", "mc_pubkey"],
                 condition=models.Q(protocol=Protocol.MESHCORE) & models.Q(mc_pubkey__isnull=False),

--- a/Meshflow/nodes/serializers.py
+++ b/Meshflow/nodes/serializers.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from rest_framework import serializers
 
 from common.access import AccessLevel, get_access_level, user_can_manage_api_keys
-from common.mesh_node_helpers import meshtastic_id_to_hex, observed_node_id_str
+from common.mesh_node_helpers import observed_node_id_str
 from common.protocol import Protocol
 from constellations.models import Constellation, MessageChannel
 from meshcore_packets.serializers_channel import MessageChannelMcSerializer
@@ -254,29 +254,76 @@ class APIKeyNodeSerializer(serializers.ModelSerializer):
         fields = ["id", "api_key", "node"]
 
 
+class LinkedManagedNodeSerializer(serializers.Serializer):
+    """Stable managed-node reference for API key detail (MT + MC)."""
+
+    internal_id = serializers.UUIDField(read_only=True)
+    node_id_str = serializers.CharField(read_only=True)
+    protocol = serializers.IntegerField(read_only=True)
+    meshtastic_node_id = serializers.IntegerField(read_only=True, allow_null=True)
+
+
 class APIKeyDetailSerializer(APIKeySerializer):
     """Serializer for API keys with node links."""
 
     nodes = serializers.SerializerMethodField()
+    linked_managed_nodes = serializers.SerializerMethodField()
 
     class Meta(APIKeySerializer.Meta):
-        fields = APIKeySerializer.Meta.fields + ["nodes"]
+        fields = APIKeySerializer.Meta.fields + ["nodes", "linked_managed_nodes"]
 
     def get_nodes(self, obj):
-        """Get the nodes linked to this API key."""
-        return [link.node.meshtastic_node_id for link in obj.node_links.all()]
+        """Legacy Meshtastic numeric ids only (omits MeshCore feeders)."""
+        from common.protocol import Protocol
+
+        return [
+            link.node.meshtastic_node_id
+            for link in obj.node_links.select_related("node").all()
+            if link.node.protocol == Protocol.MESHTASTIC and link.node.meshtastic_node_id is not None
+        ]
+
+    def get_linked_managed_nodes(self, obj):
+        links = obj.node_links.select_related("node").all()
+        return LinkedManagedNodeSerializer(
+            [
+                {
+                    "internal_id": link.node.internal_id,
+                    "node_id_str": link.node.node_id_str,
+                    "protocol": link.node.protocol,
+                    "meshtastic_node_id": link.node.meshtastic_node_id,
+                }
+                for link in links
+            ],
+            many=True,
+        ).data
 
 
 class APIKeyCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating API keys."""
 
     nodes = serializers.ListField(child=serializers.IntegerField(), required=False, write_only=True)
+    managed_node_internal_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        required=False,
+        write_only=True,
+    )
     owner = serializers.PrimaryKeyRelatedField(read_only=True)
     key = serializers.CharField(read_only=True)
 
     class Meta:
         model = NodeAPIKey
-        fields = ["id", "name", "constellation", "nodes", "owner", "created_at", "last_used", "is_active", "key"]
+        fields = [
+            "id",
+            "name",
+            "constellation",
+            "nodes",
+            "managed_node_internal_ids",
+            "owner",
+            "created_at",
+            "last_used",
+            "is_active",
+            "key",
+        ]
 
     def validate_constellation(self, value):
         user = self.context["request"].user
@@ -286,29 +333,32 @@ class APIKeyCreateSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """Create a new API key with a randomly generated key and link it to nodes."""
-        # Extract nodes from validated data
+        from common.protocol import Protocol
+
         nodes = validated_data.pop("nodes", [])
+        internal_ids = validated_data.pop("managed_node_internal_ids", [])
 
-        # Generate a random key
-        key = secrets.token_hex(32)  # 64 character hex string
-
-        # Add the key to the validated data
+        key = secrets.token_hex(32)
         validated_data["key"] = key
-
-        # Add the current user as the owner
-        user = self.context["request"].user
-        validated_data["owner"] = user
-
-        # Create the API key
+        validated_data["owner"] = self.context["request"].user
         api_key = NodeAPIKey.objects.create(**validated_data)
 
-        # Link the API key to nodes
         for meshtastic_node_id in nodes:
             try:
-                node = ManagedNode.objects.get(meshtastic_node_id=meshtastic_node_id, deleted_at__isnull=True)
-                NodeAuth.objects.create(api_key=api_key, node=node)
+                node = ManagedNode.objects.get(
+                    meshtastic_node_id=meshtastic_node_id,
+                    protocol=Protocol.MESHTASTIC,
+                    deleted_at__isnull=True,
+                )
+                NodeAuth.objects.get_or_create(api_key=api_key, node=node)
             except ManagedNode.DoesNotExist:
-                # Skip nodes that don't exist
+                pass
+
+        for node_uuid in internal_ids:
+            try:
+                node = ManagedNode.objects.get(internal_id=node_uuid, deleted_at__isnull=True)
+                NodeAuth.objects.get_or_create(api_key=api_key, node=node)
+            except ManagedNode.DoesNotExist:
                 pass
 
         return api_key
@@ -346,7 +396,7 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
             ]
 
     owner_id = serializers.PrimaryKeyRelatedField(
-        queryset=User.objects.all(), source="owner", write_only=True, required=True
+        queryset=User.objects.all(), source="owner", write_only=True, required=False
     )
     constellation_id = serializers.PrimaryKeyRelatedField(
         queryset=Constellation.objects.all(), source="constellation", write_only=True, required=True
@@ -378,7 +428,10 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
         fields = [
             "internal_id",
             "meshtastic_node_id",
+            "mc_pubkey",
             "protocol",
+            "default_location_latitude",
+            "default_location_longitude",
             "name",
             "long_name",
             "short_name",
@@ -445,9 +498,7 @@ class ManagedNodeSerializer(serializers.ModelSerializer):
         return build_geo_classification(obj)
 
     def get_node_id_str(self, obj):
-        if hasattr(obj, "node_id_str") and obj.node_id_str:
-            return obj.node_id_str
-        return meshtastic_id_to_hex(obj.meshtastic_node_id)
+        return obj.node_id_str
 
     def get_long_name(self, obj):
         if hasattr(obj, "long_name") and obj.long_name:
@@ -684,16 +735,42 @@ class OwnedManagedNodeSerializer(ManagedNodeSerializer):
         queryset=MessageChannel.objects.all(), required=False, allow_null=True
     )
 
+    def _effective_protocol(self, attrs):
+        protocol = attrs.get("protocol")
+        if protocol is not None:
+            return protocol
+        if self.instance is not None:
+            return self.instance.protocol
+        constellation = attrs.get("constellation")
+        if constellation is not None:
+            return constellation.protocol
+        return Protocol.MESHTASTIC
+
     def validate(self, attrs):
+        from common.meshcore_node_helpers import normalize_mc_pubkey
+
         attrs = super().validate(attrs)
+        protocol = self._effective_protocol(attrs)
+
         if self.instance is None:
-            meshtastic_node_id = attrs.get("meshtastic_node_id")
-            if meshtastic_node_id is not None:
-                if ManagedNode.objects.filter(meshtastic_node_id=meshtastic_node_id, deleted_at__isnull=True).exists():
+            if protocol == Protocol.MESHTASTIC:
+                meshtastic_node_id = attrs.get("meshtastic_node_id")
+                if meshtastic_node_id is None:
+                    raise serializers.ValidationError({"meshtastic_node_id": "Required for Meshtastic managed nodes."})
+                attrs["mc_pubkey"] = None
+                if ManagedNode.objects.filter(
+                    meshtastic_node_id=meshtastic_node_id,
+                    protocol=Protocol.MESHTASTIC,
+                    deleted_at__isnull=True,
+                ).exists():
                     raise serializers.ValidationError(
                         {"meshtastic_node_id": "A managed node already exists for this mesh node."}
                     )
-                if ManagedNode.objects.filter(meshtastic_node_id=meshtastic_node_id, deleted_at__isnull=False).exists():
+                if ManagedNode.objects.filter(
+                    meshtastic_node_id=meshtastic_node_id,
+                    protocol=Protocol.MESHTASTIC,
+                    deleted_at__isnull=False,
+                ).exists():
                     raise serializers.ValidationError(
                         {
                             "meshtastic_node_id": (
@@ -702,6 +779,16 @@ class OwnedManagedNodeSerializer(ManagedNodeSerializer):
                             )
                         }
                     )
+            elif protocol == Protocol.MESHCORE:
+                attrs["meshtastic_node_id"] = None
+                raw_pubkey = attrs.get("mc_pubkey")
+                if not raw_pubkey:
+                    raise serializers.ValidationError({"mc_pubkey": "Required for MeshCore managed nodes."})
+                try:
+                    attrs["mc_pubkey"] = normalize_mc_pubkey(raw_pubkey)
+                except ValueError as exc:
+                    raise serializers.ValidationError({"mc_pubkey": str(exc)})
+
         constellation = attrs.get("constellation")
         if constellation is None and self.instance is not None:
             constellation = self.instance.constellation

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -1,3 +1,5 @@
+from itertools import count
+
 from django.utils import timezone
 
 import pytest
@@ -8,18 +10,24 @@ from constellations.tests.conftest import create_constellation  # noqa: F401
 from nodes.models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, ObservedNode
 from users.tests.conftest import create_user  # noqa: F401
 
+_mt_managed_node_id_seq = count(0x10000000)
 
-def _coerce_meshtastic_node_id_kwargs(data: dict, explicit_keys: set) -> dict:
+
+def _coerce_meshtastic_node_id_kwargs(data: dict, explicit_keys: set, *, managed: bool = False) -> dict:
     """Map legacy test kwarg ``node_id`` to ``meshtastic_node_id`` (SP-03)."""
     if "node_id" in data:
         if "meshtastic_node_id" in data:
             raise ValueError("Pass only one of node_id or meshtastic_node_id")
         data["meshtastic_node_id"] = data.pop("node_id")
-    if data.get("protocol") == Protocol.MESHCORE:
+        explicit_keys = set(explicit_keys) | {"meshtastic_node_id"}
+    protocol = data.get("protocol", Protocol.MESHTASTIC)
+    if protocol == Protocol.MESHCORE:
         if "meshtastic_node_id" not in explicit_keys or data.get("meshtastic_node_id") == 0:
             data["meshtastic_node_id"] = None
         if not data.get("mc_pubkey"):
             data["mc_pubkey"] = "a" * 64
+    elif managed and "meshtastic_node_id" not in explicit_keys:
+        data["meshtastic_node_id"] = next(_mt_managed_node_id_seq)
     return data
 
 
@@ -34,7 +42,7 @@ _LEGACY_OBSERVED_NODE_FIELD_ALIASES = {
 
 def _coerce_observed_node_legacy_kwargs(data: dict) -> dict:
     """Map legacy test kwargs to ``meshtastic_*`` field names (SP-04)."""
-    _coerce_meshtastic_node_id_kwargs(data, set())
+    _coerce_meshtastic_node_id_kwargs(data, set(), managed=False)
     for old, new in _LEGACY_OBSERVED_NODE_FIELD_ALIASES.items():
         if old in data:
             if new in data:
@@ -75,7 +83,7 @@ def create_managed_node(managed_node_data, create_user, create_constellation):  
     def make_managed_node(**kwargs):
         data = managed_node_data.copy()
         data.update(kwargs)
-        _coerce_meshtastic_node_id_kwargs(data, set(kwargs.keys()))
+        _coerce_meshtastic_node_id_kwargs(data, set(kwargs.keys()), managed=True)
         if "owner" not in data:
             data["owner"] = create_user()
         if "constellation" not in data:

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -2,18 +2,24 @@ from django.utils import timezone
 
 import pytest
 
+from common.protocol import Protocol
 from constellations.models import MessageChannel
 from constellations.tests.conftest import create_constellation  # noqa: F401
 from nodes.models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, ObservedNode
 from users.tests.conftest import create_user  # noqa: F401
 
 
-def _coerce_meshtastic_node_id_kwargs(data: dict) -> dict:
+def _coerce_meshtastic_node_id_kwargs(data: dict, explicit_keys: set) -> dict:
     """Map legacy test kwarg ``node_id`` to ``meshtastic_node_id`` (SP-03)."""
     if "node_id" in data:
         if "meshtastic_node_id" in data:
             raise ValueError("Pass only one of node_id or meshtastic_node_id")
         data["meshtastic_node_id"] = data.pop("node_id")
+    if data.get("protocol") == Protocol.MESHCORE:
+        if "meshtastic_node_id" not in explicit_keys or data.get("meshtastic_node_id") == 0:
+            data["meshtastic_node_id"] = None
+        if not data.get("mc_pubkey"):
+            data["mc_pubkey"] = "a" * 64
     return data
 
 
@@ -28,7 +34,7 @@ _LEGACY_OBSERVED_NODE_FIELD_ALIASES = {
 
 def _coerce_observed_node_legacy_kwargs(data: dict) -> dict:
     """Map legacy test kwargs to ``meshtastic_*`` field names (SP-04)."""
-    _coerce_meshtastic_node_id_kwargs(data)
+    _coerce_meshtastic_node_id_kwargs(data, set())
     for old, new in _LEGACY_OBSERVED_NODE_FIELD_ALIASES.items():
         if old in data:
             if new in data:
@@ -69,7 +75,7 @@ def create_managed_node(managed_node_data, create_user, create_constellation):  
     def make_managed_node(**kwargs):
         data = managed_node_data.copy()
         data.update(kwargs)
-        _coerce_meshtastic_node_id_kwargs(data)
+        _coerce_meshtastic_node_id_kwargs(data, set(kwargs.keys()))
         if "owner" not in data:
             data["owner"] = create_user()
         if "constellation" not in data:

--- a/Meshflow/nodes/tests/test_managed_node_admin_form.py
+++ b/Meshflow/nodes/tests/test_managed_node_admin_form.py
@@ -6,7 +6,28 @@ from nodes.models import ManagedNode
 
 
 @pytest.mark.django_db
-def test_managed_node_admin_form_meshcore_node_id_defaults_to_zero(create_user, create_constellation):
+def test_managed_node_admin_form_meshcore_clears_meshtastic_node_id(create_user, create_constellation):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    form = ManagedNodeAdminForm(
+        data={
+            "protocol": str(Protocol.MESHCORE),
+            "meshtastic_node_id": "",
+            "mc_pubkey": "a" * 64,
+            "name": "MC Feeder",
+            "owner": owner.pk,
+            "constellation": constellation.pk,
+            "allow_auto_traceroute": False,
+            "latlong_0": "",
+            "latlong_1": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+    assert form.cleaned_data["meshtastic_node_id"] is None
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_form_meshcore_requires_mc_pubkey(create_user, create_constellation):
     owner = create_user()
     constellation = create_constellation(created_by=owner)
     form = ManagedNodeAdminForm(
@@ -21,8 +42,8 @@ def test_managed_node_admin_form_meshcore_node_id_defaults_to_zero(create_user, 
             "latlong_1": "",
         }
     )
-    assert form.is_valid(), form.errors
-    assert form.cleaned_data["meshtastic_node_id"] == 0
+    assert not form.is_valid()
+    assert "mc_pubkey" in form.errors
 
 
 def test_managed_node_channel_admin_fields_match_model():

--- a/Meshflow/nodes/tests/test_managed_node_channel_patch.py
+++ b/Meshflow/nodes/tests/test_managed_node_channel_patch.py
@@ -26,7 +26,7 @@ def test_managed_node_patch_channels_owner_success(create_user, create_constella
 
     client = APIClient()
     client.force_authenticate(user=owner)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
 
     response = client.patch(url, {"meshtastic_channel_0": ch_ok.id}, format="json")
     assert response.status_code == status.HTTP_200_OK
@@ -54,7 +54,7 @@ def test_managed_node_patch_channel_wrong_constellation_returns_400(
 
     client = APIClient()
     client.force_authenticate(user=owner)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
 
     response = client.patch(url, {"meshtastic_channel_0": ch_wrong.id}, format="json")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -77,7 +77,7 @@ def test_managed_node_patch_channels_non_owner_forbidden(create_user, create_con
 
     client = APIClient()
     client.force_authenticate(user=other)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
 
     response = client.patch(url, {"meshtastic_channel_0": ch.id}, format="json")
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -98,7 +98,7 @@ def test_managed_node_retrieve_owner_includes_channels(create_user, create_const
 
     client = APIClient()
     client.force_authenticate(user=owner)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
 
     response = client.get(url)
     assert response.status_code == status.HTTP_200_OK
@@ -121,7 +121,7 @@ def test_managed_node_retrieve_non_owner_omits_channels(create_user, create_cons
 
     client = APIClient()
     client.force_authenticate(user=viewer)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
 
     response = client.get(url)
     assert response.status_code == status.HTTP_200_OK

--- a/Meshflow/nodes/tests/test_managed_node_liveness.py
+++ b/Meshflow/nodes/tests/test_managed_node_liveness.py
@@ -47,7 +47,7 @@ def test_refresh_task_aligns_with_eligibility(monkeypatch, create_managed_node, 
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
     from nodes.tasks import update_managed_node_statuses
 
-    mn = create_managed_node(allow_auto_traceroute=True)
+    mn = create_managed_node(allow_auto_traceroute=True, meshtastic_node_id=0xA1000005)
     create_packet_observation(observer=mn)
     update_managed_node_statuses()
     assert ManagedNodeStatus.objects.get(node=mn).is_sending_data is True

--- a/Meshflow/nodes/tests/test_managed_node_position_fallback.py
+++ b/Meshflow/nodes/tests/test_managed_node_position_fallback.py
@@ -29,7 +29,7 @@ def test_managed_node_position_falls_back_to_default_location(create_managed_nod
     assert row["position"]["latitude"] == 55.95
     assert row["position"]["longitude"] == -3.19
 
-    detail_url = reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id})
+    detail_url = reverse("managed-nodes-detail", kwargs={"internal_id": managed.meshtastic_node_id})
     detail_resp = client.get(detail_url)
     assert detail_resp.status_code == status.HTTP_200_OK
     assert detail_resp.data["position"]["latitude"] == 55.95
@@ -55,7 +55,7 @@ def test_managed_node_position_prefers_observed_over_default(create_managed_node
 
     client = APIClient()
     client.force_authenticate(user=user)
-    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id}))
+    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"internal_id": managed.meshtastic_node_id}))
     assert detail_resp.status_code == status.HTTP_200_OK
     assert detail_resp.data["position"]["latitude"] == 56.1
     assert detail_resp.data["position"]["longitude"] == -3.5
@@ -68,6 +68,6 @@ def test_managed_node_position_null_without_observed_or_default(create_managed_n
 
     client = APIClient()
     client.force_authenticate(user=user)
-    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id}))
+    detail_resp = client.get(reverse("managed-nodes-detail", kwargs={"internal_id": managed.meshtastic_node_id}))
     assert detail_resp.status_code == status.HTTP_200_OK
     assert detail_resp.data["position"] is None

--- a/Meshflow/nodes/tests/test_managed_node_protocol_identity.py
+++ b/Meshflow/nodes/tests/test_managed_node_protocol_identity.py
@@ -1,0 +1,144 @@
+"""ManagedNode protocol identity (#362): MT vs MC field rules and REST contract."""
+
+from django.urls import reverse
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from common.protocol import Protocol
+from nodes.models import ManagedNode
+
+
+@pytest.mark.django_db
+def test_create_two_meshcore_feeders_same_constellation(create_user, create_constellation):
+    user = create_user()
+    constellation = create_constellation(protocol=Protocol.MESHCORE, created_by=user)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("managed-nodes-list")
+
+    r1 = client.post(
+        url,
+        {
+            "name": "MC A",
+            "constellation_id": constellation.id,
+            "protocol": Protocol.MESHCORE,
+            "mc_pubkey": "a" * 64,
+            "default_location_latitude": 55.0,
+            "default_location_longitude": -3.0,
+        },
+        format="json",
+    )
+    r2 = client.post(
+        url,
+        {
+            "name": "MC B",
+            "constellation_id": constellation.id,
+            "protocol": Protocol.MESHCORE,
+            "mc_pubkey": "b" * 64,
+            "default_location_latitude": 55.1,
+            "default_location_longitude": -3.1,
+        },
+        format="json",
+    )
+
+    assert r1.status_code == status.HTTP_201_CREATED, r1.data
+    assert r2.status_code == status.HTTP_201_CREATED, r2.data
+    assert r1.data["meshtastic_node_id"] is None
+    assert r2.data["meshtastic_node_id"] is None
+    assert ManagedNode.objects.filter(protocol=Protocol.MESHCORE, deleted_at__isnull=True).count() == 2
+
+
+@pytest.mark.django_db
+def test_managed_node_detail_and_patch_by_internal_id(create_user, create_managed_node):
+    user = create_user()
+    node = create_managed_node(
+        owner=user,
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey="c" * 64,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.internal_id})
+
+    get_resp = client.get(url)
+    assert get_resp.status_code == status.HTTP_200_OK
+    assert get_resp.data["mc_pubkey"] == "c" * 64
+
+    patch_resp = client.patch(url, {"name": "renamed"}, format="json")
+    assert patch_resp.status_code == status.HTTP_200_OK
+    node.refresh_from_db()
+    assert node.name == "renamed"
+
+
+@pytest.mark.django_db
+def test_meshtastic_detail_compat_numeric_lookup(create_user, create_managed_node):
+    user = create_user()
+    node = create_managed_node(owner=user, meshtastic_node_id=42424242, protocol=Protocol.MESHTASTIC)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id})
+
+    response = client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data["internal_id"] == str(node.internal_id)
+
+
+@pytest.mark.django_db
+def test_api_key_add_node_by_internal_id(create_user, create_managed_node, create_node_api_key):
+    from common.access import grant_feeder_role
+
+    user = create_user()
+    grant_feeder_role(user)
+    constellation = create_managed_node(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="d" * 64,
+    ).constellation
+    node_a = create_managed_node(
+        constellation=constellation,
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="e" * 64,
+    )
+    node_b = create_managed_node(
+        constellation=constellation,
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="f" * 64,
+    )
+    api_key = create_node_api_key(constellation=constellation, owner=user)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    for managed in (node_a, node_b):
+        resp = client.post(
+            reverse("api-keys-add-node", kwargs={"pk": api_key.id}),
+            {"managed_node_internal_id": str(managed.internal_id)},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_201_CREATED, resp.data
+
+    detail = client.get(reverse("api-keys-detail", kwargs={"pk": api_key.id}))
+    linked = {row["internal_id"] for row in detail.data["linked_managed_nodes"]}
+    assert linked == {str(node_a.internal_id), str(node_b.internal_id)}
+    assert detail.data["nodes"] == []
+
+
+@pytest.mark.django_db
+def test_meshcore_create_requires_mc_pubkey(create_user, create_constellation):
+    user = create_user()
+    constellation = create_constellation(protocol=Protocol.MESHCORE, created_by=user)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        reverse("managed-nodes-list"),
+        {
+            "name": "bad",
+            "constellation_id": constellation.id,
+            "protocol": Protocol.MESHCORE,
+        },
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "mc_pubkey" in response.data

--- a/Meshflow/nodes/tests/test_managed_node_status_task.py
+++ b/Meshflow/nodes/tests/test_managed_node_status_task.py
@@ -19,7 +19,7 @@ def test_update_managed_node_statuses_creates_and_sets_sending(
     create_packet_observation,
 ):
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
-    mn = create_managed_node()
+    mn = create_managed_node(meshtastic_node_id=123456801)
     ManagedNodeStatus.objects.filter(node=mn).delete()
 
     create_packet_observation(observer=mn)
@@ -40,7 +40,7 @@ def test_update_managed_node_statuses_stale_observation_not_sending(
     create_packet_observation,
 ):
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
-    mn = create_managed_node()
+    mn = create_managed_node(meshtastic_node_id=123456802)
     ManagedNodeStatus.objects.filter(node=mn).delete()
 
     obs = create_packet_observation(observer=mn)
@@ -60,7 +60,7 @@ def test_update_managed_node_statuses_no_observations(
     create_managed_node,
 ):
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
-    mn = create_managed_node()
+    mn = create_managed_node(meshtastic_node_id=123456803)
     ManagedNodeStatus.objects.filter(node=mn).delete()
 
     result = update_managed_node_statuses()
@@ -78,7 +78,7 @@ def test_update_managed_node_statuses_updates_existing_row(
     create_packet_observation,
 ):
     monkeypatch.setenv("SCHEDULE_TRACEROUTE_SOURCE_RECENCY_SECONDS", "600")
-    mn = create_managed_node()
+    mn = create_managed_node(meshtastic_node_id=123456804)
     ManagedNodeStatus.objects.update_or_create(
         node=mn,
         defaults={

--- a/Meshflow/nodes/tests/test_mc_flood_advert_interval.py
+++ b/Meshflow/nodes/tests/test_mc_flood_advert_interval.py
@@ -21,7 +21,7 @@ def test_patch_interval_dispatches_refresh(create_user, create_managed_node):
     )
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.internal_id})
 
     with patch(
         "meshcore_packets.services.feeder_config.dispatch_feeder_config_refresh",
@@ -51,7 +51,7 @@ def test_patch_same_interval_skips_dispatch(create_user, create_managed_node):
     )
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.internal_id})
 
     with patch(
         "meshcore_packets.services.feeder_config.dispatch_feeder_config_refresh",
@@ -68,7 +68,7 @@ def test_patch_interval_rejected_on_meshtastic(create_user, create_managed_node)
     node = create_managed_node(owner=user, protocol=Protocol.MESHTASTIC)
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": node.internal_id})
 
     response = client.patch(
         url,

--- a/Meshflow/nodes/tests/test_node_models.py
+++ b/Meshflow/nodes/tests/test_node_models.py
@@ -7,11 +7,11 @@ from common.protocol import Protocol
 def test_managed_node_creation(create_managed_node):
     """Test managed node creation with valid data."""
     node = create_managed_node()
-    assert node.meshtastic_node_id == 123456789
+    assert node.meshtastic_node_id is not None
     assert node.name == "Test Managed Node"
     assert node.owner is not None
     assert node.constellation is not None
-    assert node.node_id_str == "!075bcd15"
+    assert node.node_id_str.startswith("!")
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/tests/test_node_models.py
+++ b/Meshflow/nodes/tests/test_node_models.py
@@ -16,8 +16,9 @@ def test_managed_node_creation(create_managed_node):
 
 @pytest.mark.django_db
 def test_managed_meshcore_feeder_node_id_str(create_managed_node):
-    node = create_managed_node(protocol=Protocol.MESHCORE, meshtastic_node_id=0)
-    assert node.node_id_str == f"mc:feeder:{node.internal_id.hex[:12]}"
+    pubkey = "b" * 64
+    node = create_managed_node(protocol=Protocol.MESHCORE, meshtastic_node_id=None, mc_pubkey=pubkey)
+    assert node.node_id_str == f"mc:{pubkey[:12]}"
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -42,6 +42,15 @@ def test_managed_node_detail_view(create_managed_node, create_user):
     assert response.data["meshtastic_node_id"] == node.meshtastic_node_id
 
 
+def _managed_node_list_row(results, managed):
+    """Pick list payload row for a specific managed node (list is global, not ordered by test)."""
+    managed_id = str(managed.internal_id)
+    for row in results:
+        if str(row.get("internal_id")) == managed_id:
+            return row
+    raise AssertionError(f"Managed node {managed_id} not in list results ({len(results)} rows)")
+
+
 @pytest.mark.django_db
 def test_managed_nodes_status_fields_only_returned_with_include_status(
     create_managed_node,
@@ -68,23 +77,23 @@ def test_managed_nodes_status_fields_only_returned_with_include_status(
     list_url = reverse("managed-nodes-list")
     response_without_status = client.get(list_url)
     assert response_without_status.status_code == status.HTTP_200_OK
-    first_without_status = response_without_status.data["results"][0]
-    assert "last_packet_ingested_at" not in first_without_status
-    assert "packets_last_hour" not in first_without_status
-    assert "packets_last_24h" not in first_without_status
-    assert "radio_last_heard" not in first_without_status
-    assert "is_eligible_traceroute_source" not in first_without_status
+    row_without_status = _managed_node_list_row(response_without_status.data["results"], managed)
+    assert "last_packet_ingested_at" not in row_without_status
+    assert "packets_last_hour" not in row_without_status
+    assert "packets_last_24h" not in row_without_status
+    assert "radio_last_heard" not in row_without_status
+    assert "is_eligible_traceroute_source" not in row_without_status
 
     response_with_status = client.get(list_url, {"include": "status"})
     assert response_with_status.status_code == status.HTTP_200_OK
-    first_with_status = response_with_status.data["results"][0]
-    assert first_with_status["last_packet_ingested_at"] is not None
-    assert first_with_status["packets_last_hour"] == 1
-    assert first_with_status["packets_last_24h"] == 1
-    assert first_with_status["radio_last_heard"] is not None
-    assert first_with_status["is_eligible_traceroute_source"] is True
+    row_with_status = _managed_node_list_row(response_with_status.data["results"], managed)
+    assert row_with_status["last_packet_ingested_at"] is not None
+    assert row_with_status["packets_last_hour"] == 1
+    assert row_with_status["packets_last_24h"] == 1
+    assert row_with_status["radio_last_heard"] is not None
+    assert row_with_status["is_eligible_traceroute_source"] is True
 
-    detail_url = reverse("managed-nodes-detail", kwargs={"internal_id": managed.meshtastic_node_id})
+    detail_url = reverse("managed-nodes-detail", kwargs={"internal_id": managed.internal_id})
     detail_response = client.get(detail_url, {"include": "status"})
     assert detail_response.status_code == status.HTTP_200_OK
     assert detail_response.data["packets_last_hour"] == 1
@@ -92,7 +101,8 @@ def test_managed_nodes_status_fields_only_returned_with_include_status(
     mine_url = reverse("managed-nodes-mine")
     mine_response = client.get(mine_url, {"include": "status"})
     assert mine_response.status_code == status.HTTP_200_OK
-    assert mine_response.data["results"][0]["packets_last_24h"] == 1
+    mine_row = _managed_node_list_row(mine_response.data["results"], managed)
+    assert mine_row["packets_last_24h"] == 1
 
 
 @pytest.mark.django_db

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -17,8 +17,8 @@ def test_managed_node_list_view(create_managed_node, create_user):
     client.force_authenticate(user=user)
 
     # Create some test nodes
-    node1 = create_managed_node(owner=user)  # noqa: F841
-    node2 = create_managed_node(owner=user)  # noqa: F841
+    node1 = create_managed_node(owner=user, meshtastic_node_id=123456789)  # noqa: F841
+    node2 = create_managed_node(owner=user, meshtastic_node_id=123456790)  # noqa: F841
 
     # Test GET request
     response = client.get(reverse("managed-nodes-list"))
@@ -37,7 +37,7 @@ def test_managed_node_detail_view(create_managed_node, create_user):
     node = create_managed_node(owner=user)
 
     # Test GET request
-    response = client.get(reverse("managed-nodes-detail", kwargs={"node_id": node.meshtastic_node_id}))
+    response = client.get(reverse("managed-nodes-detail", kwargs={"internal_id": node.meshtastic_node_id}))
     assert response.status_code == status.HTTP_200_OK
     assert response.data["meshtastic_node_id"] == node.meshtastic_node_id
 
@@ -84,7 +84,7 @@ def test_managed_nodes_status_fields_only_returned_with_include_status(
     assert first_with_status["radio_last_heard"] is not None
     assert first_with_status["is_eligible_traceroute_source"] is True
 
-    detail_url = reverse("managed-nodes-detail", kwargs={"node_id": managed.meshtastic_node_id})
+    detail_url = reverse("managed-nodes-detail", kwargs={"internal_id": managed.meshtastic_node_id})
     detail_response = client.get(detail_url, {"include": "status"})
     assert detail_response.status_code == status.HTTP_200_OK
     assert detail_response.data["packets_last_hour"] == 1
@@ -453,7 +453,7 @@ def test_managed_node_soft_delete_owner_removes_node_auth_and_excludes_from_list
 
     client = APIClient()
     client.force_authenticate(user=owner)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": mn.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": mn.meshtastic_node_id})
     assert client.delete(url).status_code == status.HTTP_204_NO_CONTENT
 
     assert not NodeAuth.objects.filter(node=mn).exists()
@@ -490,7 +490,7 @@ def test_managed_node_soft_delete_staff(create_user, create_constellation, creat
 
     client = APIClient()
     client.force_authenticate(user=staff)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": mn.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": mn.meshtastic_node_id})
     assert client.delete(url).status_code == status.HTTP_204_NO_CONTENT
     mn.refresh_from_db()
     assert mn.deleted_at is not None
@@ -515,7 +515,7 @@ def test_managed_node_delete_forbidden_for_non_owner_non_staff(create_user, crea
 
     client = APIClient()
     client.force_authenticate(user=other)
-    url = reverse("managed-nodes-detail", kwargs={"node_id": mn.meshtastic_node_id})
+    url = reverse("managed-nodes-detail", kwargs={"internal_id": mn.meshtastic_node_id})
     assert client.delete(url).status_code == status.HTTP_403_FORBIDDEN
     mn.refresh_from_db()
     assert mn.deleted_at is None

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -139,25 +140,58 @@ class APIKeyViewSet(viewsets.ModelViewSet):
             raise PermissionDenied("Feeder or admin access required to create API keys.")
         serializer.save(owner=self.request.user)
 
+    @staticmethod
+    def _resolve_managed_node_for_link(meshtastic_node_id, managed_node_internal_id):
+        from common.protocol import Protocol
+
+        if managed_node_internal_id:
+            try:
+                node_uuid = uuid.UUID(str(managed_node_internal_id))
+            except ValueError:
+                return None, "managed_node_internal_id must be a valid UUID"
+            try:
+                return (
+                    ManagedNode.objects.get(internal_id=node_uuid, deleted_at__isnull=True),
+                    None,
+                )
+            except ManagedNode.DoesNotExist:
+                return None, f"Managed node {managed_node_internal_id} does not exist"
+
+        if meshtastic_node_id is None:
+            return None, "managed_node_internal_id or meshtastic_node_id is required"
+
+        try:
+            return (
+                ManagedNode.objects.get(
+                    meshtastic_node_id=meshtastic_node_id,
+                    protocol=Protocol.MESHTASTIC,
+                    deleted_at__isnull=True,
+                ),
+                None,
+            )
+        except ManagedNode.DoesNotExist:
+            return None, f"Node with ID {meshtastic_node_id} does not exist"
+
     @action(detail=True, methods=["post"])
     def add_node(self, request, pk=None):
         """Add a node to an API key."""
         api_key = self.get_object()
         meshtastic_node_id = request.data.get("meshtastic_node_id")
+        managed_node_internal_id = request.data.get("managed_node_internal_id")
 
-        if not meshtastic_node_id:
-            return Response(
-                {"error": "meshtastic_node_id is required"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if meshtastic_node_id is not None:
+            try:
+                meshtastic_node_id = int(meshtastic_node_id)
+            except TypeError, ValueError:
+                return Response(
+                    {"error": "meshtastic_node_id must be an integer"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-        try:
-            node = ManagedNode.objects.get(meshtastic_node_id=meshtastic_node_id, deleted_at__isnull=True)
-        except ManagedNode.DoesNotExist:
-            return Response(
-                {"error": f"Node with ID {meshtastic_node_id} does not exist"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        node, error = self._resolve_managed_node_for_link(meshtastic_node_id, managed_node_internal_id)
+        if error:
+            status_code = status.HTTP_404_NOT_FOUND if "does not exist" in error else status.HTTP_400_BAD_REQUEST
+            return Response({"error": error}, status=status_code)
 
         # Check if the node belongs to the same constellation as the API key
         if node.constellation != api_key.constellation:
@@ -183,20 +217,21 @@ class APIKeyViewSet(viewsets.ModelViewSet):
         """Remove a node from an API key."""
         api_key = self.get_object()
         meshtastic_node_id = request.data.get("meshtastic_node_id")
+        managed_node_internal_id = request.data.get("managed_node_internal_id")
 
-        if not meshtastic_node_id:
-            return Response(
-                {"error": "meshtastic_node_id is required"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        if meshtastic_node_id is not None:
+            try:
+                meshtastic_node_id = int(meshtastic_node_id)
+            except TypeError, ValueError:
+                return Response(
+                    {"error": "meshtastic_node_id must be an integer"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
-        try:
-            node = ManagedNode.objects.get(meshtastic_node_id=meshtastic_node_id, deleted_at__isnull=True)
-        except ManagedNode.DoesNotExist:
-            return Response(
-                {"error": f"Node with ID {meshtastic_node_id} does not exist"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        node, error = self._resolve_managed_node_for_link(meshtastic_node_id, managed_node_internal_id)
+        if error:
+            status_code = status.HTTP_404_NOT_FOUND if "does not exist" in error else status.HTTP_400_BAD_REQUEST
+            return Response({"error": error}, status=status_code)
 
         # Check if the node is linked to this API key
         link = NodeAuth.objects.filter(api_key=api_key, node=node).first()
@@ -1039,13 +1074,42 @@ class EnvironmentMetricsBulkView(APIView):
 class ManagedNodeViewSet(viewsets.ModelViewSet):
     """
     ViewSet for managing managed nodes.
+
+    Detail lookup uses ``internal_id`` (UUID). Numeric ``meshtastic_node_id`` in the path
+    is accepted for Meshtastic nodes only (deprecated).
     """
 
-    queryset = ManagedNode.objects.filter(deleted_at__isnull=True).order_by("meshtastic_node_id")
+    queryset = ManagedNode.objects.filter(deleted_at__isnull=True).order_by("protocol", "name", "internal_id")
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = ManagedNodeSerializer
-    lookup_field = "meshtastic_node_id"
-    lookup_url_kwarg = "node_id"
+    lookup_field = "internal_id"
+    lookup_url_kwarg = "internal_id"
+
+    def get_object(self):
+        lookup = self.kwargs.get(self.lookup_url_kwarg, "")
+        queryset = self.filter_queryset(self.get_queryset())
+        try:
+            node_uuid = uuid.UUID(str(lookup))
+        except ValueError:
+            node_uuid = None
+        if node_uuid is not None:
+            return get_object_or_404(queryset, internal_id=node_uuid)
+
+        try:
+            meshtastic_node_id = int(lookup)
+        except TypeError, ValueError:
+            raise Http404
+
+        from common.protocol import Protocol
+
+        compat_qs = queryset.filter(protocol=Protocol.MESHTASTIC, meshtastic_node_id=meshtastic_node_id)
+        if compat_qs.count() == 1:
+            logger.warning(
+                "Managed node detail lookup by meshtastic_node_id is deprecated; use internal_id (path=%s)",
+                lookup,
+            )
+            return compat_qs.get()
+        raise Http404
 
     def _status_requested(self):
         include_values = _multi_query_strings(self.request, "include")
@@ -1158,7 +1222,7 @@ class ManagedNodeViewSet(viewsets.ModelViewSet):
         )
 
     def _managed_nodes_queryset(self, owner=None):
-        queryset = ManagedNode.objects.filter(deleted_at__isnull=True).order_by("meshtastic_node_id")
+        queryset = ManagedNode.objects.filter(deleted_at__isnull=True).order_by("protocol", "name", "internal_id")
         if owner is not None:
             queryset = queryset.filter(owner=owner)
         queryset = self._annotate_common_fields(queryset)

--- a/Meshflow/ws/tests/test_mc_node_consumer.py
+++ b/Meshflow/ws/tests/test_mc_node_consumer.py
@@ -17,12 +17,14 @@ FEEDER_PREFIX = "1a37f5aea4a1"
 
 @pytest.mark.django_db
 @pytest.mark.asyncio
-async def test_mc_consumer_requires_prefix_when_multiple_feeders(create_managed_node, create_node_api_key):
+async def test_mc_consumer_requires_prefix_when_multiple_feeders(
+    create_managed_node, create_constellation, create_node_api_key
+):
     from nodes.models import NodeAuth
 
     @database_sync_to_async
     def setup():
-        constellation = create_managed_node(protocol=Protocol.MESHCORE).constellation
+        constellation = create_constellation(protocol=Protocol.MESHCORE)
         node_a = create_managed_node(
             meshtastic_node_id=0,
             protocol=Protocol.MESHCORE,

--- a/docs/features/meshcore/README.md
+++ b/docs/features/meshcore/README.md
@@ -9,6 +9,10 @@ Cross-repo MeshCore work is tracked on GitHub epics [#264](https://github.com/ps
 | **0** — bot seam, capture, ADRs | [phase-0-progress.md](./phase-0-progress.md) | [phase-0-outstanding.md](./phase-0-outstanding.md) |
 | **1** — MC ingestion MVP | [phase-1-progress.md](./phase-1-progress.md) | [phase-1-outstanding.md](./phase-1-outstanding.md) |
 | **2** — parity, rename track, position/text | [phase-2-progress.md](./phase-2-progress.md) | [phase-2-outstanding.md](./phase-2-outstanding.md) |
+| **ManagedNode identity** ([#362](https://github.com/pskillen/meshflow-api/issues/362)) | [managed-node-identity-progress.md](./managed-node-identity-progress.md) | [managed-node-identity-outstanding.md](./managed-node-identity-outstanding.md) |
+| **Feeder enrollment** ([#293](https://github.com/pskillen/meshflow-ui/issues/293)) | [enrollment-progress.md](./enrollment-progress.md) | [enrollment-outstanding.md](./enrollment-outstanding.md) |
+
+**Agent convention:** [progress-tracking skill](../../../.cursor/skills/progress-tracking/SKILL.md) — update progress/outstanding at plan breakpoints and before PRs.
 
 **Feature guides** (how-to, not phase status):
 

--- a/docs/features/meshcore/enrollment-outstanding.md
+++ b/docs/features/meshcore/enrollment-outstanding.md
@@ -1,0 +1,9 @@
+# MeshCore feeder enrollment — outstanding
+
+Items **skipped**, **incomplete**, or **discovered during enrollment execution** — not the [#293](https://github.com/pskillen/meshflow-ui/issues/293) plan’s future phases.
+
+**Tracking:** [meshflow-ui#293](https://github.com/pskillen/meshflow-ui/issues/293)
+
+---
+
+<!-- Add items only when discovered during enrollment work. Do not list #362 or plan phases here. -->

--- a/docs/features/meshcore/enrollment-progress.md
+++ b/docs/features/meshcore/enrollment-progress.md
@@ -1,0 +1,44 @@
+# MeshCore feeder enrollment — progress
+
+**Tracking:** [meshflow-ui#293](https://github.com/pskillen/meshflow-ui/issues/293) (parent [meshflow-ui#291](https://github.com/pskillen/meshflow-ui/issues/291))  
+**Plan:** `.cursor/plans/mc_managed_node_enrollment_f7aceb8d.plan.md`  
+**Repos:** meshflow-api, meshflow-ui (meshflow-bot docs only if copy drift found)
+
+**Prerequisite:** [managed-node-identity-progress.md](./managed-node-identity-progress.md) ([#362](https://github.com/pskillen/meshflow-api/issues/362)) merged and deployed before UI enrollment E2E.
+
+---
+
+## Overall status
+
+**Status:** Not started (blocked on #362 API contract)
+
+---
+
+## Already done (pre-enrollment)
+
+| Area | Status | Links |
+| --- | --- | --- |
+| Claim MC observed node | Complete | [meshflow-ui#292](https://github.com/pskillen/meshflow-ui/issues/292), `ClaimNode.tsx` |
+| Ingest / feeder auth / channel sync | Complete | `test_feeder_identity.py`, feeder-bootstrap |
+| Post-enroll MC settings (partial) | In repo | `NodeSettings.tsx` — channels, flood interval |
+
+---
+
+## Planned slices (from plan)
+
+| Slice | Status | Repo |
+| --- | --- | --- |
+| API MC create + `internal_id` CRUD + api-key link | Not started | meshflow-api — **do not re-implement #362 shims** |
+| UI `SetupManagedNode` MC branch | Not started | meshflow-ui |
+| UI API client (`internal_id`, pubkey create) | Not started | meshflow-ui |
+| `BotSetupInstructions` MC + v3 (#296, #295) | Not started | meshflow-ui |
+| feeder-bootstrap.md wizard-first | Not started | meshflow-api |
+| Manual E2E on staging | Not started | |
+
+---
+
+## Next
+
+1. Complete and merge [#362](https://github.com/pskillen/meshflow-api/issues/362); deploy API.
+2. API enrollment PR (`ui-293/.../managed-node-enrollment-api`) — identity work only if not already in #362.
+3. UI wizard PR; update this file before each PR.

--- a/docs/features/meshcore/feeder-bootstrap.md
+++ b/docs/features/meshcore/feeder-bootstrap.md
@@ -21,7 +21,7 @@ MeshCore uses the same pattern as Meshtastic: **device identity in the URL**, pl
 | **What the bot sends** | `node_id` in URL = device nodenum | **12-hex pubkey prefix** in URL (from `mc:` id after connect) |
 | **Optional header** | — | `X-MeshCore-Feeder-Pubkey` (64 hex) must match `ManagedNode.mc_pubkey` when set |
 | **How the API picks the observer** | `NodeAuth` + URL `node_id` | `NodeAuth` + URL prefix matches `pubkey_to_prefix(mc_pubkey)` |
-| **`ManagedNode.meshtastic_node_id`** | Must match the radio | Placeholder **`0`** only |
+| **`ManagedNode.meshtastic_node_id`** | Must match the radio | **`NULL`** (not used on the wire) |
 | **Payload `from_pubkey`** | Packet sender on the mesh | Remote node in the heard packet; not the feeder |
 
 **Shared constellation API keys:** multiple MeshCore feeders may use the same `NodeAPIKey` if each `ManagedNode` has a distinct **`mc_pubkey`** (full 64-hex from bot logs). The bot disambiguates via the URL prefix, like Meshtastic `{node_id}`.
@@ -32,22 +32,21 @@ See [#295](https://github.com/pskillen/meshflow-api/issues/295). Optional follow
 
 ## 1. Create MC ManagedNode
 
-1. Open **Django admin** → **Managed nodes** → **Add**.
+1. Open **Django admin** → **Managed nodes** → **Add** (or use the enrollment wizard when available).
 2. Set:
    - **Protocol**: MeshCore
-   - **Node ID (placeholder)**: `0`
+   - **`mc_pubkey`**: full **64-char lowercase hex** from bot connect logs (`SELF_INFO`) — required at save
    - **Name**: e.g. `Scottish Mesh MC Feeder`
    - **Owner** / **Constellation**: your MC constellation
    - **Default location** (optional): lat/lon for map display
-3. Save.
+3. Save. **Display ID** is `mc:{12-hex-prefix}`.
 
-## 2. Set feeder pubkey and API key
+## 2. API key
 
-1. Start **meshflow-bot** once with `RADIO_PROTOCOL=meshcore` and note the **full 64-hex pubkey** from connect logs (or `SELF_INFO`).
-2. Edit the ManagedNode → **MeshCore identity** → paste into **`mc_pubkey`** (lowercase hex). Save. **Display ID** becomes `mc:{12-hex-prefix}`.
-3. **Node API keys** → create or reuse a constellation key.
-4. **Node authentications** → link the key to this MC ManagedNode (multiple feeders may share one key if each has a unique `mc_pubkey`).
-5. Put the key in the bot env as `STORAGE_API_TOKEN`.
+1. **Node API keys** → create or reuse a constellation key.
+2. **Node authentications** → link the key to this MC ManagedNode, or `POST …/api-keys/{id}/add_node/` with `managed_node_internal_id` (UUID from the managed node row).
+3. Multiple feeders may share one key if each has a unique `mc_pubkey`.
+4. Put the key in the bot env as `STORAGE_API_TOKEN`.
 
 ## 3. Configure meshflow-bot
 
@@ -57,7 +56,7 @@ MESHCORE_SERIAL_DEVICE=/dev/ttyUSB0   # or MESHCORE_BLE_ADDRESS=...
 MESHCORE_UPLOAD_ENABLED=true
 STORAGE_API_ROOT=https://your-api.example/api
 STORAGE_API_TOKEN=<key from step 2>
-STORAGE_API_VERSION=2
+STORAGE_API_VERSION=3
 ```
 
 Restart the bot. Confirm logs show feeder-scoped paths, e.g. `POST /api/meshcore/feeders/{prefix}/packets/ingest/`. Do **not** use `/api/packets/0/bot-version/` for MeshCore.

--- a/docs/features/meshcore/managed-node-identity-outstanding.md
+++ b/docs/features/meshcore/managed-node-identity-outstanding.md
@@ -1,0 +1,11 @@
+# ManagedNode protocol identity — outstanding
+
+Items **skipped**, **incomplete**, or **discovered during execution** — not the [#362](https://github.com/pskillen/meshflow-api/issues/362) plan’s future phases.
+
+**Tracking:** [meshflow-api#362](https://github.com/pskillen/meshflow-api/issues/362)
+
+---
+
+<!-- Add items only when discovered during #362 work. Examples:
+- [ ] Production row with protocol=MC and mc_pubkey NULL blocked migration — fixed in admin before re-run
+-->

--- a/docs/features/meshcore/managed-node-identity-progress.md
+++ b/docs/features/meshcore/managed-node-identity-progress.md
@@ -1,0 +1,42 @@
+# ManagedNode protocol identity — progress
+
+**Tracking:** [meshflow-api#362](https://github.com/pskillen/meshflow-api/issues/362) (parent [meshflow-ui#291](https://github.com/pskillen/meshflow-ui/issues/291))  
+**Plan:** `.cursor/plans/api_362_protocol_identity_9b9056b9.plan.md`  
+**Repos:** meshflow-api only
+
+**Blocks:** [meshflow-ui#293](https://github.com/pskillen/meshflow-ui/issues/293) enrollment; API side of [meshflow-ui#254](https://github.com/pskillen/meshflow-ui/issues/254)
+
+---
+
+## Overall status
+
+**Status:** Complete (pending PR + deploy)
+
+**Branch:** `api-362/managed-node-protocol-identity` (to push)
+
+---
+
+## Delivered
+
+| Slice | Status | Notes |
+| --- | --- | --- |
+| Migration `0050` | Complete | `0`→NULL for MC; nullable `meshtastic_node_id`; `managednode_protocol_identity` CHECK; partial unique on MT id |
+| Django admin + feeder-bootstrap.md | Complete | MC requires `mc_pubkey`; no placeholder `0` |
+| Serializers | Complete | Protocol-aware create; `mc_pubkey` + default location writable; `linked_managed_nodes` on API key detail |
+| Views | Complete | `internal_id` lookup + MT numeric compat; `managed_node_internal_id` on add/remove node |
+| OpenAPI | Complete | Path `{internal_id}` uuid; nullable `meshtastic_node_id`; linked nodes schema |
+| Tests | Complete | `test_managed_node_protocol_identity.py`; fixture coercion; reverse `internal_id` |
+
+**Verify locally**
+
+```bash
+cd Meshflow && source ../venv/bin/activate
+python manage.py migrate
+python -m pytest nodes/tests/test_managed_node_protocol_identity.py nodes/tests/ -q
+```
+
+---
+
+## Next
+
+1. Open PR linking #362 / #291; deploy API before UI enrollment (#293).

--- a/docs/features/meshcore/managed-node-identity-progress.md
+++ b/docs/features/meshcore/managed-node-identity-progress.md
@@ -10,9 +10,11 @@
 
 ## Overall status
 
-**Status:** Complete (pending PR + deploy)
+**Status:** Complete (pending merge + deploy)
 
-**Branch:** `api-362/managed-node-protocol-identity` (to push)
+**PR:** [meshflow-api#363](https://github.com/pskillen/meshflow-api/pull/363)
+
+**Branch:** `api-362/pskillen/managed-node-protocol-identity`
 
 ---
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1648,10 +1648,31 @@ components:
           description: Whether the API key is active
         nodes:
           type: array
-          description: The nodes that are associated with the API key
+          description: Legacy Meshtastic numeric node ids linked to this key (MeshCore feeders omitted)
           readOnly: true
           items:
             type: integer
+        linked_managed_nodes:
+          type: array
+          readOnly: true
+          description: All linked managed nodes with stable internal_id (preferred for MeshCore)
+          items:
+            $ref: '#/components/schemas/LinkedManagedNode'
+
+    LinkedManagedNode:
+      type: object
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id_str:
+          type: string
+        protocol:
+          $ref: '#/components/schemas/MeshProtocol'
+        meshtastic_node_id:
+          type: integer
+          format: int64
+          nullable: true
 
     NodeOwnerClaim:
       type: object
@@ -1764,7 +1785,21 @@ components:
         meshtastic_node_id:
           type: integer
           format: int64
-          description: Meshtastic numeric node id for this managed feeder
+          nullable: true
+          description: Meshtastic numeric node id (null for MeshCore feeders)
+        mc_pubkey:
+          type: string
+          nullable: true
+          maxLength: 64
+          description: MeshCore feeder device pubkey (64-char lowercase hex; required when protocol=meshcore)
+        default_location_latitude:
+          type: number
+          format: double
+          nullable: true
+        default_location_longitude:
+          type: number
+          format: double
+          nullable: true
         protocol:
           $ref: '#/components/schemas/MeshProtocol'
           description: Mesh protocol for this managed node
@@ -5394,7 +5429,7 @@ paths:
                           $ref: '#/components/schemas/OwnedManagedNode'
 
 
-  /nodes/managed-nodes/{node_id}/:
+  /nodes/managed-nodes/{internal_id}/:
     get:
       summary: Get managed node details
       description: >-
@@ -5408,7 +5443,9 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
+          description: Managed node UUID (Meshtastic numeric id accepted but deprecated)
         - name: include
           in: query
           required: false
@@ -5440,7 +5477,8 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -5469,7 +5507,8 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -5494,7 +5533,7 @@ paths:
     delete:
       summary: Soft-delete managed node (un-manage)
       description: >
-        Soft-deletes the managed node for the given mesh `node_id`: sets `deleted_at`, removes all
+        Soft-deletes the managed node for the given `internal_id`: sets `deleted_at`, removes all
         `NodeAuth` links for that managed node, and excludes the row from managed-node listings and
         detail lookups (404). Allowed for the node owner or Django staff only; constellation admins
         cannot un-manage on behalf of others. Does not clear `ObservedNode.claimed_by`.
@@ -5506,7 +5545,8 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
+            type: string
+            format: uuid
       responses:
         '204':
           description: Managed node soft-deleted successfully
@@ -5651,11 +5691,15 @@ paths:
             schema:
               type: object
               properties:
+                managed_node_internal_id:
+                  type: string
+                  format: uuid
+                  description: Preferred — managed node UUID to link
                 meshtastic_node_id:
                   type: integer
-                  description: Meshtastic numeric node id of the managed node to link
+                  description: Meshtastic numeric node id (Meshtastic feeders only)
       responses:
-        '200':
+        '201':
           description: Node added successfully
           content:
             application/json:
@@ -5681,9 +5725,13 @@ paths:
             schema:
               type: object
               properties:
+                managed_node_internal_id:
+                  type: string
+                  format: uuid
+                  description: Preferred — managed node UUID to unlink
                 meshtastic_node_id:
                   type: integer
-                  description: Meshtastic numeric node id of the managed node to unlink
+                  description: Meshtastic numeric node id (Meshtastic feeders only)
       responses:
         '200':
           description: Node removed successfully


### PR DESCRIPTION
## Summary

- Migrate MeshCore `ManagedNode` rows off `meshtastic_node_id=0` to `NULL` with `managednode_protocol_identity` CHECK constraints and a partial unique index for active Meshtastic feeders.
- REST: detail/patch/delete by `internal_id` (UUID); deprecated numeric path for Meshtastic only.
- API keys: `POST …/add_node/` and `remove_node` accept `managed_node_internal_id`; detail exposes `linked_managed_nodes`.
- Admin and `feeder-bootstrap.md`: MC feeders require `mc_pubkey` at save (no placeholder 0).
- Adds progress-tracking skill and plan progress docs for agent handoff.

Closes #362. Unblocks meshflow-ui#293 enrollment and #254 (API side).

Parent epic: meshflow-ui#291

## Deployment note

Run `python manage.py migrate` before UI enrollment work. Meshtastic UI may continue using numeric path lookup until meshflow-ui#293 ships.

**Pre-migrate:** any `protocol=MeshCore` row with `meshtastic_node_id=0` and empty `mc_pubkey` must be fixed in Django admin (migration fails with a clear error).

## Testing performed

- `python manage.py migrate` (0050)
- `python -m pytest nodes/tests/ meshcore_packets/tests/ ws/tests/test_mc_node_consumer.py` (161 passed)