### PR TITLE
feat(stats): MeshCore hourly snapshots + MT protocol filter (#329, #365)

### DIFF
--- a/.cursor/rules/mf-feature-docs.mdc
+++ b/.cursor/rules/mf-feature-docs.mdc
@@ -1,0 +1,9 @@
+---
+description: Feature documentation under docs/features/ — follow mf-feature-docs skill
+globs: docs/features/**/*
+alwaysApply: false
+---
+
+When creating or editing files under `docs/features/`, read and follow [.cursor/rules/mf-feature-docs/SKILL.md](mf-feature-docs/SKILL.md).
+
+For multi-step initiatives, also use [progress-tracking](.cursor/skills/progress-tracking/SKILL.md): maintain `*-progress.md` and `*-outstanding.md` in the feature folder; update before opening PRs.

--- a/.cursor/rules/mf-feature-docs/SKILL.md
+++ b/.cursor/rules/mf-feature-docs/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: mf-feature-docs
+description: >-
+  How Meshflow documents features under docs/features/. Use when adding or
+  updating feature docs, reverse-engineering behaviour for a ticket, or creating
+  progress/outstanding logs for an initiative.
+---
+
+# Meshflow feature documentation
+
+Canonical feature docs live under **`docs/features/<topic>/`** in **meshflow-api** (even when UI or bot code participates). Cross-cutting concerns stay in
+**`docs/`** root (`RECENCY.md`, `ENV_VARS.md`, `permissions/`, `API.md`, `openapi.yaml`).
+
+Read [progress-tracking](../../skills/progress-tracking/SKILL.md) when an initiative needs execution handoff files.
+
+---
+
+## Folder layout
+
+| Pattern | When to use | Examples |
+| --- | --- | --- |
+| **`<topic>/README.md`** | Every feature area — hub page | `mesh-monitoring/README.md`, `packet-stats/README.md` |
+| **Sibling deep dives** | One concern per file; keep README as map | `flow.md`, `permissions.md`, `meshtastic.md` |
+| **`adr/`** | Irreversible or contested design choices | `packet-ingestion/adr/` |
+| **`*-progress.md` / `*-outstanding.md`** | Multi-step plans, epics, or tickets spanning PRs | `phase-2-progress.md`, `packet-stats-progress.md` |
+| **Phase files** | Large epics with numbered delivery | `meshcore/phase-1-progress.md` |
+
+**Slug:** kebab-case directory name matching the product concept (`packet-stats`, `mesh-monitoring`, not Django app name unless they align).
+
+**Do not** put the full plan backlog in `*-outstanding.md` — only debt discovered during execution (see progress-tracking skill).
+
+---
+
+## README hub template
+
+Every feature README should open with **what problem it solves** (1–3 paragraphs), then:
+
+1. **Implementation status** — table: area | status | notes (shipped / in progress / deferred).
+2. **Documentation map** — table linking sibling docs.
+3. **Concepts** — domain terms the reader needs before detail pages.
+4. **Optional diagram** — mermaid sequence/state when flow is non-obvious.
+5. **Cross-links** — `RECENCY.md` for time windows, `openapi.yaml` tag for HTTP, related features, parent GitHub epic/issue.
+
+Stop at the feature boundary: ingestion README emits signals and points to downstream features; do not document traceroute completion inside packet-ingestion.
+
+---
+
+## Deep-dive page template
+
+Use for `flow.md`, protocol-specific docs, etc.
+
+| Section | Contents |
+| --- | --- |
+| **Purpose** | What this slice does vs the hub README |
+| **Code anchors** | Django app paths, main modules (`Meshflow/stats/tasks.py`) |
+| **Data sources** | Models, fields, filters (be precise — contributors should not re-read code line-by-line) |
+| **Schedules / env** | Celery beat, env vars with defaults; link `docs/RECENCY.md` § app |
+| **HTTP API** | Paths, auth (`AllowGuestReadOnly` vs JWT), query params; point to OpenAPI |
+| **Consumers** | meshflow-ui hooks/components, bots, ops commands |
+| **Known gaps** | Explicit TODOs, deferred protocol support, doc drift |
+| **Related** | Other feature docs, issues |
+
+Prefer **tables** for endpoints, snapshot types, and field shapes. Use **JSON examples** for `StatsSnapshot.value` and API payloads when shape matters.
+
+---
+
+## Progress and outstanding pair
+
+Create both at **plan kickoff** if missing. Update **progress** when a PR/commit lands; update **outstanding** only for skipped scope or issues found while executing.
+
+| File | Role |
+| --- | --- |
+| `*-progress.md` | Shipped slices, PR links, branch, verify commands, **Next** |
+| `*-outstanding.md` | Checkboxes for discovered debt — not future plan phases |
+
+Link both from the tracking GitHub issue and the Cursor plan **Progress tracking** section.
+
+---
+
+## Style conventions (inferred from existing docs)
+
+- **British English** spelling in prose is fine; code identifiers stay as in repo.
+- Link GitHub issues/PRs with full URLs: `[meshflow-api#329](https://github.com/pskillen/meshflow-api/issues/329)`.
+- Use relative links between docs: `[meshtastic.md](meshtastic.md)`.
+- Cite **concrete defaults** (e.g. “`:05` UTC”, “2 h window”) — they belong in feature docs *and* `RECENCY.md` for ops; feature doc explains *behaviour*, RECENCY is the quick index.
+- When behaviour changes, update **feature doc**, **`RECENCY.md`** (if time-related), and **`openapi.yaml`** (if API contract changes).
+- **Reverse-engineering ticket:** document *current* behaviour first in a protocol or mechanism doc; add `meshcore.md` (or a section) for planned parity before implementing.
+
+---
+
+## Index maintenance
+
+When adding a new feature folder:
+
+1. Add a row or subsection under [docs/features/README.md](../../../docs/features/README.md) **Features** (or **Cross-Cutting** if appropriate).
+2. Add `docs/RECENCY.md` § if the feature introduces recency windows or periodic jobs.
+3. For MeshCore work, add a row to [docs/features/meshcore/README.md](../../../docs/features/meshcore/README.md) when relevant.
+
+---
+
+## Anti-patterns
+
+- Duplicating `openapi.yaml` field lists in full — summarize and link OpenAPI.
+- One giant README with no map (split when > ~200 lines or multiple audiences).
+- Outstanding file copied from the Cursor plan todo list.
+- Documenting aspirational behaviour as shipped — use **Implementation status** and **Known gaps**.

--- a/Meshflow/conftest.py
+++ b/Meshflow/conftest.py
@@ -3,5 +3,4 @@
 pytest_plugins = [
     "nodes.tests.conftest",
     "packets.tests.conftest",
-    "meshcore_packets.tests.conftest",
 ]

--- a/Meshflow/conftest.py
+++ b/Meshflow/conftest.py
@@ -1,3 +1,7 @@
 """Top-level pytest configuration. pytest_plugins must be defined here."""
 
-pytest_plugins = ["nodes.tests.conftest", "packets.tests.conftest"]
+pytest_plugins = [
+    "nodes.tests.conftest",
+    "packets.tests.conftest",
+    "meshcore_packets.tests.conftest",
+]

--- a/Meshflow/meshcore_packets/tests/conftest.py
+++ b/Meshflow/meshcore_packets/tests/conftest.py
@@ -1,30 +1,7 @@
-import pytest
-
-from common.protocol import Protocol
-from nodes.models import NodeAuth
-
 FEEDER_MC_PUBKEY = "a" * 64
 FEEDER_MC_PUBKEY_PREFIX = "a" * 12
 FEEDER_B_MC_PUBKEY = "c" * 64
 FEEDER_B_MC_PUBKEY_PREFIX = "c" * 12
-
-
-@pytest.fixture
-def meshcore_feeder(create_managed_node, create_node_api_key):
-    """MC ManagedNode + API key + NodeAuth for ingest tests."""
-    node = create_managed_node(
-        meshtastic_node_id=None,
-        protocol=Protocol.MESHCORE,
-        name="MC Feeder",
-        mc_pubkey=FEEDER_MC_PUBKEY,
-    )
-    api_key = create_node_api_key(constellation=node.constellation)
-    NodeAuth.objects.create(api_key=api_key, node=node)
-    return {
-        "node": node,
-        "api_key": api_key,
-        "feeder_pubkey_prefix": FEEDER_MC_PUBKEY_PREFIX,
-    }
 
 
 def feeder_url(name: str, prefix: str) -> str:

--- a/Meshflow/nodes/tests/conftest.py
+++ b/Meshflow/nodes/tests/conftest.py
@@ -170,3 +170,25 @@ def mark_constellation_managed_nodes_feeding(mark_managed_node_feeding):
             mark_managed_node_feeding(mn, sending=True)
 
     return _mark
+
+
+FEEDER_MC_PUBKEY = "a" * 64
+FEEDER_MC_PUBKEY_PREFIX = "a" * 12
+
+
+@pytest.fixture
+def meshcore_feeder(create_managed_node, create_node_api_key):
+    """MC ManagedNode + API key + NodeAuth for ingest and stats tests."""
+    node = create_managed_node(
+        meshtastic_node_id=None,
+        protocol=Protocol.MESHCORE,
+        name="MC Feeder",
+        mc_pubkey=FEEDER_MC_PUBKEY,
+    )
+    api_key = create_node_api_key(constellation=node.constellation)
+    NodeAuth.objects.create(api_key=api_key, node=node)
+    return {
+        "node": node,
+        "api_key": api_key,
+        "feeder_pubkey_prefix": FEEDER_MC_PUBKEY_PREFIX,
+    }

--- a/Meshflow/nodes/tests/test_node_views.py
+++ b/Meshflow/nodes/tests/test_node_views.py
@@ -593,3 +593,28 @@ def test_managed_node_create_rejected_when_active_row_exists(create_user, create
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "already exists" in str(response.data).lower()
+
+
+@pytest.mark.django_db
+def test_infrastructure_list_filters_by_protocol(create_observed_node, create_user):
+    from nodes.models import RoleSource
+
+    client = APIClient()
+    client.force_authenticate(user=create_user())
+
+    mt = create_observed_node(meshtastic_role=RoleSource.ROUTER, protocol=1)
+    mc = create_observed_node(protocol=2, meshtastic_role=None)
+
+    infra_url = "/api/nodes/observed-nodes/infrastructure/"
+
+    mt_resp = client.get(infra_url, {"protocol": "meshtastic"})
+    assert mt_resp.status_code == status.HTTP_200_OK
+    mt_ids = {r["node_id_str"] for r in mt_resp.data["results"]}
+    assert mt.node_id_str in mt_ids
+    assert mc.node_id_str not in mt_ids
+
+    mc_resp = client.get(infra_url, {"protocol": "meshcore"})
+    assert mc_resp.status_code == status.HTTP_200_OK
+    mc_ids = {r["node_id_str"] for r in mc_resp.data["results"]}
+    assert mc.node_id_str in mc_ids
+    assert mt.node_id_str not in mc_ids

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -356,7 +356,15 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         Get node counts by time window (nodes seen since each threshold).
 
         Returns counts for: 2h, 24h, 7d, 30d, 90d, and all time.
+        Optional ?protocol=meshtastic|meshcore filters ObservedNode rows.
         """
+        from common.protocol import protocol_from_query_param
+
+        protocol = protocol_from_query_param(request.query_params.get("protocol"))
+        base_qs = ObservedNode.objects.all()
+        if protocol is not None:
+            base_qs = base_qs.filter(protocol=protocol)
+
         now = timezone.now()
         windows = [
             ("2", now - timedelta(hours=2)),
@@ -367,8 +375,8 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         ]
         result = {}
         for key, threshold in windows:
-            result[key] = ObservedNode.objects.filter(last_heard__gte=threshold).count()
-        result["all"] = ObservedNode.objects.count()
+            result[key] = base_qs.filter(last_heard__gte=threshold).count()
+        result["all"] = base_qs.count()
         return Response(result)
 
     @action(detail=False, methods=["get"], url_path="search")

--- a/Meshflow/nodes/views.py
+++ b/Meshflow/nodes/views.py
@@ -631,16 +631,26 @@ class ObservedNodeViewSet(viewsets.ModelViewSet):
         """
         Get observed nodes whose role is infrastructure (router, repeater, etc.).
 
-        Query params: last_heard_after, page, page_size, include_client_base (default false)
+        Query params: last_heard_after, page, page_size, include_client_base (default false),
+        protocol (meshtastic | meshcore). Meshtastic: infrastructure meshtastic roles.
+        MeshCore: all observed MeshCore nodes (no Meshtastic role filter).
         """
-        include_client_base = request.query_params.get("include_client_base", "false").lower() == "true"
-        roles = INFRASTRUCTURE_ROLES + ([RoleSource.CLIENT_BASE] if include_client_base else [])
+        from common.protocol import Protocol, protocol_from_query_param
 
-        qs = (
-            ObservedNode.objects.filter(meshtastic_role__in=roles)
-            .order_by("-last_heard", "meshtastic_node_id")
-            .select_related("latest_status", "monitoring_config", "mesh_presence")
-        )
+        protocol = protocol_from_query_param(request.query_params.get("protocol"))
+        if protocol is None:
+            protocol = Protocol.MESHTASTIC
+
+        qs = ObservedNode.objects.all().order_by("-last_heard", "meshtastic_node_id")
+
+        if protocol == Protocol.MESHCORE:
+            qs = qs.filter(protocol=Protocol.MESHCORE)
+        else:
+            include_client_base = request.query_params.get("include_client_base", "false").lower() == "true"
+            roles = INFRASTRUCTURE_ROLES + ([RoleSource.CLIENT_BASE] if include_client_base else [])
+            qs = qs.filter(protocol=Protocol.MESHTASTIC, meshtastic_role__in=roles)
+
+        qs = qs.select_related("latest_status", "monitoring_config", "mesh_presence")
 
         last_heard_after = request.query_params.get("last_heard_after")
         if last_heard_after:

--- a/Meshflow/stats/tasks.py
+++ b/Meshflow/stats/tasks.py
@@ -12,7 +12,9 @@ from django.utils import timezone
 from celery import shared_task
 from tqdm import tqdm
 
+from common.protocol import Protocol
 from constellations.models import Constellation
+from meshcore_packets.models import MeshCorePayloadType, MeshCorePacketObservation, MeshCoreRawPacket
 from nodes.models import ObservedNode
 from packets.models import MtRawPacket, PacketObservation
 
@@ -23,10 +25,10 @@ logger = logging.getLogger(__name__)
 ONLINE_NODE_WINDOW_HOURS = int(os.environ.get("ONLINE_NODE_WINDOW_HOURS", "2"))
 
 
-def _get_last_run_started_at() -> Optional[datetime]:
-    """Return the recorded_at of the most recent new_nodes (global) snapshot, or None."""
+def _get_last_run_started_at(stat_type: str) -> Optional[datetime]:
+    """Return the recorded_at of the most recent global snapshot for stat_type, or None."""
     last = (
-        StatsSnapshot.objects.filter(stat_type="new_nodes", constellation__isnull=True)
+        StatsSnapshot.objects.filter(stat_type=stat_type, constellation__isnull=True)
         .order_by("-recorded_at")
         .values("recorded_at")
         .first()
@@ -83,7 +85,10 @@ def _collect_online_nodes(
                 .count()
             )
         else:
-            global_count = ObservedNode.objects.filter(last_heard__gte=threshold).count()
+            global_count = ObservedNode.objects.filter(
+                protocol=Protocol.MESHTASTIC,
+                last_heard__gte=threshold,
+            ).count()
         StatsSnapshot.objects.create(
             recorded_at=recorded_at,
             stat_type="online_nodes",
@@ -199,6 +204,7 @@ def _collect_new_nodes(
 
         def per_constellation_filter(obs_node_ids):
             return ObservedNode.objects.filter(
+                protocol=Protocol.MESHTASTIC,
                 meshtastic_node_id__in=obs_node_ids,
                 created_at__gte=recorded_at,
                 created_at__lt=hour_end,
@@ -211,6 +217,7 @@ def _collect_new_nodes(
 
             def per_constellation_filter(obs_node_ids):
                 return ObservedNode.objects.filter(
+                    protocol=Protocol.MESHTASTIC,
                     meshtastic_node_id__in=obs_node_ids,
                     created_at__gte=last_run_started_at,
                 )
@@ -220,6 +227,7 @@ def _collect_new_nodes(
 
             def per_constellation_filter(obs_node_ids):
                 return ObservedNode.objects.filter(
+                    protocol=Protocol.MESHTASTIC,
                     meshtastic_node_id__in=obs_node_ids,
                     created_at__isnull=False,
                 )
@@ -228,7 +236,7 @@ def _collect_new_nodes(
     if skip_existing and _snapshot_exists(recorded_at, "new_nodes", None):
         skipped += 1
     else:
-        count = ObservedNode.objects.filter(**global_filter).count()
+        count = ObservedNode.objects.filter(protocol=Protocol.MESHTASTIC, **global_filter).count()
         StatsSnapshot.objects.create(
             recorded_at=recorded_at,
             stat_type="new_nodes",
@@ -278,11 +286,214 @@ def _collect_new_nodes(
     return (created, skipped)
 
 
+MC_PACKET_TYPE_FILTERS = {
+    "advert": Q(payload_type=MeshCorePayloadType.ADVERT),
+    "channel_text": Q(payload_type=MeshCorePayloadType.CHANNEL_TEXT),
+    "contact_text": Q(payload_type=MeshCorePayloadType.CONTACT_TEXT),
+    "raw": Q(payload_type=MeshCorePayloadType.RAW),
+}
+
+
+def _collect_mc_online_nodes(
+    recorded_at: datetime,
+    *,
+    run_id: Optional[uuid.UUID] = None,
+    skip_existing: bool = False,
+    use_raw_packet_for_global: bool = False,
+) -> tuple[int, int]:
+    """Collect mc_online_nodes snapshots (hourly) for global and per-constellation."""
+    window = timedelta(hours=ONLINE_NODE_WINDOW_HOURS)
+    threshold = recorded_at - window
+    created = 0
+    skipped = 0
+
+    if skip_existing and _snapshot_exists(recorded_at, "mc_online_nodes", None):
+        skipped += 1
+    else:
+        if use_raw_packet_for_global:
+            global_count = (
+                MeshCoreRawPacket.objects.filter(
+                    from_pubkey__isnull=False,
+                    first_reported_time__gte=threshold,
+                    first_reported_time__lte=recorded_at,
+                )
+                .values_list("from_pubkey", flat=True)
+                .distinct()
+                .count()
+            )
+        else:
+            global_count = ObservedNode.objects.filter(
+                protocol=Protocol.MESHCORE,
+                last_heard__gte=threshold,
+            ).count()
+        StatsSnapshot.objects.create(
+            recorded_at=recorded_at,
+            stat_type="mc_online_nodes",
+            constellation=None,
+            value={"count": global_count, "window_hours": ONLINE_NODE_WINDOW_HOURS},
+            run_id=run_id,
+        )
+        created += 1
+
+    for constellation in Constellation.objects.all():
+        if skip_existing and _snapshot_exists(recorded_at, "mc_online_nodes", constellation.id):
+            skipped += 1
+        else:
+            count = (
+                MeshCorePacketObservation.objects.filter(
+                    observer__constellation=constellation,
+                    rx_time__gte=threshold,
+                )
+                .values("packet__from_pubkey")
+                .distinct()
+                .count()
+            )
+            StatsSnapshot.objects.create(
+                recorded_at=recorded_at,
+                stat_type="mc_online_nodes",
+                constellation=constellation,
+                value={"count": count, "window_hours": ONLINE_NODE_WINDOW_HOURS},
+                run_id=run_id,
+            )
+            created += 1
+
+    return (created, skipped)
+
+
+def _collect_mc_packet_volume(
+    recorded_at: datetime,
+    *,
+    run_id: Optional[uuid.UUID] = None,
+    skip_existing: bool = False,
+) -> tuple[int, int]:
+    """Collect mc_packet_volume snapshot (hourly, global) for MeshCore raw packets."""
+    if skip_existing and _snapshot_exists(recorded_at, "mc_packet_volume", None):
+        return (0, 1)
+
+    hour_end = recorded_at + timedelta(hours=1)
+    base_qs = MeshCoreRawPacket.objects.filter(
+        first_reported_time__gte=recorded_at,
+        first_reported_time__lt=hour_end,
+    )
+
+    annotate_kwargs = {f"_{k}": Count("id", filter=v) for k, v in MC_PACKET_TYPE_FILTERS.items()}
+    agg = base_qs.aggregate(**annotate_kwargs)
+
+    by_type = {k: agg[f"_{k}"] for k in MC_PACKET_TYPE_FILTERS}
+    total = base_qs.count()
+
+    StatsSnapshot.objects.create(
+        recorded_at=recorded_at,
+        stat_type="mc_packet_volume",
+        constellation=None,
+        value={"count": total, "by_type": by_type},
+        run_id=run_id,
+    )
+    return (1, 0)
+
+
+def _collect_mc_new_nodes(
+    recorded_at: datetime,
+    *,
+    run_id: Optional[uuid.UUID] = None,
+    skip_existing: bool = False,
+    last_run_started_at: Optional[datetime] = None,
+    for_backfill: bool = False,
+) -> tuple[int, int]:
+    """Collect mc_new_nodes snapshots for global and per-constellation."""
+    hour_end = recorded_at + timedelta(hours=1)
+    created = 0
+    skipped = 0
+
+    if for_backfill:
+        global_filter = {"created_at__gte": recorded_at, "created_at__lt": hour_end}
+
+        def per_constellation_filter(pubkeys):
+            return ObservedNode.objects.filter(
+                protocol=Protocol.MESHCORE,
+                mc_pubkey__in=pubkeys,
+                created_at__gte=recorded_at,
+                created_at__lt=hour_end,
+            )
+
+    else:
+        if last_run_started_at is not None:
+            global_filter = {"created_at__gte": last_run_started_at}
+
+            def per_constellation_filter(pubkeys):
+                return ObservedNode.objects.filter(
+                    protocol=Protocol.MESHCORE,
+                    mc_pubkey__in=pubkeys,
+                    created_at__gte=last_run_started_at,
+                )
+
+        else:
+            global_filter = {"created_at__isnull": False}
+
+            def per_constellation_filter(pubkeys):
+                return ObservedNode.objects.filter(
+                    protocol=Protocol.MESHCORE,
+                    mc_pubkey__in=pubkeys,
+                    created_at__isnull=False,
+                )
+
+    if skip_existing and _snapshot_exists(recorded_at, "mc_new_nodes", None):
+        skipped += 1
+    else:
+        count = ObservedNode.objects.filter(protocol=Protocol.MESHCORE, **global_filter).count()
+        StatsSnapshot.objects.create(
+            recorded_at=recorded_at,
+            stat_type="mc_new_nodes",
+            constellation=None,
+            value={"count": count},
+            run_id=run_id,
+        )
+        created += 1
+
+    for constellation in Constellation.objects.all():
+        if skip_existing and _snapshot_exists(recorded_at, "mc_new_nodes", constellation.id):
+            skipped += 1
+        else:
+            if for_backfill:
+                observed_pubkeys = (
+                    MeshCorePacketObservation.objects.filter(observer__constellation=constellation)
+                    .values_list("packet__from_pubkey", flat=True)
+                    .distinct()
+                )
+            else:
+                if last_run_started_at is not None:
+                    observed_pubkeys = (
+                        MeshCorePacketObservation.objects.filter(
+                            observer__constellation=constellation,
+                            rx_time__gte=last_run_started_at,
+                        )
+                        .values_list("packet__from_pubkey", flat=True)
+                        .distinct()
+                    )
+                else:
+                    observed_pubkeys = (
+                        MeshCorePacketObservation.objects.filter(observer__constellation=constellation)
+                        .values_list("packet__from_pubkey", flat=True)
+                        .distinct()
+                    )
+            count = per_constellation_filter(observed_pubkeys).count()
+            StatsSnapshot.objects.create(
+                recorded_at=recorded_at,
+                stat_type="mc_new_nodes",
+                constellation=constellation,
+                value={"count": count},
+                run_id=run_id,
+            )
+            created += 1
+
+    return (created, skipped)
+
+
 @shared_task
 def collect_stats_snapshots():
     """
-    Run periodically (hourly). Collect online_nodes (hourly), packet_volume, and new_nodes (per-run)
-    snapshots for global and per-constellation scope.
+    Run periodically (hourly). Collect Meshtastic and MeshCore snapshot types for the
+    completed previous hour (global and per-constellation where applicable).
 
     Records the *completed* previous hour (not the current hour), since the current hour
     has only just started when this runs at minute 5.
@@ -290,14 +501,21 @@ def collect_stats_snapshots():
     run_id = uuid.uuid4()
     current_hour = timezone.now().replace(minute=0, second=0, microsecond=0)
     hour_start = current_hour - timedelta(hours=1)  # Record completed previous hour
-    last_run_started_at = _get_last_run_started_at()
+    last_run_mt = _get_last_run_started_at("new_nodes")
+    last_run_mc = _get_last_run_started_at("mc_new_nodes")
 
     created = 0
     c, _ = _collect_online_nodes(hour_start, run_id=run_id)
     created += c
     c, _ = _collect_packet_volume(hour_start, run_id=run_id)
     created += c
-    c, _ = _collect_new_nodes(hour_start, run_id=run_id, last_run_started_at=last_run_started_at)
+    c, _ = _collect_new_nodes(hour_start, run_id=run_id, last_run_started_at=last_run_mt)
+    created += c
+    c, _ = _collect_mc_online_nodes(hour_start, run_id=run_id)
+    created += c
+    c, _ = _collect_mc_packet_volume(hour_start, run_id=run_id)
+    created += c
+    c, _ = _collect_mc_new_nodes(hour_start, run_id=run_id, last_run_started_at=last_run_mc)
     created += c
 
     logger.info(
@@ -311,7 +529,7 @@ def collect_stats_snapshots():
 @shared_task
 def backfill_stats_snapshots(days: int = 30):
     """
-    Backfill online_nodes, packet_volume, and new_nodes snapshots for the last N days.
+    Backfill Meshtastic and MeshCore stats snapshots for the last N days.
     Idempotent: skips hours that already have snapshots (when run sequentially).
     """
     now = timezone.now()
@@ -336,6 +554,20 @@ def backfill_stats_snapshots(days: int = 30):
         c3, s3 = _collect_new_nodes(hour, run_id=run_id, skip_existing=True, for_backfill=True)
         created += c3
         skipped += s3
+
+        c4, s4 = _collect_mc_online_nodes(
+            hour, run_id=run_id, skip_existing=True, use_raw_packet_for_global=True
+        )
+        created += c4
+        skipped += s4
+
+        c5, s5 = _collect_mc_packet_volume(hour, run_id=run_id, skip_existing=True)
+        created += c5
+        skipped += s5
+
+        c6, s6 = _collect_mc_new_nodes(hour, run_id=run_id, skip_existing=True, for_backfill=True)
+        created += c6
+        skipped += s6
 
     logger.info(
         "Finished backfilling stats snapshots for the last %d days: created=%d, skipped=%d",

--- a/Meshflow/stats/tasks.py
+++ b/Meshflow/stats/tasks.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 
 from common.protocol import Protocol
 from constellations.models import Constellation
-from meshcore_packets.models import MeshCorePayloadType, MeshCorePacketObservation, MeshCoreRawPacket
+from meshcore_packets.models import MeshCorePacketObservation, MeshCorePayloadType, MeshCoreRawPacket
 from nodes.models import ObservedNode
 from packets.models import MtRawPacket, PacketObservation
 
@@ -555,9 +555,7 @@ def backfill_stats_snapshots(days: int = 30):
         created += c3
         skipped += s3
 
-        c4, s4 = _collect_mc_online_nodes(
-            hour, run_id=run_id, skip_existing=True, use_raw_packet_for_global=True
-        )
+        c4, s4 = _collect_mc_online_nodes(hour, run_id=run_id, skip_existing=True, use_raw_packet_for_global=True)
         created += c4
         skipped += s4
 

--- a/Meshflow/stats/tests/test_mc_snapshots.py
+++ b/Meshflow/stats/tests/test_mc_snapshots.py
@@ -1,0 +1,133 @@
+"""Tests for MeshCore stats snapshot collectors (#329)."""
+
+from datetime import datetime
+
+from django.utils import timezone
+
+import pytest
+
+from common.protocol import Protocol
+from meshcore_packets.models import MeshCorePayloadType, MeshCorePacketObservation, MeshCoreRawPacket
+from stats.models import StatsSnapshot
+from stats.tasks import (
+    _collect_mc_online_nodes,
+    _collect_mc_packet_volume,
+    _collect_mc_new_nodes,
+    _collect_online_nodes,
+)
+
+
+@pytest.mark.django_db
+def test_mt_online_nodes_excludes_meshcore_observed_node(create_observed_node):
+    """#365: MC ObservedNode must not count toward online_nodes."""
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+    mc_node = create_observed_node(
+        meshtastic_node_id=None,
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="b" * 64,
+    )
+    mc_node.last_heard = timezone.make_aware(datetime(2025, 3, 15, 11, 30, 0))
+    mc_node.save()
+
+    mt_node = create_observed_node(meshtastic_node_id=222222222)
+    mt_node.last_heard = timezone.make_aware(datetime(2025, 3, 15, 11, 30, 0))
+    mt_node.save()
+
+    _collect_online_nodes(hour, run_id=None)
+
+    snap = StatsSnapshot.objects.get(stat_type="online_nodes", constellation__isnull=True, recorded_at=hour)
+    assert snap.value["count"] == 1
+
+
+@pytest.mark.django_db
+def test_mc_packet_volume_by_type(meshcore_feeder):
+    """mc_packet_volume includes per payload_type breakdown."""
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+    observer = meshcore_feeder["node"]
+
+    MeshCoreRawPacket.objects.create(
+        observer=observer,
+        payload_type=MeshCorePayloadType.ADVERT,
+        event_type="advertisement",
+        from_pubkey="b" * 64,
+        rx_time=hour,
+        first_reported_time=hour,
+        raw_json={},
+    )
+    MeshCoreRawPacket.objects.create(
+        observer=observer,
+        payload_type=MeshCorePayloadType.CHANNEL_TEXT,
+        event_type="channel_text",
+        from_pubkey="c" * 64,
+        rx_time=hour,
+        first_reported_time=hour,
+        raw_json={},
+    )
+
+    _collect_mc_packet_volume(hour, run_id=None)
+
+    snap = StatsSnapshot.objects.get(stat_type="mc_packet_volume", recorded_at=hour)
+    assert snap.value["count"] == 2
+    assert snap.value["by_type"]["advert"] == 1
+    assert snap.value["by_type"]["channel_text"] == 1
+
+
+@pytest.mark.django_db
+def test_mc_online_nodes_global_and_constellation(meshcore_feeder, create_observed_node):
+    """mc_online_nodes uses MC last_heard globally and observations per constellation."""
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+    mc_node = create_observed_node(
+        meshtastic_node_id=None,
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="d" * 64,
+    )
+    mc_node.last_heard = timezone.make_aware(datetime(2025, 3, 15, 11, 30, 0))
+    mc_node.save()
+
+    observer = meshcore_feeder["node"]
+    packet = MeshCoreRawPacket.objects.create(
+        observer=observer,
+        payload_type=MeshCorePayloadType.ADVERT,
+        event_type="advertisement",
+        from_pubkey="e" * 64,
+        rx_time=timezone.make_aware(datetime(2025, 3, 15, 11, 45, 0)),
+        first_reported_time=timezone.make_aware(datetime(2025, 3, 15, 11, 45, 0)),
+        raw_json={},
+    )
+    MeshCorePacketObservation.objects.create(
+        packet=packet,
+        observer=observer,
+        rx_time=timezone.make_aware(datetime(2025, 3, 15, 11, 45, 0)),
+    )
+
+    _collect_mc_online_nodes(hour, run_id=None)
+
+    global_snap = StatsSnapshot.objects.get(
+        stat_type="mc_online_nodes", constellation__isnull=True, recorded_at=hour
+    )
+    assert global_snap.value["count"] == 1
+
+    const_snap = StatsSnapshot.objects.get(
+        stat_type="mc_online_nodes",
+        constellation=observer.constellation,
+        recorded_at=hour,
+    )
+    assert const_snap.value["count"] == 1
+
+
+@pytest.mark.django_db
+def test_mc_new_nodes_backfill_hour_window(meshcore_feeder, create_observed_node):
+    """mc_new_nodes backfill counts nodes created in the hour window."""
+    hour = timezone.make_aware(datetime(2025, 3, 15, 12, 0, 0))
+    node = create_observed_node(
+        meshtastic_node_id=None,
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="f" * 64,
+    )
+    node.created_at = timezone.make_aware(datetime(2025, 3, 15, 12, 15, 0))
+    node.save(update_fields=["created_at"])
+
+    _collect_mc_new_nodes(hour, run_id=None, for_backfill=True)
+
+    snap = StatsSnapshot.objects.get(stat_type="mc_new_nodes", constellation__isnull=True, recorded_at=hour)
+    assert snap.value["count"] == 1

--- a/Meshflow/stats/tests/test_mc_snapshots.py
+++ b/Meshflow/stats/tests/test_mc_snapshots.py
@@ -7,12 +7,12 @@ from django.utils import timezone
 import pytest
 
 from common.protocol import Protocol
-from meshcore_packets.models import MeshCorePayloadType, MeshCorePacketObservation, MeshCoreRawPacket
+from meshcore_packets.models import MeshCorePacketObservation, MeshCorePayloadType, MeshCoreRawPacket
 from stats.models import StatsSnapshot
 from stats.tasks import (
+    _collect_mc_new_nodes,
     _collect_mc_online_nodes,
     _collect_mc_packet_volume,
-    _collect_mc_new_nodes,
     _collect_online_nodes,
 )
 
@@ -102,9 +102,7 @@ def test_mc_online_nodes_global_and_constellation(meshcore_feeder, create_observ
 
     _collect_mc_online_nodes(hour, run_id=None)
 
-    global_snap = StatsSnapshot.objects.get(
-        stat_type="mc_online_nodes", constellation__isnull=True, recorded_at=hour
-    )
+    global_snap = StatsSnapshot.objects.get(stat_type="mc_online_nodes", constellation__isnull=True, recorded_at=hour)
     assert global_snap.value["count"] == 1
 
     const_snap = StatsSnapshot.objects.get(

--- a/docs/RECENCY.md
+++ b/docs/RECENCY.md
@@ -236,6 +236,8 @@ current default of **21600** (6 h). The 6 h default is canonical — treat the
 Hourly snapshots captured at **:05 UTC** for the **previous completed hour**.
 Implemented in [`Meshflow/stats/tasks.py`](../Meshflow/stats/tasks.py).
 
+**Feature documentation:** [docs/features/packet-stats/](features/packet-stats/README.md) (Meshtastic reverse-engineered in [meshtastic.md](features/packet-stats/meshtastic.md); MeshCore [#329](https://github.com/pskillen/meshflow-api/issues/329) in [meshcore.md](features/packet-stats/meshcore.md)).
+
 | Item | Default | Env | Purpose |
 | --- | --- | --- | --- |
 | `ONLINE_NODE_WINDOW_HOURS` | **2 h** | yes | `online_nodes` snapshot window against `last_heard` / `rx_time` / `first_reported_time` |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -176,6 +176,9 @@ The dashboard surfaces recent node counts across rolling windows, constellation
 maps, and packet/throughput stats. The `stats` app produces the aggregated
 counters; the SPA's `Dashboard` page is the primary consumer.
 
+Reference: [packet-stats/](packet-stats/) — hourly `StatsSnapshot` collection,
+live Meshtastic stats API, and MeshCore snapshot parity ([#329](https://github.com/pskillen/meshflow-api/issues/329)).
+
 ### Realtime (WebSocket)
 
 The `ws` app exposes Channels consumers used for two distinct things:

--- a/docs/features/meshcore/phase-2-outstanding.md
+++ b/docs/features/meshcore/phase-2-outstanding.md
@@ -54,7 +54,7 @@ Items **skipped**, **incomplete**, or **discovered during Phase 2 / rename execu
 - [ ] Test factories — legacy kwargs (`node_id`, `hw_model`, …) remain aliases in `create_observed_node`.
 - [x] **UI nav parity** — [ui#269](https://github.com/pskillen/meshflow-ui/issues/269) (in PR; see [phase-2-progress.md](./phase-2-progress.md) § UI nav & map parity).
 - [x] **MeshCore managed-nodes live status** — `include=status` MC annotations + UI table (api branch; see progress § MeshCore managed-node live status). **Still ship**; does not close [#329](https://github.com/pskillen/meshflow-api/issues/329).
-- [ ] **Hourly MC stats snapshots** — [#329](https://github.com/pskillen/meshflow-api/issues/329): `collect_stats_snapshots` / `StatsSnapshot` / dashboard charts; document Meshtastic path first (`docs/features/stats/meshtastic_packets.md`).
+- [ ] **Hourly MC stats snapshots** — [#329](https://github.com/pskillen/meshflow-api/issues/329): `collect_stats_snapshots` / `StatsSnapshot` / dashboard charts; Meshtastic documented in [packet-stats/meshtastic.md](../packet-stats/meshtastic.md) (progress: [packet-stats-progress.md](../packet-stats/packet-stats-progress.md)).
 - [ ] **UI out of scope for #269** — `/meshtastic/*` URL migration; MeshCore traceroutes / weather screens; server-side `protocol` filter on `GET /nodes/managed-nodes/`.
 - [x] **MeshCore channel messages UI** — [ui#275](https://github.com/pskillen/meshflow-ui/issues/275) (in PR; see progress § MeshCore messages UI). MC DM history still open below.
 - [ ] **Node search** still Meshtastic-centric (global sidebar search).

--- a/docs/features/meshcore/phase-2-outstanding.md
+++ b/docs/features/meshcore/phase-2-outstanding.md
@@ -54,7 +54,7 @@ Items **skipped**, **incomplete**, or **discovered during Phase 2 / rename execu
 - [ ] Test factories — legacy kwargs (`node_id`, `hw_model`, …) remain aliases in `create_observed_node`.
 - [x] **UI nav parity** — [ui#269](https://github.com/pskillen/meshflow-ui/issues/269) (in PR; see [phase-2-progress.md](./phase-2-progress.md) § UI nav & map parity).
 - [x] **MeshCore managed-nodes live status** — `include=status` MC annotations + UI table (api branch; see progress § MeshCore managed-node live status). **Still ship**; does not close [#329](https://github.com/pskillen/meshflow-api/issues/329).
-- [ ] **Hourly MC stats snapshots** — [#329](https://github.com/pskillen/meshflow-api/issues/329): `collect_stats_snapshots` / `StatsSnapshot` / dashboard charts; Meshtastic documented in [packet-stats/meshtastic.md](../packet-stats/meshtastic.md) (progress: [packet-stats-progress.md](../packet-stats/packet-stats-progress.md)).
+- [x] **Hourly MC stats snapshots (API)** — [#329](https://github.com/pskillen/meshflow-api/issues/329): `mc_*` collectors + OpenAPI; UI in meshflow-ui same initiative.
 - [ ] **UI out of scope for #269** — `/meshtastic/*` URL migration; MeshCore traceroutes / weather screens; server-side `protocol` filter on `GET /nodes/managed-nodes/`.
 - [x] **MeshCore channel messages UI** — [ui#275](https://github.com/pskillen/meshflow-ui/issues/275) (in PR; see progress § MeshCore messages UI). MC DM history still open below.
 - [ ] **Node search** still Meshtastic-centric (global sidebar search).

--- a/docs/features/meshcore/phase-2-progress.md
+++ b/docs/features/meshcore/phase-2-progress.md
@@ -194,7 +194,7 @@ Deploy api #325 before bot fleet upgrade.
 
 **Overlap:** both touch MC packet volume over time. **Not a substitute:** #329 remains required for historical hourly snapshots and stats API parity; this fix only unblocks the operational managed-feeder table and reuses the same observation rows #329 will eventually aggregate.
 
-**Docs:** [RECENCY.md](../../RECENCY.md) § managed-node annotations (protocol split). Task 1 of #329 (Meshtastic stats doc) is still open.
+**Docs:** [RECENCY.md](../../RECENCY.md) § managed-node annotations (protocol split). Task 1 of #329: [packet-stats/meshtastic.md](../packet-stats/meshtastic.md) (see [packet-stats-progress.md](../packet-stats/packet-stats-progress.md)).
 
 ---
 

--- a/docs/features/packet-stats/README.md
+++ b/docs/features/packet-stats/README.md
@@ -1,0 +1,73 @@
+# Packet statistics
+
+Meshflow exposes **packet and node activity statistics** for operations visibility and the dashboard. Two mechanisms coexist:
+
+1. **Stored hourly snapshots** — Celery writes completed-hour aggregates into `StatsSnapshot` (cheap to chart over long ranges).
+2. **Live aggregation** — HTTP handlers query `MtRawPacket` / `PacketObservation` on demand for arbitrary date ranges and intervals.
+
+Today both paths are **Meshtastic-only**. MeshCore hourly snapshots are tracked in [#329](https://github.com/pskillen/meshflow-api/issues/329) (parent epic [#266](https://github.com/pskillen/meshflow-api/issues/266)).
+
+Django app: [`Meshflow/stats/`](../../../Meshflow/stats/). Related but separate: traceroute daily success snapshots (`stat_type=tr_success_daily`) in `traceroute_analytics` — see [traceroute](../traceroute/README.md).
+
+## Implementation status
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Hourly MT snapshots (`online_nodes`, `packet_volume`, `new_nodes`) | Shipped | `collect_stats_snapshots` at `:05` UTC |
+| MT snapshot backfill | Shipped | `backfill_stats_snapshots` + management command |
+| `GET /api/stats/snapshots/` | Shipped | Guest-readable list + filters |
+| Live MT global / per-node stats | Shipped | `GET /api/stats/global/`, `/nodes/{id}/…` |
+| Hourly MC snapshots | Not started | [#329](https://github.com/pskillen/meshflow-api/issues/329) |
+| Dashboard MC charts | Deferred | UI follow-up after API snapshots |
+| Live MC stats API | Not planned in #329 | Snapshots + list API only |
+
+## Documentation map
+
+| Doc | Contents |
+| --- | --- |
+| [meshtastic.md](meshtastic.md) | Reverse-engineered MT snapshots, collectors, live API, UI consumers |
+| [meshcore.md](meshcore.md) | Planned MC parity (#329), gaps vs MT |
+| [packet-stats-progress.md](packet-stats-progress.md) | Execution log for #329 |
+| [packet-stats-outstanding.md](packet-stats-outstanding.md) | Debt discovered during #329 work |
+| [../../RECENCY.md](../../RECENCY.md) § `stats/` | Ops quick reference (windows, beat schedule) |
+| [../packet-ingestion/README.md](../packet-ingestion/README.md) | Where `MtRawPacket` / `MeshCoreRawPacket` originate |
+
+## High-level flow
+
+```mermaid
+flowchart TB
+  subgraph ingest [Ingestion]
+    MT[MtRawPacket + PacketObservation]
+    MC[MeshCoreRawPacket - not in stats yet]
+  end
+
+  subgraph celery [Celery beat :05 UTC]
+    task[collect_stats_snapshots]
+  end
+
+  subgraph store [Postgres]
+    snap[StatsSnapshot]
+  end
+
+  subgraph api [HTTP]
+    list[GET /api/stats/snapshots/]
+    live[GET /api/stats/global/ etc.]
+  end
+
+  subgraph ui [meshflow-ui]
+    dash[MeshStatsSection / charts]
+  end
+
+  MT --> task
+  task --> snap
+  snap --> list
+  MT --> live
+  list --> dash
+  live --> dash
+```
+
+## Cross-links
+
+- **Permissions:** snapshots and global live stats are guest-readable; per-node live stats require authenticated user ([permissions](../../permissions/README.md)).
+- **OpenAPI:** `Stats` tag — [`openapi.yaml`](../../../openapi.yaml).
+- **MeshCore phase 2:** [phase-2-outstanding.md](../meshcore/phase-2-outstanding.md) (#329 item).

--- a/docs/features/packet-stats/README.md
+++ b/docs/features/packet-stats/README.md
@@ -17,8 +17,8 @@ Django app: [`Meshflow/stats/`](../../../Meshflow/stats/). Related but separate:
 | MT snapshot backfill | Shipped | `backfill_stats_snapshots` + management command |
 | `GET /api/stats/snapshots/` | Shipped | Guest-readable list + filters |
 | Live MT global / per-node stats | Shipped | `GET /api/stats/global/`, `/nodes/{id}/…` |
-| Hourly MC snapshots | Not started | [#329](https://github.com/pskillen/meshflow-api/issues/329) |
-| Dashboard MC charts | Deferred | UI follow-up after API snapshots |
+| Hourly MC snapshots | Not started | [#329](https://github.com/pskillen/meshflow-api/issues/329) API Task 2 |
+| Dashboard + protocol dashboards | Not started | [#329](https://github.com/pskillen/meshflow-api/issues/329) UI Task 3 (meshflow-ui) |
 | Live MC stats API | Not planned in #329 | Snapshots + list API only |
 
 ## Documentation map

--- a/docs/features/packet-stats/meshcore.md
+++ b/docs/features/packet-stats/meshcore.md
@@ -1,0 +1,37 @@
+# MeshCore packet statistics (planned)
+
+**Status:** Not implemented — design target for [#329](https://github.com/pskillen/meshflow-api/issues/329). Use [meshtastic.md](meshtastic.md) as the template for behaviour and JSON shapes.
+
+## Goal
+
+Hourly **MeshCore** packet / node statistics with the same operational model as Meshtastic: Celery beat at **:05 UTC** records the previous completed hour into `StatsSnapshot`, exposed via `GET /api/stats/snapshots/` for dashboard charts.
+
+MeshCore ingest models: [`Meshflow/meshcore_packets/`](../../../Meshflow/meshcore_packets/) (`MeshCoreRawPacket`, `MeshCorePacketObservation`). Observed nodes use `protocol=MESHCORE` and `mc_pubkey` on [`ObservedNode`](../../../Meshflow/nodes/models.py).
+
+## Planned snapshot types (proposed)
+
+Prefix **`mc_`** on `stat_type` (no schema migration; extends OpenAPI enum):
+
+| `stat_type` | Scope (MT parity) | Data source (intended) |
+| --- | --- | --- |
+| `mc_packet_volume` | Global only | `MeshCoreRawPacket.first_reported_time` in hour bucket; `by_type` from `MeshCorePayloadType` (`advert`, `channel_text`, `contact_text`, `raw`) |
+| `mc_online_nodes` | Global + per-constellation | Global: `ObservedNode` `protocol=MESHCORE`, `last_heard`; constellation: distinct `from_pubkey` on `MeshCorePacketObservation` by feeder constellation |
+| `mc_new_nodes` | Global + per-constellation | `ObservedNode` `protocol=MESHCORE` + `created_at` (delta / backfill same rules as MT) |
+
+**Celery:** extend existing `collect_stats_snapshots` / `backfill_stats_snapshots` (single `run_id` per hour).
+
+**Out of scope for #329:** live `GET /api/stats/global/` MeshCore aggregates; meshflow-ui protocol toggle; blending MT+MC in one chart without explicit `stat_type`.
+
+## What exists today (not snapshots)
+
+- **Managed-node live status** — packet counts in last 2 h / 24 h on `GET /api/nodes/managed-nodes/?include=status` (annotations on MC feeders). Documented under [meshcore phase-2-progress](../meshcore/phase-2-progress.md); separate from hourly `StatsSnapshot`.
+- **Ingest** — [`meshcore_packets`](../packet-ingestion/MESHCORE_PACKET_FIELDS.md) populates raw packets and observations used by future collectors.
+
+## UI (follow-up)
+
+Dashboard [`MeshStatsSection`](https://github.com/pskillen/meshflow-ui/blob/main/src/components/MeshStatsSection.tsx) hardcodes `stat_type=packet_volume`. After API ships `mc_*` types, a UI issue can add protocol selection or separate MC charts.
+
+## References
+
+- Tracking: [#329](https://github.com/pskillen/meshflow-api/issues/329), epic [#266](https://github.com/pskillen/meshflow-api/issues/266)
+- Progress: [packet-stats-progress.md](packet-stats-progress.md)

--- a/docs/features/packet-stats/meshcore.md
+++ b/docs/features/packet-stats/meshcore.md
@@ -1,6 +1,6 @@
 # MeshCore packet statistics (planned)
 
-**Status:** Not implemented — design target for [#329](https://github.com/pskillen/meshflow-api/issues/329). Use [meshtastic.md](meshtastic.md) as the template for behaviour and JSON shapes.
+**Status:** Implemented in `stats.tasks` ([#329](https://github.com/pskillen/meshflow-api/issues/329)). Use [meshtastic.md](meshtastic.md) as the template for behaviour and JSON shapes.
 
 ## Goal
 

--- a/docs/features/packet-stats/meshtastic.md
+++ b/docs/features/packet-stats/meshtastic.md
@@ -187,7 +187,7 @@ print(StatsSnapshot.objects.order_by('-recorded_at')[:5].values('recorded_at','s
 
 ## Known gaps (Meshtastic doc scope)
 
-- Global `online_nodes` / `new_nodes` counts are not filtered to `protocol=MESHTASTIC` — MeshCore observed nodes can appear once they have `last_heard` / `created_at`. **Bug:** [#365](https://github.com/pskillen/meshflow-api/issues/365) (fix planned in [#329](https://github.com/pskillen/meshflow-api/issues/329)).
+- ~~Global `online_nodes` / `new_nodes` included MeshCore rows~~ — fixed ([#365](https://github.com/pskillen/meshflow-api/issues/365)) via `protocol=MESHTASTIC` filter on global ObservedNode queries.
 - Live stats views do not accept MeshCore identity (pubkey / `internal_id`).
 - `packet_volume` has no constellation-scoped snapshots.
 - Traceroute success daily stats use a different `stat_type` (`tr_success_daily`) — not covered here.

--- a/docs/features/packet-stats/meshtastic.md
+++ b/docs/features/packet-stats/meshtastic.md
@@ -1,0 +1,195 @@
+# Meshtastic packet statistics
+
+Reverse-engineered from [`Meshflow/stats/`](../../../Meshflow/stats/) as of 2026-05. This is the reference for MeshCore parity ([#329](https://github.com/pskillen/meshflow-api/issues/329)).
+
+## Overview
+
+| Mechanism | Purpose | Storage |
+| --- | --- | --- |
+| **Hourly snapshots** | Dashboard long-range charts, ops trending | `StatsSnapshot` rows |
+| **Live API** | Ad-hoc charts, node detail pages, custom intervals | Computed per request from ORM |
+
+Snapshots favour **completed hours** and fixed JSON shapes. Live endpoints support `interval` + `interval_type` (hour/day/week/month) over user-supplied `start_date` / `end_date`.
+
+---
+
+## Celery: snapshot collection
+
+### Schedule
+
+| Item | Value |
+| --- | --- |
+| Task | `stats.tasks.collect_stats_snapshots` |
+| Beat | Every hour at **minute :05 UTC** |
+| Migration | [`stats/migrations/0002_add_collect_stats_snapshots_periodic_task.py`](../../../Meshflow/stats/migrations/0002_add_collect_stats_snapshots_periodic_task.py) |
+| Backfill task | `stats.tasks.backfill_stats_snapshots` (default **30 days**) |
+| Management command | `python manage.py backfill_stats_snapshots [--days N]` |
+
+### “Previous completed hour” lag
+
+When the task runs at e.g. `13:05 UTC`, it sets:
+
+```text
+current_hour = 13:00 UTC (floor)
+hour_start   = 12:00 UTC  (= current_hour - 1h)
+```
+
+All snapshots for that run use `recorded_at = hour_start` (the **start** of the hour being summarized). The in-progress hour (`13:00–14:00`) is never written.
+
+Each run assigns a shared **`run_id`** (`uuid4`) on every snapshot created in that execution.
+
+### Idempotency
+
+`_snapshot_exists(recorded_at, stat_type, constellation_id)` prevents duplicate rows. Backfill passes `skip_existing=True` so re-runs are safe.
+
+---
+
+## Snapshot types (Meshtastic)
+
+| `stat_type` | Scope | `value` JSON shape |
+| --- | --- | --- |
+| `online_nodes` | Global + per-`Constellation` | `{"count": int, "window_hours": int}` |
+| `packet_volume` | **Global only** | `{"count": int, "by_type": {…}}` |
+| `new_nodes` | Global + per-`Constellation` | `{"count": int}` |
+
+`constellation_id` is `null` on the model for global scope.
+
+### `online_nodes`
+
+**Window:** `threshold = recorded_at - ONLINE_NODE_WINDOW_HOURS` (env, default **2**). A node counts as “online” if heard at or after `threshold` relative to the snapshot hour boundary.
+
+| Scope | Query (normal collection) |
+| --- | --- |
+| Global | `ObservedNode.objects.filter(last_heard__gte=threshold).count()` — **all protocols today** (MC nodes included if they have `last_heard`) |
+| Per-constellation | Distinct `packet__from_int` on `PacketObservation` where `observer__constellation=…` and `rx_time__gte=threshold` |
+
+**Backfill global variant:** `use_raw_packet_for_global=True` counts distinct `from_int` on `MtRawPacket` with `first_reported_time` in `[threshold, recorded_at]` instead of `last_heard`. Used when historical `last_heard` may not extend far enough (bulk-imported history).
+
+### `packet_volume`
+
+**Bucket:** `[recorded_at, recorded_at + 1 hour)` on `MtRawPacket.first_reported_time`.
+
+**Total:** count of rows in bucket after exclusions.
+
+**`by_type` keys** (MTI subclass filters in `PACKET_TYPE_FILTERS`):
+
+| Key | Filter |
+| --- | --- |
+| `text_message` | `messagepacket` present |
+| `position` | `positionpacket` |
+| `node_info` | `nodeinfopacket` |
+| `device_metrics` | `devicemetricspacket` |
+| `local_stats` | `localstatspacket` |
+| `environment_metrics` | `environmentmetricspacket` |
+| `traceroute` | `traceroutepacket` |
+
+**Self-ingested device metrics exclusion:** rows where the packet is device metrics **and** every `PacketObservation` has `observer.meshtastic_node_id == packet.from_int` are excluded (feeder hearing only itself).
+
+No per-constellation `packet_volume` snapshots exist for Meshtastic.
+
+### `new_nodes`
+
+Two modes:
+
+| Mode | When | Global count |
+| --- | --- | --- |
+| **Hourly beat** | `collect_stats_snapshots` | `ObservedNode` with `created_at >= last_run_started_at` |
+| **Backfill** | `for_backfill=True` | `created_at` in `[recorded_at, recorded_at + 1h)` |
+
+`last_run_started_at` comes from the most recent **global** `new_nodes` snapshot’s `recorded_at` (`_get_last_run_started_at()`). First run uses `created_at__isnull=False` (all nodes with a timestamp).
+
+**Per-constellation:** count `ObservedNode` rows whose `meshtastic_node_id` appears in `PacketObservation` from feeders in that constellation (with the same time filter as global — delta or hour window). Uses `meshtastic_node_id__in=observed_node_ids` from packet observations.
+
+---
+
+## Environment
+
+| Variable | Default | Used by |
+| --- | --- | --- |
+| `ONLINE_NODE_WINDOW_HOURS` | `2` | `online_nodes` snapshot `window_hours` and threshold |
+
+See also [RECENCY.md](../../RECENCY.md) § `stats/`.
+
+---
+
+## HTTP API
+
+Base path: `/api/stats/` ([`stats/urls.py`](../../../Meshflow/stats/urls.py)).
+
+### Stored snapshots
+
+| Endpoint | Auth | Query params |
+| --- | --- | --- |
+| `GET /api/stats/snapshots/` | Guest read | `stat_type`, `constellation_id` (`-1` = global), `recorded_at_after`, `recorded_at_before`, pagination |
+
+Response: paginated `StatsSnapshot` (`recorded_at`, `stat_type`, `constellation_id`, `value`).
+
+OpenAPI enum for `stat_type` today: `online_nodes`, `new_nodes`, `packet_volume`.
+
+### Live aggregation (Meshtastic `node_id` = decimal nodenum)
+
+| Endpoint | Auth | Notes |
+| --- | --- | --- |
+| `GET /api/stats/global/` | Guest read | All `MtRawPacket`; one `packets` count per interval (no per-type breakdown) |
+| `GET /api/stats/nodes/{node_id}/packets/` | Authenticated | Packets **from** node (`from_int`); per-type counts per interval; device-metrics exclusion |
+| `GET /api/stats/nodes/{node_id}/received/` | Authenticated | `PacketObservation` as **managed** feeder; per-type by `rx_time` |
+| `GET /api/stats/nodes/{node_id}/neighbours/` | Authenticated | Counts by source (relay or `from_int`); LSB ambiguity handling |
+
+**Common query params** (`parse_stats_params`):
+
+| Param | Default | Notes |
+| --- | --- | --- |
+| `interval` | `1` | Multiplier for truncation |
+| `interval_type` | `hour` | `hour`, `day`, `week`, `month` |
+| `start_date` / `end_date` | optional | ISO 8601 or `YYYY-MM-DD` |
+| Month interval | — | Approximated as **30 days** in `get_interval_delta` |
+
+Path param `node_id` is **Meshtastic numeric nodenum**; handlers filter `ObservedNode` / `ManagedNode` with `protocol=MESHTASTIC`.
+
+---
+
+## UI consumers (meshflow-ui)
+
+| Component | API | `stat_type` / endpoint |
+| --- | --- | --- |
+| `MeshStatsSection` | Snapshots | `online_nodes`, `new_nodes`, `packet_volume` |
+| `PacketStatsChartFromSnapshots` | `GET /api/stats/snapshots/?stat_type=packet_volume` | Global rows only (`constellation_id === null`) |
+| `OnlineNodesChart` | Snapshots | `online_nodes` or `new_nodes` |
+| `PacketStatsChart` / `PacketTypeChart` | Live | `GET /api/stats/global/` or per-node |
+| Hooks | `useStatsSnapshots`, `usePacketStats` | [`usePacketStats.ts`](https://github.com/pskillen/meshflow-ui/blob/main/src/hooks/api/usePacketStats.ts) |
+
+Client aggregates hourly snapshot points into 6 h / daily buckets ([`stats-aggregation.ts`](https://github.com/pskillen/meshflow-ui/blob/main/src/lib/stats-aggregation.ts)): `packet_volume` **sums** counts; `online_nodes` **averages** within a bucket.
+
+---
+
+## Operations
+
+```bash
+cd Meshflow && source ../venv/bin/activate
+
+# Synchronous backfill (Celery task inline)
+python manage.py backfill_stats_snapshots --days 30
+
+# Or enqueue
+# celery -A Meshflow call stats.tasks.backfill_stats_snapshots --kwargs='{"days": 30}'
+```
+
+**Verify recent snapshots:**
+
+```bash
+python manage.py shell -c "
+from stats.models import StatsSnapshot
+print(StatsSnapshot.objects.order_by('-recorded_at')[:5].values('recorded_at','stat_type','value'))
+"
+```
+
+---
+
+## Known gaps (Meshtastic doc scope)
+
+- Global `online_nodes` / `new_nodes` counts are not filtered to `protocol=MESHTASTIC` — MeshCore observed nodes can appear once they have `last_heard` / `created_at`. **Bug:** [#365](https://github.com/pskillen/meshflow-api/issues/365) (fix planned in [#329](https://github.com/pskillen/meshflow-api/issues/329)).
+- Live stats views do not accept MeshCore identity (pubkey / `internal_id`).
+- `packet_volume` has no constellation-scoped snapshots.
+- Traceroute success daily stats use a different `stat_type` (`tr_success_daily`) — not covered here.
+
+See [meshcore.md](meshcore.md) for planned MC snapshot types.

--- a/docs/features/packet-stats/packet-stats-outstanding.md
+++ b/docs/features/packet-stats/packet-stats-outstanding.md
@@ -1,0 +1,23 @@
+# Packet statistics (MeshCore snapshots) — outstanding
+
+Items **skipped**, **incomplete**, or **discovered during execution** — not the [#329](https://github.com/pskillen/meshflow-api/issues/329) plan’s future phases.
+
+**Tracking:** [meshflow-api#329](https://github.com/pskillen/meshflow-api/issues/329)
+
+---
+
+## Documentation
+
+- [x] **RECENCY.md** § `stats/` — link to [packet-stats/README.md](README.md)
+- [x] **features/README.md** — packet-stats under Stats & dashboard
+
+## Implementation (#329 Task 2+)
+
+- [ ] Hourly `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` collectors
+- [ ] OpenAPI `stat_type` enum extension
+- [ ] Unit tests mirroring `stats/tests/test_tasks.py`
+- [ ] meshflow-ui dashboard protocol / MC charts (separate UI issue)
+
+## Bug (fix in #329 PR)
+
+- [ ] [#365](https://github.com/pskillen/meshflow-api/issues/365) — MT `online_nodes` / `new_nodes` snapshots must filter `ObservedNode` to `protocol=MESHTASTIC` (tracked in plan + #329)

--- a/docs/features/packet-stats/packet-stats-outstanding.md
+++ b/docs/features/packet-stats/packet-stats-outstanding.md
@@ -20,7 +20,7 @@ Items **skipped**, **incomplete**, or **discovered during execution** — not th
 
 ## Implementation (#329 — UI Task 3, meshflow-ui)
 
-- [ ] Main dashboard overlay + protocol dashboard pages + nav (meshflow-ui PR)
+- [x] Main dashboard overlay + protocol dashboard pages + nav — [meshflow-ui#306](https://github.com/pskillen/meshflow-ui/pull/306)
 
 ## Bug (#365)
 

--- a/docs/features/packet-stats/packet-stats-outstanding.md
+++ b/docs/features/packet-stats/packet-stats-outstanding.md
@@ -13,15 +13,15 @@ Items **skipped**, **incomplete**, or **discovered during execution** — not th
 
 ## Implementation (#329 — API Task 2)
 
-- [ ] Hourly `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` collectors
-- [ ] OpenAPI `stat_type` enum extension
-- [ ] Unit tests mirroring `stats/tests/test_tasks.py`
-- [ ] (Optional) `recent_counts?protocol=` for main dashboard MT/MC table
+- [x] Hourly `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` collectors
+- [x] OpenAPI `stat_type` enum extension
+- [x] Unit tests in `stats/tests/test_mc_snapshots.py`
+- [x] `recent_counts?protocol=` for main dashboard MT/MC table
 
 ## Implementation (#329 — UI Task 3, meshflow-ui)
 
-See plan § Task 3: main dashboard overlay, protocol dashboards, nav reorder (MC Managed nodes under Nodes; no MC traceroutes).
+- [ ] Main dashboard overlay + protocol dashboard pages + nav (meshflow-ui PR)
 
-## Bug (fix in #329 PR)
+## Bug (#365)
 
-- [ ] [#365](https://github.com/pskillen/meshflow-api/issues/365) — MT `online_nodes` / `new_nodes` snapshots must filter `ObservedNode` to `protocol=MESHTASTIC` (tracked in plan + #329)
+- [x] MT `online_nodes` / `new_nodes` filter `protocol=MESHTASTIC`

--- a/docs/features/packet-stats/packet-stats-outstanding.md
+++ b/docs/features/packet-stats/packet-stats-outstanding.md
@@ -11,12 +11,16 @@ Items **skipped**, **incomplete**, or **discovered during execution** — not th
 - [x] **RECENCY.md** § `stats/` — link to [packet-stats/README.md](README.md)
 - [x] **features/README.md** — packet-stats under Stats & dashboard
 
-## Implementation (#329 Task 2+)
+## Implementation (#329 — API Task 2)
 
 - [ ] Hourly `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` collectors
 - [ ] OpenAPI `stat_type` enum extension
 - [ ] Unit tests mirroring `stats/tests/test_tasks.py`
-- [ ] meshflow-ui dashboard protocol / MC charts (separate UI issue)
+- [ ] (Optional) `recent_counts?protocol=` for main dashboard MT/MC table
+
+## Implementation (#329 — UI Task 3, meshflow-ui)
+
+See plan § Task 3: main dashboard overlay, protocol dashboards, nav reorder (MC Managed nodes under Nodes; no MC traceroutes).
 
 ## Bug (fix in #329 PR)
 

--- a/docs/features/packet-stats/packet-stats-progress.md
+++ b/docs/features/packet-stats/packet-stats-progress.md
@@ -8,7 +8,11 @@
 
 ## Overall status
 
-**Status:** In progress (API + UI ready for PR)
+**Status:** Complete (pending merge + deploy)
+
+**PR (API):** https://github.com/pskillen/meshflow-api/pull/366 — closes #329, #365
+
+**PR (UI):** https://github.com/pskillen/meshflow-ui/pull/306
 
 **Branch (API):** `api-329/pskillen/packet-stats-docs`
 

--- a/docs/features/packet-stats/packet-stats-progress.md
+++ b/docs/features/packet-stats/packet-stats-progress.md
@@ -10,7 +10,7 @@
 
 **Status:** In progress (Task 1 doc largely complete)
 
-**Branch:** _(not created yet)_
+**Branch:** `api-329/pskillen/packet-stats-docs`
 
 ---
 

--- a/docs/features/packet-stats/packet-stats-progress.md
+++ b/docs/features/packet-stats/packet-stats-progress.md
@@ -2,61 +2,66 @@
 
 **Tracking:** [meshflow-api#329](https://github.com/pskillen/meshflow-api/issues/329) (parent [#266](https://github.com/pskillen/meshflow-api/issues/266))  
 **Plan:** `.cursor/plans/#329_mc_stats_snapshots_94705979.plan.md`  
-**Repos:** meshflow-api (this work); meshflow-ui deferred
+**Repos:** meshflow-api, meshflow-ui
 
 ---
 
 ## Overall status
 
-**Status:** In progress (Task 1 doc largely complete)
+**Status:** In progress (API + UI ready for PR)
 
-**Branch:** `api-329/pskillen/packet-stats-docs`
+**Branch (API):** `api-329/pskillen/packet-stats-docs`
+
+**Branch (UI):** `api-329/pskillen/mc-stats-ui`
 
 ---
 
 ## Task 1 — Document Meshtastic stats
 
-**Status:** In progress
+**Status:** Complete
 
 **Delivered**
 
-- Feature doc hub: [README.md](README.md)
-- Reverse-engineered MT behaviour: [meshtastic.md](meshtastic.md)
-- Feature-docs skill: [.cursor/rules/mf-feature-docs/SKILL.md](../../../.cursor/rules/mf-feature-docs/SKILL.md)
-- Nascent MC plan doc: [meshcore.md](meshcore.md)
-- Progress / outstanding pair (this file + [packet-stats-outstanding.md](packet-stats-outstanding.md))
-
-**Still to do**
-
-- Optional: trim duplicate #329 path `docs/features/stats/meshtastic_packets.md` if we standardize on `packet-stats/` only
-
-**Cross-links done:** [RECENCY.md](../../RECENCY.md) § `stats/`, [features/README.md](../README.md), [phase-2-outstanding.md](../meshcore/phase-2-outstanding.md) (#329 doc path)
+- [docs/features/packet-stats/](README.md) hub + [meshtastic.md](meshtastic.md) + [meshcore.md](meshcore.md)
+- RECENCY + features README cross-links
 
 ---
 
-## Related bug
+## Task 2 — API
 
-**[#365](https://github.com/pskillen/meshflow-api/issues/365)** — MT `online_nodes` / `new_nodes` include MC `ObservedNode` rows; fix in #329 implementation pass (see plan § MT protocol filter).
-
----
-
-## Task 2 — MeshCore snapshot collectors
-
-**Status:** Not started
+**Status:** Complete (pending PR merge)
 
 **Delivered**
 
-- _(none)_
+- [#365](https://github.com/pskillen/meshflow-api/issues/365): `protocol=MESHTASTIC` on MT `online_nodes` / `new_nodes`
+- `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` collectors + backfill
+- `recent_counts?protocol=` on observed nodes
+- OpenAPI `stat_type` enum extended
+- Tests: `Meshflow/stats/tests/test_mc_snapshots.py`
 
-**Deploy / verify**
+**Verify**
 
-- After implementation: `python -m pytest Meshflow/stats/ -v`
-- Ops: `python manage.py backfill_stats_snapshots` for MC history
+```bash
+cd Meshflow && source ../venv/bin/activate
+python -m pytest Meshflow/stats/ -v
+```
+
+---
+
+## Task 3 — UI (meshflow-ui)
+
+**Status:** Complete (pending PR)
+
+**Delivered**
+
+- Main `/` dashboard: MT+MC recent counts, overlaid Mesh Stats, node activity removed
+- `/meshtastic/dashboard`, `/meshcore/dashboard`
+- Nav: protocol dashboards first; MC Managed nodes under Nodes
 
 ---
 
 ## Next
 
-1. Finish Task 1 cross-links (RECENCY, features README).
-2. Branch `api-329/<author>/mc-stats-snapshots` from `origin/main`.
-3. Implement `mc_*` collectors in `stats/tasks.py` + tests + OpenAPI + update [meshcore.md](meshcore.md) when shipped.
+1. Push API + UI branches; open PRs (closes #329, #365 on API).
+2. Deploy API; run `backfill_stats_snapshots` for MC history.
+3. Deploy UI after API.

--- a/docs/features/packet-stats/packet-stats-progress.md
+++ b/docs/features/packet-stats/packet-stats-progress.md
@@ -1,0 +1,62 @@
+# Packet statistics (MeshCore snapshots) — progress
+
+**Tracking:** [meshflow-api#329](https://github.com/pskillen/meshflow-api/issues/329) (parent [#266](https://github.com/pskillen/meshflow-api/issues/266))  
+**Plan:** `.cursor/plans/#329_mc_stats_snapshots_94705979.plan.md`  
+**Repos:** meshflow-api (this work); meshflow-ui deferred
+
+---
+
+## Overall status
+
+**Status:** In progress (Task 1 doc largely complete)
+
+**Branch:** _(not created yet)_
+
+---
+
+## Task 1 — Document Meshtastic stats
+
+**Status:** In progress
+
+**Delivered**
+
+- Feature doc hub: [README.md](README.md)
+- Reverse-engineered MT behaviour: [meshtastic.md](meshtastic.md)
+- Feature-docs skill: [.cursor/rules/mf-feature-docs/SKILL.md](../../../.cursor/rules/mf-feature-docs/SKILL.md)
+- Nascent MC plan doc: [meshcore.md](meshcore.md)
+- Progress / outstanding pair (this file + [packet-stats-outstanding.md](packet-stats-outstanding.md))
+
+**Still to do**
+
+- Optional: trim duplicate #329 path `docs/features/stats/meshtastic_packets.md` if we standardize on `packet-stats/` only
+
+**Cross-links done:** [RECENCY.md](../../RECENCY.md) § `stats/`, [features/README.md](../README.md), [phase-2-outstanding.md](../meshcore/phase-2-outstanding.md) (#329 doc path)
+
+---
+
+## Related bug
+
+**[#365](https://github.com/pskillen/meshflow-api/issues/365)** — MT `online_nodes` / `new_nodes` include MC `ObservedNode` rows; fix in #329 implementation pass (see plan § MT protocol filter).
+
+---
+
+## Task 2 — MeshCore snapshot collectors
+
+**Status:** Not started
+
+**Delivered**
+
+- _(none)_
+
+**Deploy / verify**
+
+- After implementation: `python -m pytest Meshflow/stats/ -v`
+- Ops: `python manage.py backfill_stats_snapshots` for MC history
+
+---
+
+## Next
+
+1. Finish Task 1 cross-links (RECENCY, features README).
+2. Branch `api-329/<author>/mc-stats-snapshots` from `origin/main`.
+3. Implement `mc_*` collectors in `stats/tasks.py` + tests + OpenAPI + update [meshcore.md](meshcore.md) when shipped.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4562,6 +4562,16 @@ paths:
             type: boolean
             default: false
             description: Include CLIENT_BASE role nodes
+        - name: protocol
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [meshtastic, meshcore]
+            default: meshtastic
+            description: >
+              Meshtastic (default) returns nodes with infrastructure meshtastic roles.
+              MeshCore returns all observed MeshCore nodes in the time window.
       responses:
         '200':
           description: List of infrastructure nodes

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2483,8 +2483,8 @@ components:
           description: When the snapshot was taken
         stat_type:
           type: string
-          enum: [online_nodes, new_nodes, packet_volume]
-          description: Type of stat
+          enum: [online_nodes, new_nodes, packet_volume, mc_online_nodes, mc_new_nodes, mc_packet_volume]
+          description: Type of stat (mc_* are MeshCore hourly snapshots)
         constellation_id:
           type: integer
           nullable: true
@@ -4470,7 +4470,7 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/MeshProtocol'
-          description: Filter by mesh protocol (meshtastic or meshcore). recent_counts remains Meshtastic-only.
+          description: Filter by mesh protocol (meshtastic or meshcore). Applies to list; use on recent_counts for per-protocol dashboard counts.
         - name: last_heard_after
           in: query
           required: false
@@ -5915,7 +5915,7 @@ paths:
           required: false
           schema:
             type: string
-            enum: [online_nodes, new_nodes, packet_volume]
+            enum: [online_nodes, new_nodes, packet_volume, mc_online_nodes, mc_new_nodes, mc_packet_volume]
             description: Filter by stat type
         - name: constellation_id
           in: query


### PR DESCRIPTION
## Summary

- Document Meshtastic/MeshCore packet stats under `docs/features/packet-stats/` (Task 1).
- Fix [#365](https://github.com/pskillen/meshflow-api/issues/365): MT `online_nodes` / `new_nodes` snapshots filter `ObservedNode` to `protocol=MESHTASTIC`.
- Add hourly MeshCore snapshots: `mc_packet_volume`, `mc_online_nodes`, `mc_new_nodes` (extends `collect_stats_snapshots` / backfill).
- `GET /api/nodes/observed-nodes/recent_counts/?protocol=meshtastic|meshcore` for per-protocol dashboard counts.
- `GET /api/nodes/observed-nodes/infrastructure/?protocol=meshtastic|meshcore` for per-protocol mesh infrastructure pages in the UI.
- OpenAPI: extend `StatsSnapshot.stat_type` enum and document infrastructure `protocol` param.

Part of [#329](https://github.com/pskillen/meshflow-api/issues/329) / epic [#266](https://github.com/pskillen/meshflow-api/issues/266).

**Pair with:** [meshflow-ui#306](https://github.com/pskillen/meshflow-ui/pull/306) — deploy API before UI.

## Testing performed

- `python -m pytest Meshflow/stats/ -v` (including `test_mc_snapshots.py`)
- `python -m pytest Meshflow/nodes/tests/test_node_views.py::test_infrastructure_list_filters_by_protocol -v`
- Docs reviewed against `stats/tasks.py`