### PR TITLE
feat(meshcore): passive path v1 — observation path_hashes + message heard display (#267)

### DIFF
--- a/Meshflow/meshcore_packets/migrations/0003_remove_meshcorerawpacket_path_hashes.py
+++ b/Meshflow/meshcore_packets/migrations/0003_remove_meshcorerawpacket_path_hashes.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("meshcore_packets", "0002_rename_meshcore_raw_prefix_hash_idx_meshcore_pa_from_pu_8e7820_idx_and_more"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="meshcorerawpacket",
+            name="path_hashes",
+        ),
+    ]

--- a/Meshflow/meshcore_packets/models.py
+++ b/Meshflow/meshcore_packets/models.py
@@ -37,7 +37,6 @@ class MeshCoreRawPacket(models.Model):
     rx_rssi = models.FloatField(null=True, blank=True)
     rx_snr = models.FloatField(null=True, blank=True)
     route_typename = models.CharField(max_length=32, null=True, blank=True)
-    path_hashes = models.JSONField(null=True, blank=True)
     raw_json = models.JSONField()
     first_reported_time = models.DateTimeField(default=timezone.now, db_index=True)
 

--- a/Meshflow/meshcore_packets/serializers.py
+++ b/Meshflow/meshcore_packets/serializers.py
@@ -106,7 +106,6 @@ class MeshCorePacketIngestSerializer(serializers.Serializer):
             "rx_rssi": validated_data.get("rx_rssi"),
             "rx_snr": validated_data.get("rx_snr"),
             "route_typename": validated_data.get("route_typename"),
-            "path_hashes": validated_data.get("path_hashes"),
             "raw_json": validated_data,
         }
 
@@ -130,7 +129,8 @@ class MeshCorePacketIngestSerializer(serializers.Serializer):
     def _ensure_observation(self, packet, observer, validated_data, rx_time):
         channel_idx = validated_data.get("channel_idx")
         channel = resolve_mc_channel(observer, channel_idx) if channel_idx is not None else None
-        obs, _ = MeshCorePacketObservation.objects.get_or_create(
+        path_hashes = validated_data.get("path_hashes")
+        obs, _ = MeshCorePacketObservation.objects.update_or_create(
             packet=packet,
             observer=observer,
             defaults={
@@ -138,7 +138,7 @@ class MeshCorePacketIngestSerializer(serializers.Serializer):
                 "rx_time": rx_time,
                 "rx_rssi": validated_data.get("rx_rssi"),
                 "rx_snr": validated_data.get("rx_snr"),
-                "path_hashes": validated_data.get("path_hashes"),
+                "path_hashes": path_hashes,
             },
         )
         self.observation = obs

--- a/Meshflow/meshcore_packets/services/path_resolution.py
+++ b/Meshflow/meshcore_packets/services/path_resolution.py
@@ -1,0 +1,48 @@
+"""MeshCore path segment display (v1: no hash→ObservedNode linking)."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+HOP_STATUS_UNKNOWN = "unknown"
+HOP_STATUS_AMBIGUOUS = "ambiguous"
+HOP_STATUS_RESOLVED = "resolved"
+
+
+def _normalize_segment(segment: str) -> str:
+    return str(segment).strip().lower().replace("0x", "")
+
+
+def format_path_hop(segment: str) -> dict[str, Any]:
+    """One display hop for a wire path segment (v1: always unknown)."""
+    normalized = _normalize_segment(segment)
+    return {
+        "hash": normalized,
+        "status": HOP_STATUS_UNKNOWN,
+        "node_id_str": None,
+        "internal_id": None,
+        "long_name": None,
+        "ambiguous": False,
+    }
+
+
+def format_path_hops(segments: list[str] | None) -> list[dict[str, Any]]:
+    if not segments:
+        return []
+    return [format_path_hop(segment) for segment in segments]
+
+
+def bulk_format_path_hops(segments: Iterable[str]) -> dict[str, dict[str, Any]]:
+    """Dedupe segments for a single message list response."""
+    cache: dict[str, dict[str, Any]] = {}
+    for segment in segments:
+        normalized = _normalize_segment(segment)
+        if normalized and normalized not in cache:
+            cache[normalized] = format_path_hop(normalized)
+    return cache
+
+
+def path_known_for_segments(segments: list[str] | None) -> bool:
+    """True only when all hops are resolved (v1 always false)."""
+    hops = format_path_hops(segments)
+    return bool(hops) and all(hop.get("status") == HOP_STATUS_RESOLVED for hop in hops)

--- a/Meshflow/meshcore_packets/tests/test_path_hashes_observation.py
+++ b/Meshflow/meshcore_packets/tests/test_path_hashes_observation.py
@@ -1,0 +1,93 @@
+"""path_hashes stored per observation only (#369)."""
+
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from meshcore_packets.models import MeshCorePacketObservation, MeshCoreRawPacket
+from meshcore_packets.tests.conftest import (
+    FEEDER_B_MC_PUBKEY,
+    FEEDER_B_MC_PUBKEY_PREFIX,
+    FEEDER_MC_PUBKEY_PREFIX,
+    feeder_url,
+)
+from nodes.models import NodeAuth
+
+FULL_PUBKEY = "b" * 64
+
+
+@pytest.fixture
+def ingest_client(meshcore_feeder):
+    client = APIClient()
+    client.credentials(HTTP_X_API_KEY=meshcore_feeder["api_key"].key)
+    return client
+
+
+@pytest.fixture
+def second_mc_feeder(create_managed_node, create_node_api_key):
+    from common.protocol import Protocol
+
+    node = create_managed_node(
+        meshtastic_node_id=None,
+        protocol=Protocol.MESHCORE,
+        name="MC Feeder B",
+        mc_pubkey=FEEDER_B_MC_PUBKEY,
+    )
+    api_key = create_node_api_key(constellation=node.constellation)
+    NodeAuth.objects.create(api_key=api_key, node=node)
+    return {"node": node, "api_key": api_key}
+
+
+@pytest.mark.django_db
+def test_path_hashes_on_observation_only_two_feeders(ingest_client, meshcore_feeder, second_mc_feeder):
+    now = timezone.now()
+    base = {
+        "event_type": "advertisement",
+        "payload_type": "advert",
+        "from_pubkey": FULL_PUBKEY,
+        "pkt_hash": 77701,
+        "rx_time": now.timestamp(),
+        "raw": {},
+    }
+    url_a = feeder_url("meshcore-feeder-packet-ingest", FEEDER_MC_PUBKEY_PREFIX)
+    url_b = feeder_url("meshcore-feeder-packet-ingest", FEEDER_B_MC_PUBKEY_PREFIX)
+
+    client_b = APIClient()
+    client_b.credentials(HTTP_X_API_KEY=second_mc_feeder["api_key"].key)
+
+    r1 = ingest_client.post(url_a, {**base, "path_hashes": ["aa", "bb"]}, format="json")
+    r2 = client_b.post(url_b, {**base, "path_hashes": ["cc", "dd"]}, format="json")
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+
+    assert MeshCoreRawPacket.objects.filter(pkt_hash=77701).count() == 1
+    packet = MeshCoreRawPacket.objects.get(pkt_hash=77701)
+    field_names = {f.name for f in MeshCoreRawPacket._meta.get_fields()}
+    assert "path_hashes" not in field_names
+
+    observations = MeshCorePacketObservation.objects.filter(packet=packet).order_by("observer__name")
+    assert observations.count() == 2
+    paths = {tuple(obs.path_hashes or []) for obs in observations}
+    assert paths == {("aa", "bb"), ("cc", "dd")}
+
+
+@pytest.mark.django_db
+def test_observation_path_hashes_updated_on_reingest(ingest_client, meshcore_feeder):
+    now = timezone.now()
+    url = feeder_url("meshcore-feeder-packet-ingest", FEEDER_MC_PUBKEY_PREFIX)
+    payload = {
+        "event_type": "advertisement",
+        "payload_type": "advert",
+        "from_pubkey": FULL_PUBKEY,
+        "pkt_hash": 77702,
+        "rx_time": now.timestamp(),
+        "path_hashes": ["11"],
+        "raw": {},
+    }
+    ingest_client.post(url, payload, format="json")
+    ingest_client.post(url, {**payload, "path_hashes": ["22", "33"]}, format="json")
+
+    packet = MeshCoreRawPacket.objects.get(pkt_hash=77702)
+    obs = MeshCorePacketObservation.objects.get(packet=packet, observer=meshcore_feeder["node"])
+    assert obs.path_hashes == ["22", "33"]

--- a/Meshflow/meshcore_packets/tests/test_path_resolution.py
+++ b/Meshflow/meshcore_packets/tests/test_path_resolution.py
@@ -1,0 +1,37 @@
+"""Tests for MeshCore path segment display (v1)."""
+
+from meshcore_packets.services.path_resolution import (
+    bulk_format_path_hops,
+    format_path_hops,
+    path_known_for_segments,
+)
+
+
+def test_format_path_hops_unknown_status():
+    hops = format_path_hops(["f3bc", "f1"])
+    assert len(hops) == 2
+    assert hops[0] == {
+        "hash": "f3bc",
+        "status": "unknown",
+        "node_id_str": None,
+        "internal_id": None,
+        "long_name": None,
+        "ambiguous": False,
+    }
+    assert hops[1]["hash"] == "f1"
+
+
+def test_format_path_hops_normalizes_hex():
+    hops = format_path_hops(["0xF3BC"])
+    assert hops[0]["hash"] == "f3bc"
+
+
+def test_bulk_format_path_hops_dedupes():
+    cache = bulk_format_path_hops(["aa", "aa", "bb"])
+    assert set(cache.keys()) == {"aa", "bb"}
+    assert cache["aa"]["status"] == "unknown"
+
+
+def test_path_known_false_in_v1():
+    assert path_known_for_segments(["aa", "bb"]) is False
+    assert path_known_for_segments(None) is False

--- a/Meshflow/nodes/positioning.py
+++ b/Meshflow/nodes/positioning.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from nodes.models import LocationSource, ManagedNode, ObservedNode
+from typing import Iterable
+
+from django.core.exceptions import ObjectDoesNotExist
+
+from nodes.models import LocationSource, ManagedNode, ObservedNode, Position
 
 
 def managed_node_default_position_data(managed_node: ManagedNode) -> dict | None:
@@ -25,6 +29,46 @@ def managed_node_default_position_data(managed_node: ManagedNode) -> dict | None
         "sats_in_view": None,
         "pdop": None,
     }
+
+
+def observed_node_lat_lon(node: ObservedNode) -> tuple[float, float] | None:
+    """
+    Lat/lon for map display — same sources as ObservedNode ``latest_position`` API field.
+
+    Prefer ``NodeLatestStatus``; fall back to the newest ``Position`` row when status
+    is missing or has no coordinates (common for MeshCore ADVERT history).
+    """
+    prefetched = getattr(node, "_map_latest_position", None)
+    if prefetched is not None:
+        if prefetched.latitude is not None and prefetched.longitude is not None:
+            return float(prefetched.latitude), float(prefetched.longitude)
+        return None
+
+    try:
+        status = node.latest_status
+    except ObjectDoesNotExist:
+        status = None
+    if status is not None and status.latitude is not None and status.longitude is not None:
+        return float(status.latitude), float(status.longitude)
+
+    position = Position.objects.filter(node=node).order_by("-reported_time").only("latitude", "longitude").first()
+    if position is not None and position.latitude is not None and position.longitude is not None:
+        return float(position.latitude), float(position.longitude)
+    return None
+
+
+def prefetch_observed_node_positions(nodes: Iterable[ObservedNode]) -> None:
+    """Attach ``_map_latest_position`` on each node to avoid N+1 Position lookups."""
+    node_list = list(nodes)
+    if not node_list:
+        return
+    node_ids = [node.internal_id for node in node_list]
+    latest_by_node: dict = {}
+    for position in Position.objects.filter(node_id__in=node_ids).order_by("-reported_time"):
+        if position.node_id not in latest_by_node:
+            latest_by_node[position.node_id] = position
+    for node in node_list:
+        node._map_latest_position = latest_by_node.get(node.internal_id)
 
 
 def managed_node_lat_lon(managed_node: ManagedNode) -> tuple[float, float] | None:

--- a/Meshflow/packets/serializers.py
+++ b/Meshflow/packets/serializers.py
@@ -1614,17 +1614,29 @@ class PrefetchedPacketObservationSerializer(serializers.ModelSerializer):
     observer = ObserverSerializer(read_only=True)
     direct_from_sender = serializers.SerializerMethodField()
     hop_count = serializers.SerializerMethodField()
+    observer_position = serializers.SerializerMethodField()
+    path_known = serializers.SerializerMethodField()
 
     class Meta:
         model = PacketObservation
         fields = [
             "observer",
+            "observer_position",
             "rx_time",
             "rx_rssi",
             "rx_snr",
             "direct_from_sender",
             "hop_count",
+            "path_known",
         ]
+
+    def get_observer_position(self, obj):
+        from text_messages.map_helpers import managed_node_map_position
+
+        return managed_node_map_position(obj.observer)
+
+    def get_path_known(self, obj):
+        return False
 
     def get_direct_from_sender(self, obj):
         """Return True if the packet was heard directly from the sender."""

--- a/Meshflow/text_messages/map_helpers.py
+++ b/Meshflow/text_messages/map_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from common.protocol import Protocol
 from nodes.models import ManagedNode, ObservedNode
-from nodes.positioning import managed_node_lat_lon
+from nodes.positioning import managed_node_lat_lon, observed_node_lat_lon
 
 
 def map_position_dict(latitude, longitude) -> dict | None:
@@ -16,12 +16,9 @@ def map_position_dict(latitude, longitude) -> dict | None:
 def observed_node_map_position(node: ObservedNode | None) -> dict | None:
     if node is None:
         return None
-    try:
-        status = node.latest_status
-    except ObservedNode.latest_status.RelatedObjectDoesNotExist:
-        return None
-    if status.latitude is not None and status.longitude is not None:
-        return map_position_dict(status.latitude, status.longitude)
+    coords = observed_node_lat_lon(node)
+    if coords:
+        return map_position_dict(coords[0], coords[1])
     return None
 
 

--- a/Meshflow/text_messages/map_helpers.py
+++ b/Meshflow/text_messages/map_helpers.py
@@ -1,0 +1,46 @@
+"""Map position helpers for message heard UI."""
+
+from __future__ import annotations
+
+from common.protocol import Protocol
+from nodes.models import ManagedNode, ObservedNode
+from nodes.positioning import managed_node_lat_lon
+
+
+def map_position_dict(latitude, longitude) -> dict | None:
+    if latitude is None or longitude is None:
+        return None
+    return {"latitude": float(latitude), "longitude": float(longitude)}
+
+
+def observed_node_map_position(node: ObservedNode | None) -> dict | None:
+    if node is None:
+        return None
+    try:
+        status = node.latest_status
+    except ObservedNode.latest_status.RelatedObjectDoesNotExist:
+        return None
+    if status.latitude is not None and status.longitude is not None:
+        return map_position_dict(status.latitude, status.longitude)
+    return None
+
+
+def managed_node_map_position(managed_node: ManagedNode) -> dict | None:
+    if managed_node.default_location_latitude is not None and managed_node.default_location_longitude is not None:
+        return map_position_dict(
+            managed_node.default_location_latitude,
+            managed_node.default_location_longitude,
+        )
+    if managed_node.protocol == Protocol.MESHCORE and managed_node.mc_pubkey:
+        obs = (
+            ObservedNode.objects.filter(protocol=Protocol.MESHCORE, mc_pubkey=managed_node.mc_pubkey.lower())
+            .select_related("latest_status")
+            .first()
+        )
+        pos = observed_node_map_position(obs)
+        if pos:
+            return pos
+    coords = managed_node_lat_lon(managed_node)
+    if coords:
+        return map_position_dict(coords[0], coords[1])
+    return None

--- a/Meshflow/text_messages/mc_channel_sender.py
+++ b/Meshflow/text_messages/mc_channel_sender.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 
 from common.protocol import Protocol
 from nodes.models import ObservedNode
+from nodes.positioning import prefetch_observed_node_positions
 
 from .map_helpers import observed_node_map_position
 
@@ -51,6 +52,7 @@ def mc_sender_candidates_for_label(label: str) -> list[ObservedNode]:
 
 
 def _candidates_for_nodes(nodes: list[ObservedNode]) -> list[dict]:
+    prefetch_observed_node_positions(nodes)
     seen: set[str] = set()
     out: list[dict] = []
     for node in nodes:

--- a/Meshflow/text_messages/mc_channel_sender.py
+++ b/Meshflow/text_messages/mc_channel_sender.py
@@ -1,0 +1,89 @@
+"""Infer MeshCore channel message sender from embedded name prefix."""
+
+from __future__ import annotations
+
+from django.db.models import Q
+
+from common.protocol import Protocol
+from nodes.models import ObservedNode
+
+from .map_helpers import observed_node_map_position
+
+
+def parse_mc_channel_sender_label(message_text: str | None) -> str | None:
+    """
+    Channel text often prefixes the body as ``{name}: {message}`` (colon + space only).
+
+    Returns the name segment or None when the pattern does not match.
+    """
+    if not message_text:
+        return None
+    sep = ": "
+    idx = message_text.find(sep)
+    if idx <= 0:
+        return None
+    label = message_text[:idx].strip()
+    body = message_text[idx + len(sep) :]
+    if not label or not body:
+        return None
+    return label
+
+
+def serialize_mc_sender_candidate(node: ObservedNode) -> dict:
+    return {
+        "internal_id": str(node.internal_id),
+        "node_id_str": node.node_id_str,
+        "long_name": node.long_name,
+        "short_name": node.short_name,
+        "position": observed_node_map_position(node),
+    }
+
+
+def mc_sender_candidates_for_label(label: str) -> list[ObservedNode]:
+    if not label:
+        return []
+    return list(
+        ObservedNode.objects.filter(protocol=Protocol.MESHCORE)
+        .filter(Q(long_name__iexact=label) | Q(short_name__iexact=label))
+        .select_related("latest_status")
+        .order_by("-last_heard")
+    )
+
+
+def _candidates_for_nodes(nodes: list[ObservedNode]) -> list[dict]:
+    seen: set[str] = set()
+    out: list[dict] = []
+    for node in nodes:
+        key = str(node.internal_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(serialize_mc_sender_candidate(node))
+    return out
+
+
+def mc_sender_candidates_for_message(message_text: str | None) -> list[dict]:
+    label = parse_mc_channel_sender_label(message_text)
+    if not label:
+        return []
+    return _candidates_for_nodes(mc_sender_candidates_for_label(label))
+
+
+def bulk_mc_sender_candidates_by_label(labels: set[str]) -> dict[str, list[dict]]:
+    if not labels:
+        return {}
+    label_list = list(labels)
+    q = Q()
+    for label in label_list:
+        q |= Q(long_name__iexact=label) | Q(short_name__iexact=label)
+    nodes = ObservedNode.objects.filter(protocol=Protocol.MESHCORE).filter(q).select_related("latest_status")
+    by_label: dict[str, list[ObservedNode]] = {label: [] for label in label_list}
+    label_lower = {label: label.lower() for label in label_list}
+    for node in nodes:
+        for label in label_list:
+            key = label_lower[label]
+            if (node.long_name and node.long_name.lower() == key) or (
+                node.short_name and node.short_name.lower() == key
+            ):
+                by_label[label].append(node)
+    return {label: _candidates_for_nodes(by_label[label]) for label in label_list}

--- a/Meshflow/text_messages/serializers.py
+++ b/Meshflow/text_messages/serializers.py
@@ -8,6 +8,7 @@ from nodes.models import ManagedNode, ObservedNode
 from packets.serializers import PrefetchedPacketObservationSerializer
 
 from .map_helpers import managed_node_map_position, observed_node_map_position
+from .mc_channel_sender import parse_mc_channel_sender_label
 from .models import TextMessage
 
 
@@ -34,7 +35,7 @@ def _mc_heard_observer(managed_node: ManagedNode, mc_observed_by_pubkey: dict) -
         observed = mc_observed_by_pubkey.get(managed_node.mc_pubkey.lower())
     return {
         "node_id_str": managed_node.node_id_str,
-        "internal_id": str(observed.id) if observed else None,
+        "internal_id": str(observed.internal_id) if observed else None,
         "long_name": observed.long_name if observed else managed_node.name,
         "short_name": observed.short_name if observed else managed_node.node_id_str,
         "position": managed_node_map_position(managed_node),
@@ -51,6 +52,8 @@ class TextMessageSerializer(serializers.ModelSerializer):
 
     sender = ObservedNodeSerializer(read_only=True, allow_null=True)
     sender_position = serializers.SerializerMethodField()
+    mc_sender_label = serializers.SerializerMethodField()
+    mc_sender_candidates = serializers.SerializerMethodField()
     channel = serializers.PrimaryKeyRelatedField(queryset=MessageChannel.objects.all())
     heard = serializers.SerializerMethodField()
     packet_id = serializers.SerializerMethodField()
@@ -60,7 +63,31 @@ class TextMessageSerializer(serializers.ModelSerializer):
         return Protocol(obj.protocol).label.lower()
 
     def get_sender_position(self, obj):
-        return observed_node_map_position(obj.sender) if obj.sender_id else None
+        if obj.sender_id:
+            return observed_node_map_position(obj.sender)
+        if obj.protocol == Protocol.MESHCORE:
+            candidates = self.get_mc_sender_candidates(obj)
+            if len(candidates) == 1 and candidates[0].get("position"):
+                return candidates[0]["position"]
+        return None
+
+    def get_mc_sender_label(self, obj):
+        if obj.protocol != Protocol.MESHCORE or obj.sender_id:
+            return None
+        return parse_mc_channel_sender_label(obj.message_text)
+
+    def get_mc_sender_candidates(self, obj):
+        if obj.protocol != Protocol.MESHCORE or obj.sender_id:
+            return []
+        cache = self.context.get("mc_sender_candidates_by_label")
+        if cache is not None:
+            label = parse_mc_channel_sender_label(obj.message_text)
+            if not label:
+                return []
+            return cache.get(label, [])
+        from .mc_channel_sender import mc_sender_candidates_for_message
+
+        return mc_sender_candidates_for_message(obj.message_text)
 
     def get_packet_id(self, obj):
         if obj.original_packet_id:
@@ -80,6 +107,8 @@ class TextMessageSerializer(serializers.ModelSerializer):
             "packet_id",
             "sender",
             "sender_position",
+            "mc_sender_label",
+            "mc_sender_candidates",
             "recipient_meshtastic_node_id",
             "channel",
             "sent_at",

--- a/Meshflow/text_messages/serializers.py
+++ b/Meshflow/text_messages/serializers.py
@@ -3,10 +3,42 @@ from rest_framework import serializers
 from common.protocol import Protocol
 from constellations.models import MessageChannel
 from meshcore_packets.models import MeshCorePacketObservation
-from nodes.models import ObservedNode
+from meshcore_packets.services.path_resolution import format_path_hops, path_known_for_segments
+from nodes.models import ManagedNode, ObservedNode
 from packets.serializers import PrefetchedPacketObservationSerializer
 
+from .map_helpers import managed_node_map_position, observed_node_map_position
 from .models import TextMessage
+
+
+def _normalize_path_segment(segment) -> str:
+    return str(segment).strip().lower().replace("0x", "")
+
+
+def _resolved_path_from_cache(segments, cache):
+    if not segments:
+        return []
+    hops = []
+    for segment in segments:
+        key = _normalize_path_segment(segment)
+        hop = cache.get(key) if cache else None
+        if hop is None:
+            hop = format_path_hops([segment])[0]
+        hops.append(hop)
+    return hops
+
+
+def _mc_heard_observer(managed_node: ManagedNode, mc_observed_by_pubkey: dict) -> dict:
+    observed = None
+    if managed_node.mc_pubkey:
+        observed = mc_observed_by_pubkey.get(managed_node.mc_pubkey.lower())
+    return {
+        "node_id_str": managed_node.node_id_str,
+        "internal_id": str(observed.id) if observed else None,
+        "long_name": observed.long_name if observed else managed_node.name,
+        "short_name": observed.short_name if observed else managed_node.node_id_str,
+        "position": managed_node_map_position(managed_node),
+    }
 
 
 class TextMessageSerializer(serializers.ModelSerializer):
@@ -18,6 +50,7 @@ class TextMessageSerializer(serializers.ModelSerializer):
             fields = ["node_id_str", "long_name", "short_name"]
 
     sender = ObservedNodeSerializer(read_only=True, allow_null=True)
+    sender_position = serializers.SerializerMethodField()
     channel = serializers.PrimaryKeyRelatedField(queryset=MessageChannel.objects.all())
     heard = serializers.SerializerMethodField()
     packet_id = serializers.SerializerMethodField()
@@ -25,6 +58,9 @@ class TextMessageSerializer(serializers.ModelSerializer):
 
     def get_protocol(self, obj):
         return Protocol(obj.protocol).label.lower()
+
+    def get_sender_position(self, obj):
+        return observed_node_map_position(obj.sender) if obj.sender_id else None
 
     def get_packet_id(self, obj):
         if obj.original_packet_id:
@@ -43,6 +79,7 @@ class TextMessageSerializer(serializers.ModelSerializer):
             "original_mc_packet_id",
             "packet_id",
             "sender",
+            "sender_position",
             "recipient_meshtastic_node_id",
             "channel",
             "sent_at",
@@ -54,19 +91,31 @@ class TextMessageSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_heard(self, obj):
+        path_hop_cache = self.context.get("path_hop_cache") or {}
+        mc_observed_by_pubkey = self.context.get("mc_observed_by_pubkey") or {}
+
         if obj.protocol == Protocol.MESHCORE and obj.original_mc_packet_id:
-            observations = MeshCorePacketObservation.objects.filter(
-                packet_id=obj.original_mc_packet_id,
-            ).select_related("observer")
-            return [
-                {
-                    "observer": obs.observer.node_id_str,
-                    "rx_time": obs.rx_time,
-                    "rx_rssi": obs.rx_rssi,
-                    "rx_snr": obs.rx_snr,
-                }
-                for obs in observations
-            ]
+            packet = obj.original_mc_packet
+            observations = getattr(packet, "prefetched_mc_observations", None)
+            if observations is None:
+                observations = MeshCorePacketObservation.objects.filter(packet_id=packet.id).select_related(
+                    "observer",
+                )
+            heard = []
+            for obs in observations:
+                segments = obs.path_hashes or []
+                heard.append(
+                    {
+                        "observer": _mc_heard_observer(obs.observer, mc_observed_by_pubkey),
+                        "rx_time": obs.rx_time,
+                        "rx_rssi": obs.rx_rssi,
+                        "rx_snr": obs.rx_snr,
+                        "path_hashes": segments,
+                        "resolved_path": _resolved_path_from_cache(segments, path_hop_cache),
+                        "path_known": path_known_for_segments(segments),
+                    }
+                )
+            return heard
 
         if hasattr(obj.original_packet, "prefetched_observations"):
             observations = obj.original_packet.prefetched_observations

--- a/Meshflow/text_messages/tests/test_heard_api.py
+++ b/Meshflow/text_messages/tests/test_heard_api.py
@@ -1,0 +1,93 @@
+"""Message list heard[] path and position fields."""
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
+from django.utils import timezone
+
+import pytest
+from rest_framework.test import APIClient
+
+from meshcore_packets.services.channel_sync import reconcile_mc_channels
+from meshcore_packets.tests.conftest import FEEDER_MC_PUBKEY_PREFIX, feeder_url
+from text_messages.models import TextMessage
+
+
+@pytest.fixture
+def ingest_client(meshcore_feeder):
+    client = APIClient()
+    client.credentials(HTTP_X_API_KEY=meshcore_feeder["api_key"].key)
+    return client
+
+
+@pytest.mark.django_db
+def test_mc_message_heard_includes_path_display(meshcore_feeder, ingest_client):
+    reconcile_mc_channels(
+        meshcore_feeder["node"],
+        [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}],
+    )
+    now = timezone.now()
+    url = feeder_url("meshcore-feeder-packet-ingest", FEEDER_MC_PUBKEY_PREFIX)
+    ingest_client.post(
+        url,
+        {
+            "event_type": "channel_message",
+            "payload_type": "channel_text",
+            "channel_idx": 0,
+            "pkt_hash": 88010,
+            "rx_time": now.timestamp(),
+            "text": "heard path ui",
+            "path_hashes": ["ab", "cd"],
+            "raw": {},
+        },
+        format="json",
+    )
+    tm = TextMessage.objects.get(message_text="heard path ui")
+    client = APIClient()
+    list_url = reverse("textmessage-list")
+    response = client.get(list_url, {"channel_id": tm.channel_id})
+    assert response.status_code == 200
+    row = next(item for item in response.data["results"] if item["id"] == str(tm.id))
+    assert row["sender_position"] is None
+    assert len(row["heard"]) == 1
+    heard = row["heard"][0]
+    assert heard["path_hashes"] == ["ab", "cd"]
+    assert heard["path_known"] is False
+    assert heard["resolved_path"][0]["hash"] == "ab"
+    assert heard["resolved_path"][0]["status"] == "unknown"
+    assert "observer" in heard
+    assert heard["observer"]["node_id_str"].startswith("mc:")
+
+
+@pytest.mark.django_db
+def test_message_list_query_count_bounded(meshcore_feeder, ingest_client):
+    """Prefetch observations and bulk path hop cache — no per-message observation query."""
+    reconcile_mc_channels(
+        meshcore_feeder["node"],
+        [{"mc_channel_idx": 0, "name": "Public", "mc_channel_type": "PUBLIC"}],
+    )
+    now = timezone.now()
+    url = feeder_url("meshcore-feeder-packet-ingest", FEEDER_MC_PUBKEY_PREFIX)
+    for idx in range(3):
+        ingest_client.post(
+            url,
+            {
+                "event_type": "channel_message",
+                "payload_type": "channel_text",
+                "channel_idx": 0,
+                "pkt_hash": 88020 + idx,
+                "rx_time": now.timestamp(),
+                "text": f"batch {idx}",
+                "path_hashes": [f"{idx}a"],
+                "raw": {},
+            },
+            format="json",
+        )
+
+    client = APIClient()
+    list_url = reverse("textmessage-list")
+    with CaptureQueriesContext(connection) as ctx:
+        response = client.get(list_url)
+    assert response.status_code == 200
+    assert len(response.data["results"]) >= 3
+    assert len(ctx) <= 25

--- a/Meshflow/text_messages/tests/test_mc_channel_sender.py
+++ b/Meshflow/text_messages/tests/test_mc_channel_sender.py
@@ -1,0 +1,74 @@
+"""MeshCore channel sender label parsing and candidate lookup."""
+
+import pytest
+
+from common.protocol import Protocol
+from nodes.models import NodeLatestStatus, ObservedNode
+from text_messages.mc_channel_sender import (
+    bulk_mc_sender_candidates_by_label,
+    mc_sender_candidates_for_message,
+    parse_mc_channel_sender_label,
+)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("Alice: hello mesh", "Alice"),
+        ("Bob: ", None),
+        ("No colon here", None),
+        ("Bad:no space", None),
+    ],
+)
+def test_parse_mc_channel_sender_label(text, expected):
+    assert parse_mc_channel_sender_label(text) == expected
+
+
+@pytest.mark.django_db
+def test_mc_sender_candidates_match_long_and_short_name():
+    node_a = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="a" * 64,
+        mc_pubkey_prefix="a" * 12,
+        long_name="WMF",
+        short_name="WMF",
+        last_heard=None,
+    )
+    NodeLatestStatus.objects.create(node=node_a, latitude=55.1, longitude=-4.1)
+    ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="b" * 64,
+        mc_pubkey_prefix="b" * 12,
+        long_name="Other",
+        short_name="OTHR",
+        last_heard=None,
+    )
+    dup = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="c" * 64,
+        mc_pubkey_prefix="c" * 12,
+        long_name="WMF",
+        short_name="WM2",
+        last_heard=None,
+    )
+    candidates = mc_sender_candidates_for_message("WMF: ping")
+    ids = {c["internal_id"] for c in candidates}
+    assert str(node_a.internal_id) in ids
+    assert str(dup.internal_id) in ids
+    assert len(candidates) == 2
+    assert candidates[0]["position"] is not None or candidates[1]["position"] is not None
+
+
+@pytest.mark.django_db
+def test_bulk_mc_sender_candidates_by_label():
+    ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="d" * 64,
+        mc_pubkey_prefix="d" * 12,
+        long_name="Zed",
+        short_name="ZED",
+        last_heard=None,
+    )
+    result = bulk_mc_sender_candidates_by_label({"Zed", "Missing"})
+    assert len(result["Zed"]) == 1
+    assert result["Missing"] == []

--- a/Meshflow/text_messages/tests/test_mc_channel_sender.py
+++ b/Meshflow/text_messages/tests/test_mc_channel_sender.py
@@ -1,9 +1,11 @@
 """MeshCore channel sender label parsing and candidate lookup."""
 
+from django.utils import timezone
+
 import pytest
 
 from common.protocol import Protocol
-from nodes.models import NodeLatestStatus, ObservedNode
+from nodes.models import MeshCoreLocationSource, NodeLatestStatus, ObservedNode, Position
 from text_messages.mc_channel_sender import (
     bulk_mc_sender_candidates_by_label,
     mc_sender_candidates_for_message,
@@ -57,6 +59,32 @@ def test_mc_sender_candidates_match_long_and_short_name():
     assert str(dup.internal_id) in ids
     assert len(candidates) == 2
     assert candidates[0]["position"] is not None or candidates[1]["position"] is not None
+
+
+@pytest.mark.django_db
+def test_mc_sender_candidate_position_from_latest_position_row():
+    """Position when only Position history exists (NodeLatestStatus empty)."""
+    node = ObservedNode.objects.create(
+        protocol=Protocol.MESHCORE,
+        mc_pubkey="e" * 64,
+        mc_pubkey_prefix="e" * 12,
+        long_name="MapNode",
+        short_name="MAP",
+        last_heard=None,
+    )
+    NodeLatestStatus.objects.create(node=node, latitude=None, longitude=None)
+    now = timezone.now()
+    Position.objects.create(
+        node=node,
+        reported_time=now,
+        logged_time=now,
+        latitude=55.99,
+        longitude=-4.09,
+        meshcore_location_source=MeshCoreLocationSource.ADVERT,
+    )
+    candidates = mc_sender_candidates_for_message("MapNode: test")
+    assert len(candidates) == 1
+    assert candidates[0]["position"] == {"latitude": 55.99, "longitude": -4.09}
 
 
 @pytest.mark.django_db

--- a/Meshflow/text_messages/views.py
+++ b/Meshflow/text_messages/views.py
@@ -2,15 +2,18 @@ from django.db import models
 from django.db.models import Q
 
 from rest_framework import viewsets
+from rest_framework.response import Response
 
 from common.drf_permissions import AllowGuestReadOnly, IsAuthenticatedUser
 from common.mesh_node_helpers import MESHTASTIC_BROADCAST_ID
 from common.protocol import Protocol
+from meshcore_packets.models import MeshCorePacketObservation
+from meshcore_packets.services.path_resolution import bulk_format_path_hops
 from nodes.models import ManagedNode, ObservedNode
 from packets.models import PacketObservation
 
 from .models import TextMessage
-from .serializers import TextMessageSerializer
+from .serializers import TextMessageSerializer, _normalize_path_segment
 
 
 class TextMessageViewSet(viewsets.ModelViewSet):
@@ -26,6 +29,7 @@ class TextMessageViewSet(viewsets.ModelViewSet):
         queryset = (
             TextMessage.objects.select_related(
                 "sender",
+                "sender__latest_status",
                 "original_packet",
                 "original_mc_packet",
                 "channel",
@@ -57,18 +61,67 @@ class TextMessageViewSet(viewsets.ModelViewSet):
             | Q(protocol=Protocol.MESHCORE, sender__isnull=True, channel__isnull=False)
         )
 
-        observation_qs = PacketObservation.objects.select_related("observer")
+        mt_observation_qs = PacketObservation.objects.select_related("observer")
+        mc_observation_qs = MeshCorePacketObservation.objects.select_related("observer")
         queryset = queryset.prefetch_related(
-            models.Prefetch("original_packet__observations", queryset=observation_qs, to_attr="prefetched_observations")
+            models.Prefetch(
+                "original_packet__observations",
+                queryset=mt_observation_qs,
+                to_attr="prefetched_observations",
+            ),
+            models.Prefetch(
+                "original_mc_packet__observations",
+                queryset=mc_observation_qs,
+                to_attr="prefetched_mc_observations",
+            ),
         )
 
         return queryset
+
+    def _path_segments_for_messages(self, messages):
+        segments = []
+        for msg in messages:
+            if msg.protocol != Protocol.MESHCORE or not msg.original_mc_packet_id:
+                continue
+            packet = msg.original_mc_packet
+            observations = getattr(packet, "prefetched_mc_observations", None) or []
+            for obs in observations:
+                if obs.path_hashes:
+                    segments.extend(_normalize_path_segment(segment) for segment in obs.path_hashes)
+        return segments
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        messages = page if page is not None else list(queryset)
+        context = self.get_serializer_context()
+        context["path_hop_cache"] = bulk_format_path_hops(self._path_segments_for_messages(messages))
+        serializer = self.get_serializer(messages, many=True, context=context)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
         observer_node_ids = (
             ManagedNode.objects.filter(deleted_at__isnull=True).values_list("meshtastic_node_id", flat=True).distinct()
         )
-        observed_nodes = ObservedNode.objects.filter(meshtastic_node_id__in=observer_node_ids)
+        observed_nodes = ObservedNode.objects.filter(meshtastic_node_id__in=observer_node_ids).select_related(
+            "latest_status",
+        )
         context["observer_nodes_map"] = {n.meshtastic_node_id: n for n in observed_nodes}
+
+        mc_pubkeys = (
+            ManagedNode.objects.filter(
+                deleted_at__isnull=True,
+                protocol=Protocol.MESHCORE,
+                mc_pubkey__isnull=False,
+            )
+            .values_list("mc_pubkey", flat=True)
+            .distinct()
+        )
+        mc_observed = ObservedNode.objects.filter(protocol=Protocol.MESHCORE, mc_pubkey__in=mc_pubkeys).select_related(
+            "latest_status",
+        )
+        context["mc_observed_by_pubkey"] = {node.mc_pubkey.lower(): node for node in mc_observed if node.mc_pubkey}
         return context

--- a/Meshflow/text_messages/views.py
+++ b/Meshflow/text_messages/views.py
@@ -12,6 +12,7 @@ from meshcore_packets.services.path_resolution import bulk_format_path_hops
 from nodes.models import ManagedNode, ObservedNode
 from packets.models import PacketObservation
 
+from .mc_channel_sender import bulk_mc_sender_candidates_by_label, parse_mc_channel_sender_label
 from .models import TextMessage
 from .serializers import TextMessageSerializer, _normalize_path_segment
 
@@ -78,6 +79,15 @@ class TextMessageViewSet(viewsets.ModelViewSet):
 
         return queryset
 
+    def _mc_sender_labels_for_messages(self, messages):
+        labels = set()
+        for msg in messages:
+            if msg.protocol == Protocol.MESHCORE and not msg.sender_id:
+                label = parse_mc_channel_sender_label(msg.message_text)
+                if label:
+                    labels.add(label)
+        return labels
+
     def _path_segments_for_messages(self, messages):
         segments = []
         for msg in messages:
@@ -96,6 +106,9 @@ class TextMessageViewSet(viewsets.ModelViewSet):
         messages = page if page is not None else list(queryset)
         context = self.get_serializer_context()
         context["path_hop_cache"] = bulk_format_path_hops(self._path_segments_for_messages(messages))
+        context["mc_sender_candidates_by_label"] = bulk_mc_sender_candidates_by_label(
+            self._mc_sender_labels_for_messages(messages)
+        )
         serializer = self.get_serializer(messages, many=True, context=context)
         if page is not None:
             return self.get_paginated_response(serializer.data)

--- a/docs/features/meshcore/message-sender.md
+++ b/docs/features/meshcore/message-sender.md
@@ -36,9 +36,23 @@ Each candidate includes: `internal_id`, `node_id_str`, `long_name`, `short_name`
 
 Implementation: `text_messages/mc_channel_sender.py`; list responses bulk-load candidates per page.
 
-## UI (heard map)
+## UI
 
-The message heard map uses `sender_position` when unambiguous. For MC channel text, the UI reads `mc_sender_candidates` and places the sender marker when exactly one candidate has `position`. Multiple matches: list still works; map may omit sender until the user disambiguates (future).
+### Message list header (`message-display-sender.ts`)
+
+MeshCore channel rows have `sender` null. The header label uses `mc_sender_candidates`:
+
+| Candidates | Header | Node link |
+| --- | --- | --- |
+| 0 | Anonymous | none |
+| 1 | Candidate short/long name | MeshCore node detail |
+| >1 | Parsed `mc_sender_label` + “N matches” badge (tooltip lists names) | none |
+
+Consecutive-message grouping uses the single candidate’s `node_id_str`, or `mc-ambiguous:{label}` when multiple.
+
+### Heard map
+
+The heard map uses `sender_position` when unambiguous. For MC channel text, the UI reads `mc_sender_candidates` and places the sender marker when exactly one candidate has `position`. Multiple matches: feeder markers and path lines still render; sender pin omitted with an explanatory overlay.
 
 ## Limitations
 

--- a/docs/features/meshcore/message-sender.md
+++ b/docs/features/meshcore/message-sender.md
@@ -1,0 +1,49 @@
+# MeshCore channel message sender inference
+
+MeshCore **channel** (`channel_message`) text on the wire carries **no sender pubkey** — only `channel_idx` and the message body ([ADR-0001 (node identity)](../packet-ingestion/adr/0001-mc-node-identity.md), [text-message-channels.md](text-message-channels.md)).
+
+`TextMessage.sender` stays `null` for channel text. **Contact/DM** (`contact_message`) still sets `sender` from `from_pubkey_prefix` at ingest.
+
+## On-air text convention
+
+Many clients prefix channel messages as:
+
+```text
+{sender_name}: {message body}
+```
+
+Rules used by the API:
+
+- Delimiter is **colon + single space** (`": "`). `Alice:hi` does not parse.
+- The name is everything before the first `": "`.
+- Empty name or empty body after the delimiter → no label (no candidates).
+
+Example: `WMF: hello mesh` → label `WMF`.
+
+This is **heuristic**, not a MeshCore protocol field. Wrong prefixes or edited bodies produce no match or wrong matches.
+
+## API: `mc_sender_label` and `mc_sender_candidates`
+
+On `GET /api/messages/text/` for MeshCore channel rows (`sender` null):
+
+| Field | Meaning |
+| --- | --- |
+| `mc_sender_label` | Parsed name from `message_text`, or `null` |
+| `mc_sender_candidates` | `ObservedNode` rows where `long_name` or `short_name` equals the label (case-insensitive). Often one node; duplicate display names return multiple. |
+| `sender_position` | Position from `sender` when set; else position of the **only** candidate with known coordinates |
+
+Each candidate includes: `internal_id`, `node_id_str`, `long_name`, `short_name`, `position` (from `NodeLatestStatus` when known).
+
+Implementation: `text_messages/mc_channel_sender.py`; list responses bulk-load candidates per page.
+
+## UI (heard map)
+
+The message heard map uses `sender_position` when unambiguous. For MC channel text, the UI reads `mc_sender_candidates` and places the sender marker when exactly one candidate has `position`. Multiple matches: list still works; map may omit sender until the user disambiguates (future).
+
+## Limitations
+
+- No constellation filter on candidates today (global name match on all MC `ObservedNode` rows).
+- Does not parse other prefix styles (`[Alice]`, etc.).
+- Does not set `TextMessage.sender` FK (display-only inference).
+
+**Related:** [meshcore-path-progress.md](../traceroute/meshcore-path-progress.md) (passive path / heard map).

--- a/docs/features/meshcore/message-sender.md
+++ b/docs/features/meshcore/message-sender.md
@@ -32,7 +32,7 @@ On `GET /api/messages/text/` for MeshCore channel rows (`sender` null):
 | `mc_sender_candidates` | `ObservedNode` rows where `long_name` or `short_name` equals the label (case-insensitive). Often one node; duplicate display names return multiple. |
 | `sender_position` | Position from `sender` when set; else position of the **only** candidate with known coordinates |
 
-Each candidate includes: `internal_id`, `node_id_str`, `long_name`, `short_name`, `position` (from `NodeLatestStatus` when known).
+Each candidate includes: `internal_id`, `node_id_str`, `long_name`, `short_name`, `position` (from `NodeLatestStatus` when set, else the latest `Position` row — same rule as the node detail `latest_position` field).
 
 Implementation: `text_messages/mc_channel_sender.py`; list responses bulk-load candidates per page.
 

--- a/docs/features/meshcore/text-message-channels.md
+++ b/docs/features/meshcore/text-message-channels.md
@@ -11,7 +11,7 @@ How MeshCore **group text** and **channel configuration** flow from the radio th
 
 **Normative ADRs:** [ADR-0002](../packet-ingestion/adr/0002-mc-channel-modelling.md) (channels), [ADR-0003](../packet-ingestion/adr/0003-mc-broadcast-semantics.md) (broadcast vs DM), [ADR-0001](../packet-ingestion/adr/0001-mc-node-identity.md) (sender identity on text).
 
-**Related:** [feeder-bootstrap.md](feeder-bootstrap.md), [README.md](README.md) (phase docs), [MESHCORE_PACKET_FIELDS.md](../packet-ingestion/MESHCORE_PACKET_FIELDS.md).
+**Related:** [feeder-bootstrap.md](feeder-bootstrap.md), [README.md](README.md) (phase docs), [MESHCORE_PACKET_FIELDS.md](../packet-ingestion/MESHCORE_PACKET_FIELDS.md), [message-sender.md](message-sender.md) (channel `Name: body` sender inference).
 
 ---
 

--- a/docs/features/packet-ingestion/README.md
+++ b/docs/features/packet-ingestion/README.md
@@ -18,39 +18,32 @@ signals emitted here and do their own normalisation. Refer to those features'
 own documentation for what they do with the packets — this README intentionally
 stops at "signal emitted".
 
-## Reference docs
+## Documentation map
 
-- [PACKET_FIELDS.md](PACKET_FIELDS.md) — wire-level field reference for every
-packet type accepted by ingestion.
-- [DEDUPLICATION.md](DEDUPLICATION.md) — the rules that decide when two
-ingested packets describe the same on-air transmission.
+| Doc | Contents |
+| --- | --- |
+| **[meshtastic.md](meshtastic.md)** | MT packet-type inventory, bot → API → `MtRawPacket` → business models |
+| **[meshcore.md](meshcore.md)** | MC upload scope, ingest path, Phase 2 gap vs [#266](https://github.com/pskillen/meshflow-api/issues/266) |
+| [PACKET_FIELDS.md](PACKET_FIELDS.md) | MT wire-level fields per portnum / telemetry variant |
+| [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md) | MC capture-verified dump shapes |
+| [DEDUPLICATION.md](DEDUPLICATION.md) | MT dedup window; MC see [adr/0004](adr/0004-mc-dedup-key.md) |
+| [signals.md](signals.md) | MT post-processing signals (MC uses `meshcore_packet_received` in-app) |
+| [adr/](adr/README.md) | MC identity, channels, broadcast, dedup |
 
-Sample raw packet payloads (one per port number) live in
-`[docs/packets/](../../packets/)` at the top of `docs/`.
+Sample JSON: [docs/packets/](../../packets/) (MT by portnum), [docs/packets/meshcore/](../../packets/meshcore/README.md).
 
-## MeshCore (Phase 0.5 — design only)
+## Implementation status
 
-MeshCore (MC) is being added as a second first-class protocol alongside
-Meshtastic (MT). The wire shape is different — Ed25519 pubkeys instead of
-32-bit node ids, no `packet_id`, channel index without a channel hash — so
-the API gets a parallel ingest path rather than coercing MC into the MT
-schema.
+| Protocol | Ingest app | Endpoint | Phase |
+| --- | --- | --- | --- |
+| Meshtastic | `packets` | `POST /api/packets/{node_id}/ingest/` | Production |
+| MeshCore | `meshcore_packets` | `POST /api/meshcore/feeders/{prefix}/packets/ingest/` | Phase 1 MVP (advert + text); [#266](https://github.com/pskillen/meshflow-api/issues/266) for full types |
 
-Phase 0.5 lands the schema decisions only; no models, endpoints, or
-`openapi.yaml` changes yet (those are Phase 1, tracked under
-[meshflow-api#265](https://github.com/pskillen/meshflow-api/issues/265)).
+MeshCore uses a **parallel** schema (pubkeys, `pkt_hash`, no Meshtastic `packet_id`) — see [meshcore.md](meshcore.md) and ADRs under [adr/](adr/README.md).
 
-- [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md) — capture-verified
-field reference, derivative of the Phase 0.4 bundle in
-[meshflow-bot/docs/meshcore_packets/](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets).
-- [adr/](adr/README.md) — ADRs covering MC node identity, channels,
-broadcast semantics, and dedup key. Tracked in
-[meshflow-api#276](https://github.com/pskillen/meshflow-api/issues/276)
-(epic [#264](https://github.com/pskillen/meshflow-api/issues/264)).
-- Representative MC sample JSONs (one per event shape) live in
-[`docs/packets/meshcore/`](../../packets/meshcore/README.md).
+## End-to-end flow (Meshtastic)
 
-## End-to-end Flow
+Protocol-specific tables and diagrams: **[meshtastic.md](meshtastic.md)** (MT), **[meshcore.md](meshcore.md)** (MC).
 
 ```mermaid
 sequenceDiagram

--- a/docs/features/packet-ingestion/meshcore.md
+++ b/docs/features/packet-ingestion/meshcore.md
@@ -42,7 +42,7 @@ Code: `meshflow-bot/src/meshcore/serializers.py`, `src/api/StorageAPI.py` (`stor
 | `contact_text` | `CONTACT_TEXT` (3) | `MeshCoreTextPacket` | `TextMessage` + sender `ObservedNode` from `from_pubkey_prefix`; node-claim path |
 | `raw` | `RAW` (99) | `MeshCoreRawPacket` | **Serializer supports it; bot does not upload `raw` today** |
 
-Also creates **`MeshCorePacketObservation`** per `(packet, observer)` (deduped).
+Also creates or updates **`MeshCorePacketObservation`** per `(packet, observer)` (deduped). Repeater **`path_hashes`** are stored on the observation row only (not on deduped `MeshCoreRawPacket`), so two feeders reporting the same `pkt_hash` can keep different paths. See [ADR-0001 (path hash resolution)](../traceroute/adr/0001-mc-path-hash-resolution.md).
 
 Dedup: `meshcore_packets/services/dedup.py` — `pkt_hash` + time window (see [adr/0004-mc-dedup-key.md](adr/0004-mc-dedup-key.md)).
 

--- a/docs/features/packet-ingestion/meshcore.md
+++ b/docs/features/packet-ingestion/meshcore.md
@@ -1,0 +1,161 @@
+# MeshCore packet ingestion — data path
+
+Reverse-engineered map of how MeshCore (MC) traffic moves from a feeder through **meshflow-bot** into **`meshcore_packets`** and downstream business models. Capture-level field reference: [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md) (derivative of [meshflow-bot `docs/meshcore_packets/`](https://github.com/pskillen/meshflow-bot/tree/main/docs/meshcore_packets)).
+
+Phase 1 MVP is shipped; [epic #266](https://github.com/pskillen/meshflow-api/issues/266) tracks full packet-type parity (advert subclasses, ack/req/resp, telemetry, dual-FK migrations).
+
+---
+
+## What the bot uploads today
+
+`MeshCorePacketSerializer.UPLOADABLE_PAYLOAD_TYPES` = `advert`, `channel_text`, `contact_text` only.
+
+| Bot `event_type` (envelope) | API `payload_type` | Uploaded? |
+| --- | --- | --- |
+| `advertisement` | `advert` | Yes |
+| `rx_log_data` with `payload_typename == ADVERT` | `advert` (+ optional `adv_lat` / `adv_lon` / `adv_name`) | Yes |
+| `channel_message` | `channel_text` | Yes |
+| `contact_message` | `contact_text` | Yes |
+| `rx_log_data` (non-ADVERT, e.g. TEXT_MSG, PATH, REQ, CONTROL) | — | **No** — `MeshCoreSkipUpload` in bot |
+| `control_data`, `discover_response`, `path_update`, `trace_data`, `messages_waiting`, … | — | **No** — capture/dump only unless later phases map them |
+
+Requires `RADIO_PROTOCOL=meshcore` and `MESHCORE_UPLOAD_ENABLED=true`. Otherwise the bot writes JSON under `data/meshcore_packets/` only.
+
+POST: `POST /api/meshcore/feeders/{feeder_pubkey_prefix}/packets/ingest/` — prefix is the feeder’s **12-hex pubkey prefix** (same as WebSocket URL). Auth: `NodeAPIKey` + `MeshCoreFeederPermission`.
+
+Code: `meshflow-bot/src/meshcore/serializers.py`, `src/api/StorageAPI.py` (`store_raw_meshcore_packet`).
+
+### Bot events translated but not uploaded
+
+`meshflow-bot/src/meshcore/translation.py` builds `IncomingPacket` for many `EventType`s (e.g. `ACK`, `PATH_UPDATE`, `RAW_DATA`, `BATTERY`) for local dispatch and dumps; only the three payload types above are serialised for API ingest.
+
+---
+
+## Packet types the API accepts
+
+`MeshCorePacketIngestSerializer` (`meshcore_packets/serializers.py`):
+
+| `payload_type` | `MeshCorePayloadType` | Raw model | Business / side effects |
+| --- | --- | --- | --- |
+| `advert` | `ADVERT` (1) | `MeshCoreRawPacket` | `ObservedNode` upsert (pubkey / prefix); optional `Position` + `NodeLatestStatus` if `adv_lat`/`adv_lon` non-zero; `meshcore_adv_type` on node |
+| `channel_text` | `CHANNEL_TEXT` (2) | `MeshCoreTextPacket` | `TextMessage` (`original_mc_packet`, `protocol=MESHCORE`); channel FK via feeder `channel_idx` |
+| `contact_text` | `CONTACT_TEXT` (3) | `MeshCoreTextPacket` | `TextMessage` + sender `ObservedNode` from `from_pubkey_prefix`; node-claim path |
+| `raw` | `RAW` (99) | `MeshCoreRawPacket` | **Serializer supports it; bot does not upload `raw` today** |
+
+Also creates **`MeshCorePacketObservation`** per `(packet, observer)` (deduped).
+
+Dedup: `meshcore_packets/services/dedup.py` — `pkt_hash` + time window (see [adr/0004-mc-dedup-key.md](adr/0004-mc-dedup-key.md)).
+
+### API short-circuits
+
+| Condition | Response |
+| --- | --- |
+| Top-level `encrypted` | **304**, no write |
+| Invalid body | **400** |
+| Non-MC feeder / wrong prefix | **403** |
+
+---
+
+## End-to-end flow
+
+```mermaid
+flowchart LR
+  subgraph bot [meshflow-bot]
+    MC[meshcore asyncio / events]
+    SER[MeshCorePacketSerializer]
+    U[POST feeders/.../packets/ingest/]
+  end
+  subgraph api [meshflow-api meshcore_packets]
+    V[MeshCorePacketIngestView]
+    Z[MeshCorePacketIngestSerializer]
+    OBS[MeshCorePacketObservation]
+    SIG[meshcore_packet_received]
+    TXT[meshcore_text_packet_received]
+  end
+  subgraph biz [Business models]
+    ON[ObservedNode mc_pubkey / prefix]
+    POS[Position + NodeLatestStatus]
+    TM[TextMessage]
+  end
+  MC --> SER --> U --> V --> Z --> OBS --> SIG --> ON
+  SIG --> POS
+  Z --> TXT --> TM
+```
+
+---
+
+## API → raw storage
+
+| Model | Role |
+| --- | --- |
+| `MeshCoreRawPacket` | Common row: observer, `payload_type`, `event_type`, pubkey fields, `pkt_hash`, RF metadata, `raw_json` |
+| `MeshCoreTextPacket` | Subclass for channel/contact text (`text`, `channel`, `to_pubkey_prefix`) |
+| `MeshCorePacketObservation` | Per-feeder hearing (like MT `PacketObservation`) |
+
+List API (JWT): `GET /api/meshcore/packets/` — filter `payload_type`, `from_pubkey_prefix`.
+
+---
+
+## Raw → business
+
+### `meshcore_packets` app
+
+| Step | Module | Behaviour |
+| --- | --- | --- |
+| All ingests | `receivers.upsert_observed_node_from_meshcore_packet` | `meshcore_packet_received` → `resolve_or_create_mc_observed_node`, `last_heard` |
+| ADVERT + coords | `services/position.apply_advert_position` | `Position.original_mc_packet`, `NodeLatestStatus` |
+| Text | `text_messages.receivers` → `MeshCoreTextMessageService` | `TextMessage.original_mc_packet` |
+
+No dedicated services yet for ack/req/resp/telemetry — **#266** scope.
+
+### Cross-app
+
+| App | Role |
+| --- | --- |
+| `text_messages` | MC text + claims (`try_accept_node_claim` on contact text) |
+| `stats` | `mc_packet_volume` snapshots count `MeshCoreRawPacket` / observations (see [packet-stats/meshcore.md](../packet-stats/meshcore.md)) |
+| `constellations` | `MessageChannel` resolution for `channel_idx` on text + observations |
+
+MC does **not** use the Meshtastic `packets` app or `MtRawPacket` tables.
+
+---
+
+## Identity model (summary)
+
+- Full node: 64-hex Ed25519 pubkey → `ObservedNode.mc_pubkey`, id `mc:{hex}` in bot.
+- Prefix-only senders (channel frames, some DMs): `mc_pubkey_prefix` (12 hex) until a full ADVERT arrives — [adr/0001-mc-node-identity.md](adr/0001-mc-node-identity.md).
+
+---
+
+## Phase 2 gap vs [#266](https://github.com/pskillen/meshflow-api/issues/266)
+
+Captured on air (see [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md)) but **not** end-to-end in API yet:
+
+| Wire / dump area | Epic direction |
+| --- | --- |
+| `rx_log_data` TEXT_MSG, PATH, REQ, RESP, CONTROL | Subclasses + storage-only or business rules |
+| Dedicated `ack` / `req` / `resp` events | Storage models |
+| Telemetry / CayenneLPP | `NodeLatestStatus` + metric receivers |
+| `protocol` + `original_mt_packet` / `original_mc_packet` on shared business tables | Dual-FK migrations with CHECK |
+
+Track execution: [meshcore/phase-2-outstanding.md](../meshcore/phase-2-outstanding.md). Path/traceroute parity ([#267](https://github.com/pskillen/meshflow-api/issues/267)): [traceroute/meshcore-path-progress.md](../traceroute/meshcore-path-progress.md).
+
+---
+
+## Provenance FKs (MC)
+
+| Business model | Link to raw |
+| --- | --- |
+| `TextMessage` | `original_mc_packet` → `MeshCoreTextPacket` |
+| `Position` | `original_mc_packet` → `MeshCoreRawPacket` (ADVERT ingest) |
+
+Meshtastic provenance remains `original_packet` on `TextMessage` only (no MC FK on MT-only paths).
+
+---
+
+## Related docs
+
+- [Packet ingestion hub](README.md)
+- [MESHCORE_PACKET_FIELDS.md](MESHCORE_PACKET_FIELDS.md)
+- [MeshCore phase 1](../meshcore/phase-1-progress.md)
+- [Packet stats (MC)](../packet-stats/meshcore.md)

--- a/docs/features/packet-ingestion/meshtastic.md
+++ b/docs/features/packet-ingestion/meshtastic.md
@@ -1,0 +1,152 @@
+# Meshtastic packet ingestion — data path
+
+Reverse-engineered map of how Meshtastic (MT) traffic moves from a feeder radio through **meshflow-bot** into **meshflow-api** raw tables and downstream business models. Wire field detail lives in [PACKET_FIELDS.md](PACKET_FIELDS.md); dedup rules in [DEDUPLICATION.md](DEDUPLICATION.md).
+
+Parent epic for MeshCore parity: [meshflow-api#266](https://github.com/pskillen/meshflow-api/issues/266).
+
+---
+
+## Packet types the API accepts
+
+Ingestion is keyed on `decoded.portnum` in the JSON body. Anything else returns **400** (`Unknown packet type`).
+
+| `decoded.portnum` | TELEMETRY variant (if applicable) | Raw model (`packets.models`) | Business / side effects |
+| --- | --- | --- | --- |
+| `TEXT_MESSAGE_APP` | — | `MessagePacket` | `TextMessage` (`original_packet` FK); claim tokens via `text_messages`; `text_message_received` signal |
+| `NODEINFO_APP` | — | `NodeInfoPacket` | `ObservedNode` name/role/hw/key fields |
+| `POSITION_APP` | — | `PositionPacket` | `Position` row + `NodeLatestStatus` lat/lon/time |
+| `TELEMETRY_APP` | `deviceMetrics` | `DeviceMetricsPacket` | `DeviceMetrics` + `NodeLatestStatus`; `device_metrics_recorded` → mesh monitoring |
+| `TELEMETRY_APP` | `localStats` | `LocalStatsPacket` | **Raw storage only** — `local_stats_packet_received` is emitted but has **no** `packets/receivers.py` handler (no `BasePacketService`; stats queries count `LocalStatsPacket` rows) |
+| `TELEMETRY_APP` | `environmentMetrics` | `EnvironmentMetricsPacket` | `EnvironmentMetrics` + `NodeLatestStatus` |
+| `TELEMETRY_APP` | `airQualityMetrics` | `AirQualityMetricsPacket` | `AirQualityMetrics` + `NodeLatestStatus` |
+| `TELEMETRY_APP` | `powerMetrics` | `PowerMetricsPacket` | `PowerMetrics` + `NodeLatestStatus` |
+| `TELEMETRY_APP` | `healthMetrics` | `HealthMetricsPacket` | `HealthMetrics` + `NodeLatestStatus` |
+| `TELEMETRY_APP` | `hostMetrics` | `HostMetricsPacket` | `HostMetrics` + `NodeLatestStatus` |
+| `TELEMETRY_APP` | `trafficManagementStats` | `TrafficManagementStatsPacket` | **Raw storage only** — receiver logs; no metrics tables |
+| `TRACEROUTE_APP` | — | `TraceroutePacket` | `AutoTraceRoute` completion, Neo4j export, DX/mesh-monitoring via `auto_traceroute_completed_from_packet` |
+
+Every successful ingest also creates **`PacketObservation`** (per feeder hearing) and runs the generic **`packet_received`** receiver (placeholder `ObservedNode`, `meshtastic_inferred_max_hops` when `hop_start` is present).
+
+### Not ingested (bot or API)
+
+| Stage | Behaviour |
+| --- | --- |
+| Bot | `IGNORE_PORTNUMS` env — portnums skipped before POST |
+| Bot | No `decoded` / encrypted-only — skipped (no upload) |
+| Bot | Self `deviceMetrics` loopback to TCP client — skipped (`is_self_telemetry`) |
+| API | Top-level `encrypted` — **304**, no DB write |
+| API | Unknown `portnum` — **400** |
+| API | `TELEMETRY_APP` without a recognised telemetry object — **400** |
+
+Other Meshtastic portnums (e.g. `ROUTING_APP`, `ADMIN_APP`) are not mapped in `PacketIngestSerializer` today.
+
+---
+
+## End-to-end flow
+
+```mermaid
+flowchart LR
+  subgraph bot [meshflow-bot]
+    R[Meshtastic TCP / pubsub]
+    F[Filter: decoded, not self-telemetry, not IGNORE_PORTNUMS]
+    S[StorageAPIWrapper.store_raw_packet]
+  end
+  subgraph api [meshflow-api packets app]
+    V[PacketIngestView]
+    Z[PacketIngestSerializer → MtRawPacket subclass]
+    O[PacketObservation]
+    SIG[packet_received + *_packet_received]
+    SVC[*PacketService in packets/receivers.py]
+  end
+  subgraph biz [Business models]
+    ON[ObservedNode / NodeLatestStatus]
+    TM[TextMessage]
+    TR[AutoTraceRoute / traceroute graph]
+  end
+  R --> F --> S --> V --> Z --> O --> SIG --> SVC --> ON
+  SVC --> TM
+  SVC --> TR
+```
+
+---
+
+## Bot → API
+
+| Step | Location | Notes |
+| --- | --- | --- |
+| Listen | `meshtastic-bot` `MeshtasticRadio` — `meshtastic.receive` | Builds `IncomingPacket` with Meshtastic-shaped `raw` dict |
+| Filter | `MeshflowBot._on_packet` | See table above |
+| Sanitise | `StorageAPIWrapper.store_raw_packet` | Drops non-JSON `raw` protobuf; base64 `bytes`; fills `channel` |
+| POST | `POST /api/packets/{my_nodenum}/ingest/` | `my_nodenum` = **observer** (feeder), not sender; `NodeAPIKey` auth |
+| Legacy | `POST /api/raw-packet/` | Still supported by bot for older deployments |
+| Failure | `failed_packets_dir` JSON dump | No automatic retry |
+
+Code: `meshflow-bot/src/meshtastic/radio.py`, `src/bot.py`, `src/api/StorageAPI.py`.
+
+---
+
+## API → raw storage
+
+| Step | Location | Notes |
+| --- | --- | --- |
+| Auth | `NodeAPIKeyAuthentication` + `NodeAuthorizationPermission` | Observer `ManagedNode` on `request.auth.node` |
+| Dispatch | `PacketIngestSerializer` | `Meshflow/packets/serializers.py` — portnum → subclass serializer |
+| Dedup | `find_existing_packet(from_int, packet_id, rx_time)` | Reuses one `MtRawPacket` per on-air TX within window; always ensures observation |
+| Persist | `MtRawPacket` hierarchy + `PacketObservation` | See [README — Storage shape](README.md#storage-shape) |
+| Signals | `PacketIngestView` | Type-specific `*_packet_received` + always `packet_received` |
+
+OpenAPI: `openapi.yaml` — `packets` ingest paths.
+
+---
+
+## Raw → business (by app)
+
+### Inside `packets` app (`packets/receivers.py` + `packets/services/`)
+
+All type-specific services extend **`BasePacketService`**: upsert `ObservedNode` (protocol=`MESHTASTIC`), emit `packet_from_node_processed`, update **`last_heard`** (see [RECENCY.md](../../RECENCY.md)), then type logic.
+
+| Service | Primary writes |
+| --- | --- |
+| `TextMessagePacketService` | `TextMessage` + `original_packet` |
+| `NodeInfoPacketService` | `ObservedNode` identity fields |
+| `PositionPacketService` | `Position`, `NodeLatestStatus` |
+| `DeviceMetricsPacketService` | `DeviceMetrics`, `NodeLatestStatus`, `device_metrics_recorded` |
+| `EnvironmentMetricsPacketService` | `EnvironmentMetrics`, `NodeLatestStatus` |
+| `AirQualityMetricsPacketService` | `AirQualityMetrics`, `NodeLatestStatus` |
+| `HealthMetricsPacketService` | `HealthMetrics`, `NodeLatestStatus` |
+| `HostMetricsPacketService` | `HostMetrics`, `NodeLatestStatus` |
+| `PowerMetricsPacketService` | `PowerMetrics`, `NodeLatestStatus` |
+| `TraceroutePacketService` | `AutoTraceRoute` + completion signals |
+
+### Other Django apps (subscribe to ingest / post-processing signals)
+
+| App | Trigger | Outcome |
+| --- | --- | --- |
+| `text_messages` | `message_packet_received` (via packets receiver) | Claims, `text_message_received` |
+| `traceroute` | `traceroute_packet_received` → completion wiring | WS notify, Neo4j |
+| `mesh_monitoring` | `device_metrics_recorded`, `node_last_heard_advanced`, traceroute completion | Watches / presence |
+| `dx_monitoring` | `packet_from_node_processed`, traceroute completion | DX candidates |
+| `stats` | ORM on `MtRawPacket` subclasses | Dashboard packet-type counts (not live ingest) |
+
+Post-processing signal catalogue: [signals.md](signals.md).
+
+---
+
+## Provenance FKs (MT)
+
+| Business model | Link to raw |
+| --- | --- |
+| `TextMessage` | `original_packet` → `MessagePacket` |
+| `Position` | No `original_packet` FK today — history keyed by `node` + `reported_time` |
+| Metrics tables | Historical rows per ingest; latest mirrored on `NodeLatestStatus` |
+
+Dual-protocol `TextMessage.protocol` and CHECK constraints: `text_messages.models`.
+
+---
+
+## Related docs
+
+- [Packet ingestion hub](README.md)
+- [PACKET_FIELDS.md](PACKET_FIELDS.md)
+- [Packet stats (MT counts)](../packet-stats/meshtastic.md)
+- [Traceroute](../traceroute/)

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -2,6 +2,15 @@
 
 The traceroute feature tracks path discovery between Meshtastic nodes on the mesh network. **Core lifecycle** (model, scheduling, dispatch, packet completion, WebSocket status) lives in the **`traceroute`** Django app. **Derived analytics** — Neo4j export and queries, reach/coverage pivots, stats and heatmap HTTP handlers — live in **`traceroute_analytics`**, while public URLs stay under `/api/traceroutes/` for compatibility (see [areas-of-concern](areas-of-concern.md)).
 
+## MeshCore path parity (Phase 3)
+
+MeshCore does not use Meshtastic `TRACEROUTE_APP` / numeric hop lists on the wire. Phase 3 work ([#267](https://github.com/pskillen/meshflow-api/issues/267)) splits into:
+
+- **Passive path** — repeater `path_hashes` on forwarded packets (ingest → per-feeder observations → resolve to `ObservedNode` → UI). Execution tracking: [meshcore-path-progress.md](meshcore-path-progress.md), [meshcore-path-outstanding.md](meshcore-path-outstanding.md). Ingest context: [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md).
+- **Active traceroute** (later) — MC analog of `AutoTraceRoute`, scheduler protocol guards, Neo4j edges labelled by protocol.
+
+Meshtastic sections below remain the reference for the **active** traceroute system today.
+
 ## Overview
 
 - **AutoTraceRoute**: Django model recording each traceroute request (manual or scheduled) and its result.
@@ -79,6 +88,8 @@ Auto-scheduler and permission checks share one notion of a **live** source node 
 
 ## Related Documentation
 
+- [MeshCore path progress](meshcore-path-progress.md) – Phase 3 epic #267 execution log (passive + active TR)
+- [MeshCore path outstanding](meshcore-path-outstanding.md) – deferred / discovered debt for #267
 - [Areas of concern](areas-of-concern.md) – Ownership boundaries for core traceroute, monitoring, DX, analytics, and visualisation
 - [Algorithms](algorithms.md) – Source, strategy, and target selection (including auto reliability)
 - [Permissions](permissions.md) – Canonical rules for who may view and trigger traceroutes

--- a/docs/features/traceroute/README.md
+++ b/docs/features/traceroute/README.md
@@ -6,7 +6,7 @@ The traceroute feature tracks path discovery between Meshtastic nodes on the mes
 
 MeshCore does not use Meshtastic `TRACEROUTE_APP` / numeric hop lists on the wire. Phase 3 work ([#267](https://github.com/pskillen/meshflow-api/issues/267)) splits into:
 
-- **Passive path** — repeater `path_hashes` on forwarded packets (ingest → per-feeder observations → resolve to `ObservedNode` → UI). Execution tracking: [meshcore-path-progress.md](meshcore-path-progress.md), [meshcore-path-outstanding.md](meshcore-path-outstanding.md). Ingest context: [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md).
+- **Passive path** — repeater `path_hashes` on forwarded packets (ingest → per-feeder observations → display hops → UI). ADR: [adr/0001-mc-path-hash-resolution.md](adr/0001-mc-path-hash-resolution.md). Tracking: [meshcore-path-progress.md](meshcore-path-progress.md), [meshcore-path-outstanding.md](meshcore-path-outstanding.md). Ingest: [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md).
 - **Active traceroute** (later) — MC analog of `AutoTraceRoute`, scheduler protocol guards, Neo4j edges labelled by protocol.
 
 Meshtastic sections below remain the reference for the **active** traceroute system today.

--- a/docs/features/traceroute/adr/0001-mc-path-hash-resolution.md
+++ b/docs/features/traceroute/adr/0001-mc-path-hash-resolution.md
@@ -1,0 +1,54 @@
+# ADR-0001 — MeshCore path hash resolution
+
+**Status:** Accepted (v1 display-only)  
+**Date:** 2026-05-27  
+**Tracking:** [meshflow-api#267](https://github.com/pskillen/meshflow-api/issues/267), [#360](https://github.com/pskillen/meshflow-api/issues/360)
+
+## Context
+
+MeshCore forwarded packets may include a repeater **path** as concatenated hex bytes split by `path_hash_size` (see [MESHCORE_PACKET_FIELDS.md](../../packet-ingestion/MESHCORE_PACKET_FIELDS.md)). Feeders upload these as `path_hashes[]` on ingest. Multi-feeder dedup stores one `MeshCoreRawPacket` per on-air transmission but one `MeshCorePacketObservation` per feeder, each with its own path ([#369](https://github.com/pskillen/meshflow-api/issues/369)).
+
+Meshtastic traceroute enrichment maps numeric `node_id` values in `route` JSON to `ObservedNode` rows. MeshCore path segments are **short opaque hashes** (often 1–3 bytes per hop), not full pubkeys.
+
+[ADR-0001 (node identity)](../../packet-ingestion/adr/0001-mc-node-identity.md) defines `mc_pubkey` (64 hex) and `mc_pubkey_prefix` (12 hex) for node identity. Nothing in that ADR or in capture docs proves that an arbitrary path segment equals a suffix or prefix of those fields.
+
+## Section A — Spike (hash derivation)
+
+**Reviewed sources:**
+
+| Source | Finding |
+| --- | --- |
+| Capture JSON (`docs/packets/meshcore/`) | `path`, `path_len`, `path_hash_size` on `rx_log_data` and decoded messages; segments are hex substrings of `path`. |
+| `meshflow-bot` `MeshCorePacketSerializer._path_hashes()` | Splits `path` by `path_hash_size`; no semantic mapping to pubkeys. |
+| `meshcore_py` / firmware | No stable, documented mapping from 1–3 byte path hash → 32-byte Ed25519 pubkey in Meshflow docs at spike time. |
+
+**Conclusion (spike outcome): unproven**
+
+We can reliably **parse and display** path segments per feeder observation. We **cannot** safely map segments to `ObservedNode` rows using `mc_pubkey__iendswith`, prefix match, or `last_heard` tie-breaks without a spec-backed algorithm. False positives would mislead map and traceroute-style UI.
+
+**Follow-up:** Revisit when upstream (MeshCore / `meshcore_py`) documents hash derivation, or when we ingest `path_update` / other events that carry explicit hash→pubkey bindings.
+
+## Section B — v1 API behaviour (shipped in #267 passive path)
+
+1. **`path_hashes`** on `MeshCorePacketObservation` only (not on deduped raw packet row).
+2. **`resolved_path`** on message `heard[]` — display hops, not Meshtastic `route_nodes`:
+
+```json
+{
+  "hash": "f3bcf1",
+  "status": "unknown",
+  "node_id_str": null,
+  "internal_id": null,
+  "long_name": null,
+  "ambiguous": false
+}
+```
+
+3. **`path_known`:** `false` in v1 (UI draws dashed sender→feeder lines; hash tooltips at segment midpoints when applicable).
+4. **No DB lookup** for hop→node in v1. `status=resolved` and non-null `internal_id` are reserved for a future proven matcher.
+
+## Consequences
+
+- Message heard map shows sender, feeder position(s), and **dashed** paths; hop labels show raw hash hex.
+- UI must not link unknown hops to node detail pages.
+- When a proven matcher lands, add tests that fail if heuristic matching is reintroduced without ADR update.

--- a/docs/features/traceroute/meshcore-path-outstanding.md
+++ b/docs/features/traceroute/meshcore-path-outstanding.md
@@ -1,38 +1,37 @@
 # MeshCore path / traceroute parity — outstanding
 
-Items **skipped**, **incomplete**, or **discovered during planning** for [#267](https://github.com/pskillen/meshflow-api/issues/267) — not the full epic backlog (see epic issue + [meshcore-path-progress.md](meshcore-path-progress.md)).
+Items **skipped**, **incomplete**, or **discovered during planning** for [#267](https://github.com/pskillen/meshflow-api/issues/267).
 
 ---
 
-## Passive path — schema & ingest
+## Passive path
 
-- [ ] **#369** — remove `path_hashes` from `meshcore_packets_raw`; observation-only; no prod backfill.
-- [ ] **`_ensure_observation`** — on dedup re-ingest, update observation RF/path fields when observer already has a row (verify `get_or_create` behaviour).
-- [ ] **#360** — ADR: hash segment → `ObservedNode` (collisions, unknown hops).
-- [ ] **#360** — read API `resolved_path` (or nested observations on packet detail).
-- [ ] **#304** — UI passive path (meshflow-ui).
+- [x] **#369** — observation-only `path_hashes` (API branch `api-267/pskillen/meshcore-path`).
+- [x] **#360 (narrowed)** — message `heard[]` path display + positions (not packet list API).
+- [ ] **Proven matcher** — implement hash segment → `ObservedNode` when [ADR §A](adr/0001-mc-path-hash-resolution.md) documents safe rules (no `iendswith` / `last_heard` heuristics in v1).
+- [ ] **`GET /meshcore/packets/`** — optional `resolved_path` on packet list/detail (deferred).
+- [ ] **#304** — UI `HeardPathMap` + heard dialog (meshflow-ui).
 
 ---
 
 ## Bot ([meshflow-bot#119](https://github.com/pskillen/meshflow-bot/issues/119))
 
-- [ ] Unit tests for `_path_hashes()` (1/2/3-byte `path_hash_size`) — core forward behaviour already in production.
-- [ ] Optional: upload `rx_log_data` PATH-only frames (coordinate API payload type if added).
-- [ ] Document limitation: `path_len > 0` but no `path` on decoded `channel_message` / `contact_message` → `path_hashes` often null.
+- [ ] Unit tests for `_path_hashes()` (1/2/3-byte `path_hash_size`) — separate bot PR.
+- [ ] Optional: upload `rx_log_data` PATH-only frames.
+- [ ] Document limitation: `path_len > 0` but no `path` on decoded messages → `path_hashes` often null.
 
 ---
 
 ## Active traceroute (deferred)
 
-- [ ] Spike / ADR: MC active trace vs Meshtastic `TRACEROUTE_APP` + `AutoTraceRoute` lifecycle.
-- [ ] `pick_traceroute_target` protocol guard (MT feeder → MT target only).
-- [ ] Neo4j / heatmap protocol dimension on edges.
-- [ ] MC new-node baseline traceroute analog (if distinct from passive path evidence).
+- [ ] Spike / ADR: MC active trace vs Meshtastic `TRACEROUTE_APP`.
+- [ ] `pick_traceroute_target` protocol guard.
+- [ ] Neo4j / heatmap protocol dimension.
+- [ ] MC new-node baseline traceroute analog.
 
 ---
 
-## Cross-links / doc drift
+## Cross-links
 
-- [ ] Update [#267](https://github.com/pskillen/meshflow-api/issues/267) epic body table when #369 lands (observation-only note).
-- [ ] [#360](https://github.com/pskillen/meshflow-api/issues/360) issue text still says path on `MeshCoreRawPacket` — refresh after #369.
-- [ ] Optional: `flow.md` section “MeshCore passive path” once read API is stable.
+- [ ] Update [#267](https://github.com/pskillen/meshflow-api/issues/267) epic when API PR merges.
+- [ ] Optional: `flow.md` section “MeshCore passive path” once UI lands.

--- a/docs/features/traceroute/meshcore-path-outstanding.md
+++ b/docs/features/traceroute/meshcore-path-outstanding.md
@@ -1,0 +1,38 @@
+# MeshCore path / traceroute parity — outstanding
+
+Items **skipped**, **incomplete**, or **discovered during planning** for [#267](https://github.com/pskillen/meshflow-api/issues/267) — not the full epic backlog (see epic issue + [meshcore-path-progress.md](meshcore-path-progress.md)).
+
+---
+
+## Passive path — schema & ingest
+
+- [ ] **#369** — remove `path_hashes` from `meshcore_packets_raw`; observation-only; no prod backfill.
+- [ ] **`_ensure_observation`** — on dedup re-ingest, update observation RF/path fields when observer already has a row (verify `get_or_create` behaviour).
+- [ ] **#360** — ADR: hash segment → `ObservedNode` (collisions, unknown hops).
+- [ ] **#360** — read API `resolved_path` (or nested observations on packet detail).
+- [ ] **#304** — UI passive path (meshflow-ui).
+
+---
+
+## Bot ([meshflow-bot#119](https://github.com/pskillen/meshflow-bot/issues/119))
+
+- [ ] Unit tests for `_path_hashes()` (1/2/3-byte `path_hash_size`) — core forward behaviour already in production.
+- [ ] Optional: upload `rx_log_data` PATH-only frames (coordinate API payload type if added).
+- [ ] Document limitation: `path_len > 0` but no `path` on decoded `channel_message` / `contact_message` → `path_hashes` often null.
+
+---
+
+## Active traceroute (deferred)
+
+- [ ] Spike / ADR: MC active trace vs Meshtastic `TRACEROUTE_APP` + `AutoTraceRoute` lifecycle.
+- [ ] `pick_traceroute_target` protocol guard (MT feeder → MT target only).
+- [ ] Neo4j / heatmap protocol dimension on edges.
+- [ ] MC new-node baseline traceroute analog (if distinct from passive path evidence).
+
+---
+
+## Cross-links / doc drift
+
+- [ ] Update [#267](https://github.com/pskillen/meshflow-api/issues/267) epic body table when #369 lands (observation-only note).
+- [ ] [#360](https://github.com/pskillen/meshflow-api/issues/360) issue text still says path on `MeshCoreRawPacket` — refresh after #369.
+- [ ] Optional: `flow.md` section “MeshCore passive path” once read API is stable.

--- a/docs/features/traceroute/meshcore-path-progress.md
+++ b/docs/features/traceroute/meshcore-path-progress.md
@@ -1,0 +1,108 @@
+# MeshCore path / traceroute parity — progress
+
+**Epic:** [meshflow-api#267](https://github.com/pskillen/meshflow-api/issues/267) — MeshCore Phase 3 traceroute / path parity (MC analog of Meshtastic `AutoTraceRoute` + analytics).
+
+**Repos:** meshflow-api (primary), meshflow-bot, meshflow-ui.
+
+**Related docs**
+
+- Meshtastic traceroute: [README.md](README.md), [flow.md](flow.md)
+- MC ingest + `path_hashes`: [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md)
+- Outstanding: [meshcore-path-outstanding.md](meshcore-path-outstanding.md)
+
+---
+
+## Overall status
+
+**Status:** In progress (planning + passive-path slice; active MC traceroute not started)
+
+**Branch (docs):** `api-267/pskillen/meshcore-path-docs`
+
+---
+
+## Conceptual split
+
+| Track | Goal | Status |
+| --- | --- | --- |
+| **Passive path** | Hop breadcrumbs on forwarded MC packets (`path_hashes` on ingest → resolve → UI) | Tickets filed; schema fix [#369](https://github.com/pskillen/meshflow-api/issues/369) pending |
+| **Active traceroute** | `AutoTraceRoute` (or sibling) + bot command + scheduler + Neo4j protocol labels | Epic backlog; needs spike/ADR per #267 |
+
+Meshtastic today: active TR drives most topology evidence; MC Phase 3 starts with **passive** evidence because the wire uses repeater hash paths, not numeric node IDs in packets.
+
+---
+
+## Passive path slice (2026-05-26)
+
+**Status:** Not started (API/UI); ingest partially ready
+
+### Bot ingest — `path_hashes` on POST body
+
+**Status:** Core behaviour shipped (ticket still open for tests/optional PATH frames)
+
+- [meshflow-bot#119](https://github.com/pskillen/meshflow-bot/issues/119) — open; `_path_hashes()` in `MeshCorePacketSerializer` when `payload.path` is present on `advert` / `channel_text` / `contact_text`.
+- Production: `path_hashes` visible in DB when wire includes `path` (often null on DMs with only `path_len`).
+
+### API storage
+
+**Status:** Works but wrong shape for multi-feeder
+
+- Ingest writes `path_hashes` on **`MeshCoreRawPacket`** and **`MeshCorePacketObservation`** today (`meshcore_packets/serializers.py`).
+- [#369](https://github.com/pskillen/meshflow-api/issues/369) — drop raw-column; observation-only (same on-air packet, different paths per feeder).
+
+### Resolution + read API
+
+**Status:** Not started
+
+- [#360](https://github.com/pskillen/meshflow-api/issues/360) — hash → `ObservedNode` (`mc_pubkey` / prefix), `resolved_path` on read APIs, ADR for ambiguity.
+
+### UI
+
+**Status:** Not started
+
+- [meshflow-ui#304](https://github.com/pskillen/meshflow-ui/issues/304) — passive route display (depends on #360 + #369).
+
+### Closed / deferred ingest scope
+
+- [#368](https://github.com/pskillen/meshflow-api/issues/368) — bulk “all missing MC packet types” ingest **closed (not planned)**; path gaps tracked here and under #267, not #266.
+
+---
+
+## Documentation (this branch)
+
+**Status:** In progress
+
+- [packet-ingestion/meshtastic.md](../packet-ingestion/meshtastic.md) — MT ingest → business model map.
+- [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md) — MC ingest map + Phase 2 vs #266 gap table.
+- [packet-ingestion/README.md](../packet-ingestion/README.md) — hub updated for MC Phase 1.
+- This file + [meshcore-path-outstanding.md](meshcore-path-outstanding.md).
+
+---
+
+## Active traceroute (epic backlog — not started)
+
+Per [#267](https://github.com/pskillen/meshflow-api/issues/267) body:
+
+1. Spike + ADR: MC vs MT traceroute semantics (`meshcore_py`).
+2. Schema: `AutoTraceRoute.protocol` or `MeshCorePathObservation`.
+3. Scheduler / Celery: never mix MT sources with MC targets.
+4. `traceroute_analytics` / Neo4j protocol on edges.
+5. UI heatmap/topology/coverage protocol filter.
+
+No PRs yet.
+
+---
+
+## Suggested implementation order (for planning)
+
+1. **#369** — observation-only `path_hashes` (unblocks correct multi-feeder data).
+2. **#360** — resolution service + OpenAPI read shape.
+3. **#304** — UI breadcrumbs.
+4. **ADR spike** — active MC TR vs passive-only long term.
+5. Active TR + analytics (epic items 2–5).
+
+---
+
+## Next
+
+- Cursor execution plan for epic #267 (passive slice first).
+- Implement #369 on `api-267/...` feature branch after docs PR merges.

--- a/docs/features/traceroute/meshcore-path-progress.md
+++ b/docs/features/traceroute/meshcore-path-progress.md
@@ -8,15 +8,16 @@
 
 - Meshtastic traceroute: [README.md](README.md), [flow.md](flow.md)
 - MC ingest + `path_hashes`: [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md)
+- ADR (path hash v1 display): [adr/0001-mc-path-hash-resolution.md](adr/0001-mc-path-hash-resolution.md)
 - Outstanding: [meshcore-path-outstanding.md](meshcore-path-outstanding.md)
 
 ---
 
 ## Overall status
 
-**Status:** In progress (planning + passive-path slice; active MC traceroute not started)
+**Status:** In progress (API passive-path slice on feature branch; UI/bot tests pending)
 
-**Branch (docs):** `api-267/pskillen/meshcore-path-docs`
+**Branch (API):** `api-267/pskillen/meshcore-path`
 
 ---
 
@@ -24,85 +25,61 @@
 
 | Track | Goal | Status |
 | --- | --- | --- |
-| **Passive path** | Hop breadcrumbs on forwarded MC packets (`path_hashes` on ingest → resolve → UI) | Tickets filed; schema fix [#369](https://github.com/pskillen/meshflow-api/issues/369) pending |
+| **Passive path** | Hop breadcrumbs on forwarded MC packets (`path_hashes` on ingest → display → UI map) | API #369 + #360 message slice in progress |
 | **Active traceroute** | `AutoTraceRoute` (or sibling) + bot command + scheduler + Neo4j protocol labels | Epic backlog; needs spike/ADR per #267 |
 
 Meshtastic today: active TR drives most topology evidence; MC Phase 3 starts with **passive** evidence because the wire uses repeater hash paths, not numeric node IDs in packets.
 
 ---
 
-## Passive path slice (2026-05-26)
-
-**Status:** Not started (API/UI); ingest partially ready
+## Passive path slice
 
 ### Bot ingest — `path_hashes` on POST body
 
-**Status:** Core behaviour shipped (ticket still open for tests/optional PATH frames)
+**Status:** Core behaviour shipped (tests in meshflow-bot PR)
 
-- [meshflow-bot#119](https://github.com/pskillen/meshflow-bot/issues/119) — open; `_path_hashes()` in `MeshCorePacketSerializer` when `payload.path` is present on `advert` / `channel_text` / `contact_text`.
-- Production: `path_hashes` visible in DB when wire includes `path` (often null on DMs with only `path_len`).
+- [meshflow-bot#119](https://github.com/pskillen/meshflow-bot/issues/119) — `_path_hashes()` when wire `path` present.
 
-### API storage
+### API storage ([#369](https://github.com/pskillen/meshflow-api/issues/369))
 
-**Status:** Works but wrong shape for multi-feeder
+**Status:** Done on `api-267/pskillen/meshcore-path`
 
-- Ingest writes `path_hashes` on **`MeshCoreRawPacket`** and **`MeshCorePacketObservation`** today (`meshcore_packets/serializers.py`).
-- [#369](https://github.com/pskillen/meshflow-api/issues/369) — drop raw-column; observation-only (same on-air packet, different paths per feeder).
+- `path_hashes` on **`MeshCorePacketObservation` only**; dropped from `MeshCoreRawPacket`.
+- Ingest uses `update_or_create` on `(packet, observer)` to refresh path/RF fields.
 
-### Resolution + read API
+### Message API ([#360](https://github.com/pskillen/meshflow-api/issues/360) narrowed)
+
+**Status:** Done on feature branch (message history only)
+
+- `GET /api/messages/text/` — `sender_position`, MT `heard[].observer_position`, MC `heard[]` with `path_hashes`, `resolved_path` (v1 `status=unknown`), `path_known=false`.
+- Prefetch + bulk hop cache; no `resolved_path` on packet list API.
+- ADR: [0001-mc-path-hash-resolution.md](adr/0001-mc-path-hash-resolution.md) — hash→node linking **unproven**; matcher deferred.
+
+### UI ([#304](https://github.com/pskillen/meshflow-ui/issues/304))
 
 **Status:** Not started
 
-- [#360](https://github.com/pskillen/meshflow-api/issues/360) — hash → `ObservedNode` (`mc_pubkey` / prefix), `resolved_path` on read APIs, ADR for ambiguity.
-
-### UI
-
-**Status:** Not started
-
-- [meshflow-ui#304](https://github.com/pskillen/meshflow-ui/issues/304) — passive route display (depends on #360 + #369).
-
-### Closed / deferred ingest scope
-
-- [#368](https://github.com/pskillen/meshflow-api/issues/368) — bulk “all missing MC packet types” ingest **closed (not planned)**; path gaps tracked here and under #267, not #266.
+- `HeardPathMap` + heard dialog (MT + MC).
 
 ---
 
-## Documentation (this branch)
+## Documentation
 
-**Status:** In progress
-
-- [packet-ingestion/meshtastic.md](../packet-ingestion/meshtastic.md) — MT ingest → business model map.
-- [packet-ingestion/meshcore.md](../packet-ingestion/meshcore.md) — MC ingest map + Phase 2 vs #266 gap table.
-- [packet-ingestion/README.md](../packet-ingestion/README.md) — hub updated for MC Phase 1.
-- This file + [meshcore-path-outstanding.md](meshcore-path-outstanding.md).
+- [packet-ingestion/meshtastic.md](../packet-ingestion/meshtastic.md), [meshcore.md](../packet-ingestion/meshcore.md)
+- This file + [meshcore-path-outstanding.md](meshcore-path-outstanding.md)
+- [adr/0001-mc-path-hash-resolution.md](adr/0001-mc-path-hash-resolution.md)
 
 ---
 
 ## Active traceroute (epic backlog — not started)
 
-Per [#267](https://github.com/pskillen/meshflow-api/issues/267) body:
-
-1. Spike + ADR: MC vs MT traceroute semantics (`meshcore_py`).
-2. Schema: `AutoTraceRoute.protocol` or `MeshCorePathObservation`.
-3. Scheduler / Celery: never mix MT sources with MC targets.
-4. `traceroute_analytics` / Neo4j protocol on edges.
-5. UI heatmap/topology/coverage protocol filter.
-
-No PRs yet.
-
----
-
-## Suggested implementation order (for planning)
-
-1. **#369** — observation-only `path_hashes` (unblocks correct multi-feeder data).
-2. **#360** — resolution service + OpenAPI read shape.
-3. **#304** — UI breadcrumbs.
-4. **ADR spike** — active MC TR vs passive-only long term.
-5. Active TR + analytics (epic items 2–5).
+Per [#267](https://github.com/pskillen/meshflow-api/issues/267) body — no PRs yet.
 
 ---
 
 ## Next
 
-- Cursor execution plan for epic #267 (passive slice first).
-- Implement #369 on `api-267/...` feature branch after docs PR merges.
+1. Merge API PR (closes #369, #360 message slice).
+2. UI PR `ui-267/pskillen/meshcore-path` (closes meshflow-ui#304).
+3. Bot unit tests PR for `_path_hashes()`.
+4. Proven hash→`ObservedNode` matcher after upstream spec (ADR §A follow-up).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2661,6 +2661,26 @@ components:
           $ref: '#/components/schemas/MapPosition'
           nullable: true
 
+    McSenderCandidate:
+      type: object
+      description: >
+        ObservedNode matched from MeshCore channel text prefix ``{name}: {body}`` when wire sender id is absent.
+      properties:
+        internal_id:
+          type: string
+          format: uuid
+        node_id_str:
+          type: string
+        long_name:
+          type: string
+          nullable: true
+        short_name:
+          type: string
+          nullable: true
+        position:
+          $ref: '#/components/schemas/MapPosition'
+          nullable: true
+
     MeshCoreHeardObservation:
       type: object
       properties:
@@ -2763,7 +2783,20 @@ components:
           $ref: '#/components/schemas/MapPosition'
           nullable: true
           readOnly: true
-          description: Sender map position from NodeLatestStatus when known
+          description: >
+            Sender map position from linked ObservedNode, or sole MC candidate when exactly one match has coordinates.
+        mc_sender_label:
+          type: string
+          nullable: true
+          readOnly: true
+          description: Name parsed from MC channel text ``{name}: {body}``; null for MT or contact/DM rows.
+        mc_sender_candidates:
+          type: array
+          readOnly: true
+          description: >
+            MC channel messages only — ObservedNodes whose long_name or short_name matches mc_sender_label (0–N).
+          items:
+            $ref: '#/components/schemas/McSenderCandidate'
         heard:
           type: array
           description: >

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -143,6 +143,9 @@ components:
           type: array
           items:
             type: string
+          description: >
+            Repeater path segments for this feeder observation (stored on MeshCorePacketObservation only;
+            not on deduped MeshCoreRawPacket).
         channel_idx:
           type: integer
           nullable: true
@@ -2594,6 +2597,98 @@ components:
           type: integer
           description: The number of hops the packet took to reach the observer
           nullable: true
+        observer_position:
+          $ref: '#/components/schemas/MapPosition'
+          nullable: true
+          description: Feeder map position (default location or linked ObservedNode)
+        path_known:
+          type: boolean
+          description: True when hop positions are known end-to-end (Meshtastic messages always false in v1)
+
+    MapPosition:
+      type: object
+      required: [latitude, longitude]
+      properties:
+        latitude:
+          type: number
+          format: double
+        longitude:
+          type: number
+          format: double
+
+    ResolvedHop:
+      type: object
+      required: [hash, status, ambiguous]
+      properties:
+        hash:
+          type: string
+          description: Lowercase hex path segment from the wire
+        status:
+          type: string
+          enum: [unknown, ambiguous, resolved]
+          description: v1 passive path uses unknown unless a proven matcher resolves the hop
+        node_id_str:
+          type: string
+          nullable: true
+        internal_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: ObservedNode id when status is resolved
+        long_name:
+          type: string
+          nullable: true
+        ambiguous:
+          type: boolean
+
+    HeardObserver:
+      type: object
+      description: MeshCore feeder that heard a message (ManagedNode + optional ObservedNode enrichment)
+      properties:
+        node_id_str:
+          type: string
+        internal_id:
+          type: string
+          format: uuid
+          nullable: true
+        long_name:
+          type: string
+          nullable: true
+        short_name:
+          type: string
+          nullable: true
+        position:
+          $ref: '#/components/schemas/MapPosition'
+          nullable: true
+
+    MeshCoreHeardObservation:
+      type: object
+      properties:
+        observer:
+          $ref: '#/components/schemas/HeardObserver'
+        rx_time:
+          type: string
+          format: date-time
+        rx_rssi:
+          type: number
+          format: float
+          nullable: true
+        rx_snr:
+          type: number
+          format: float
+          nullable: true
+        path_hashes:
+          type: array
+          items:
+            type: string
+          nullable: true
+        resolved_path:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResolvedHop'
+        path_known:
+          type: boolean
+          description: False in v1 (hop positions not linked to map coordinates)
 
     TextMessage:
       type: object
@@ -2664,12 +2759,21 @@ components:
           nullable: true
           description: The packet_id of the message being replied to
           readOnly: true
+        sender_position:
+          $ref: '#/components/schemas/MapPosition'
+          nullable: true
+          readOnly: true
+          description: Sender map position from NodeLatestStatus when known
         heard:
           type: array
-          description: List of nodes that heard this message
-          items:
-            $ref: '#/components/schemas/PacketObservation'
+          description: >
+            Feeders that heard this message. Meshtastic items match PacketObservation (with observer_position).
+            MeshCore items match MeshCoreHeardObservation (path_hashes + resolved_path display hops).
           readOnly: true
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/PacketObservation'
+              - $ref: '#/components/schemas/MeshCoreHeardObservation'
 
     MessageChannel:
       type: object


### PR DESCRIPTION
## Summary

Delivers the meshflow-api slice of epic #267 passive path:

- **#369** — `path_hashes` on `MeshCorePacketObservation` only; dropped from deduped raw packet; `update_or_create` on re-ingest.
- **#360 (narrowed)** — `GET /api/messages/text/` exposes `sender_position`, MT `heard[].observer_position`, MC `heard[]` with observer object, `path_hashes`, `resolved_path` (v1 `status=unknown`), and `path_known=false`. Prefetch + bulk hop cache.
- **ADR** — [0001-mc-path-hash-resolution.md](docs/features/traceroute/adr/0001-mc-path-hash-resolution.md): hash→pubkey mapping **unproven**; no speculative DB matching in v1.
- **MC channel sender inference** — [message-sender.md](docs/features/meshcore/message-sender.md): parse `{name}: {body}` prefix; return `mc_sender_label` + `mc_sender_candidates` (ObservedNode matches by long/short name) for heard-map positioning when unambiguous.

Explicitly **not** in this PR: `resolved_path` on `GET /meshcore/packets/`.

Closes #369
Closes #360

Part of #267

## Testing performed

- `python -m pytest Meshflow/meshcore_packets/ Meshflow/text_messages/ -v`
- `black`, `isort`, `flake8` on changed modules
- Tests: observation-only path_hashes, path display service, message heard API, MC sender label/candidates