### PR TITLE
feat(admin): manually add a managed node

### DIFF
--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.widgets import FilteredSelectMultiple
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
+from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -23,7 +24,7 @@ from common.mesh_node_helpers import (
 from common.protocol import Protocol
 from meshcore_packets.services.channel_apply import apply_mc_channels_to_feeder
 
-from .managed_node_bootstrap import ensure_observed_node_for_managed_node
+from .managed_node_bootstrap import ensure_observed_node_for_managed_node, find_matching_observed_node
 from .models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, NodeLatestStatus, ObservedNode
 
 
@@ -521,6 +522,7 @@ class ManagedNodeAdmin(admin.ModelAdmin):
         "meshtastic_node_id",
         "display_id",
         "name",
+        "observed_node_link",
         "owner",
         "constellation",
         "mc_channel_count",
@@ -568,6 +570,17 @@ class ManagedNodeAdmin(admin.ModelAdmin):
     @admin.display(description=_("Display ID"))
     def display_id(self, obj):
         return obj.node_id_str
+
+    @admin.display(description=_("Observed node"))
+    def observed_node_link(self, obj):
+        try:
+            observed = find_matching_observed_node(obj)
+        except ValueError:
+            return "—"
+        if observed is None:
+            return "—"
+        url = reverse("admin:nodes_observednode_change", args=[observed.pk])
+        return format_html('<a href="{}">{}</a>', url, observed)
 
     @admin.display(description=_("MC channels"))
     def mc_channel_count(self, obj):

--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -44,7 +44,7 @@ class ManagedNodeActiveFilter(admin.SimpleListFilter):
         return queryset
 
 
-MANAGED_NODE_COMMON_FIELDS = (
+MANAGED_NODE_MESHTASTIC_FEEDER_FIELDS = (
     "protocol",
     "meshtastic_node_id",
     "name",
@@ -53,6 +53,16 @@ MANAGED_NODE_COMMON_FIELDS = (
     "allow_auto_traceroute",
     "latlong",
 )
+MANAGED_NODE_MESHCORE_FEEDER_FIELDS = (
+    "protocol",
+    "name",
+    "owner",
+    "constellation",
+    "allow_auto_traceroute",
+    "latlong",
+    "mc_flood_advert_interval_hours",
+)
+MANAGED_NODE_COMMON_FIELDS = MANAGED_NODE_MESHTASTIC_FEEDER_FIELDS
 MANAGED_NODE_CHANNEL_FIELDS = tuple(f"meshtastic_channel_{i}" for i in range(8))
 
 
@@ -344,7 +354,10 @@ class ManagedNodeAdminForm(forms.ModelForm):
     meshtastic_node_id = forms.CharField(
         label=_("Node ID"),
         widget=NodeIdDatalistWidget,
-        help_text=_("Select from observed Meshtastic nodes or enter a decimal id or !hex8."),
+        help_text=_(
+            "Select from observed Meshtastic nodes or enter a decimal id or !hex8. "
+            "A new node id may be entered when bootstrapping a constellation."
+        ),
     )
 
     latlong = LatLongFormField(
@@ -598,8 +611,39 @@ class ManagedNodeAdmin(admin.ModelAdmin):
             return ("display_id", "mc_channels_mirror", "mc_channels_synced_at")
         return ("mc_channels_synced_at",)
 
+    def _protocol_for_admin(self, request, obj):
+        if obj is not None:
+            return obj.protocol
+        if request is not None and request.method == "POST":
+            try:
+                return int(request.POST.get("protocol", Protocol.MESHTASTIC))
+            except TypeError, ValueError:
+                pass
+        return Protocol.MESHTASTIC
+
     def get_fieldsets(self, request, obj=None):
-        common = (_("Feeder"), {"fields": MANAGED_NODE_COMMON_FIELDS})
+        protocol = self._protocol_for_admin(request, obj)
+        if protocol == Protocol.MESHCORE:
+            common = (_("Feeder"), {"fields": MANAGED_NODE_MESHCORE_FEEDER_FIELDS})
+            mc_identity_fields = ("mc_pubkey",) if obj is None else ("mc_pubkey", "display_id")
+            mc_identity = (_("MeshCore identity"), {"fields": mc_identity_fields})
+            if obj is not None and obj.protocol == Protocol.MESHCORE:
+                mc_channels = (
+                    _("MeshCore channels (device mirror)"),
+                    {
+                        "fields": ("mc_channels_mirror", "mc_channels_synced_at"),
+                        "description": _(
+                            "Read-only snapshot from the feeder device (bot channel sync). "
+                            "Edit constellation channel definitions under MeshCore channels, "
+                            "then use the admin action “Push MC channel config to feeder device” "
+                            "to apply this mirror to the radio."
+                        ),
+                    },
+                )
+                return (common, mc_identity, mc_channels)
+            return (common, mc_identity)
+
+        common = (_("Feeder"), {"fields": MANAGED_NODE_MESHTASTIC_FEEDER_FIELDS})
         channels = (
             _("Meshtastic channels"),
             {
@@ -608,21 +652,6 @@ class ManagedNodeAdmin(admin.ModelAdmin):
                 "description": _("Not used for MeshCore feeders."),
             },
         )
-        if obj and obj.protocol == Protocol.MESHCORE:
-            mc_identity = (_("MeshCore identity"), {"fields": ("mc_pubkey", "display_id")})
-            mc_channels = (
-                _("MeshCore channels (device mirror)"),
-                {
-                    "fields": ("mc_channels_mirror", "mc_channels_synced_at"),
-                    "description": _(
-                        "Read-only snapshot from the feeder device (bot channel sync). "
-                        "Edit constellation channel definitions under MeshCore channels, "
-                        "then use the admin action “Push MC channel config to feeder device” "
-                        "to apply this mirror to the radio."
-                    ),
-                },
-            )
-            return (common, mc_identity, mc_channels)
         return (common, channels)
 
 

--- a/Meshflow/nodes/admin.py
+++ b/Meshflow/nodes/admin.py
@@ -23,6 +23,7 @@ from common.mesh_node_helpers import (
 from common.protocol import Protocol
 from meshcore_packets.services.channel_apply import apply_mc_channels_to_feeder
 
+from .managed_node_bootstrap import ensure_observed_node_for_managed_node
 from .models import ManagedNode, ManagedNodeStatus, NodeAPIKey, NodeAuth, NodeLatestStatus, ObservedNode
 
 
@@ -653,6 +654,24 @@ class ManagedNodeAdmin(admin.ModelAdmin):
             },
         )
         return (common, channels)
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if change:
+            return
+        observed, created = ensure_observed_node_for_managed_node(obj)
+        if created:
+            self.message_user(
+                request,
+                _("Created ObservedNode %(node)s for feeder owner.") % {"node": observed.node_id_str},
+                level=messages.SUCCESS,
+            )
+        elif observed.claimed_by_id == obj.owner_id:
+            self.message_user(
+                request,
+                _("Linked feeder to existing ObservedNode %(node)s.") % {"node": observed.node_id_str},
+                level=messages.INFO,
+            )
 
 
 @admin.register(ManagedNodeStatus)

--- a/Meshflow/nodes/managed_node_bootstrap.py
+++ b/Meshflow/nodes/managed_node_bootstrap.py
@@ -27,7 +27,7 @@ def _names_from_managed_node(managed_node: ManagedNode) -> tuple[str, str]:
     return long_name, short_name[:5]
 
 
-def _find_matching_observed_node(managed_node: ManagedNode) -> ObservedNode | None:
+def find_matching_observed_node(managed_node: ManagedNode) -> ObservedNode | None:
     if managed_node.protocol == Protocol.MESHTASTIC:
         if managed_node.meshtastic_node_id is None:
             raise ValueError("Meshtastic managed node requires meshtastic_node_id")
@@ -54,7 +54,7 @@ def ensure_observed_node_for_managed_node(managed_node: ManagedNode) -> tuple[Ob
     When the observed node is unclaimed, sets claimed_by to the managed node owner.
     """
     long_name, short_name = _names_from_managed_node(managed_node)
-    observed = _find_matching_observed_node(managed_node)
+    observed = find_matching_observed_node(managed_node)
     created = False
 
     if observed is None:

--- a/Meshflow/nodes/managed_node_bootstrap.py
+++ b/Meshflow/nodes/managed_node_bootstrap.py
@@ -1,0 +1,80 @@
+"""Bootstrap ObservedNode rows when creating ManagedNodes outside normal mesh flow."""
+
+from __future__ import annotations
+
+from django.db import transaction
+
+from common.mesh_node_helpers import meshtastic_id_to_hex
+from common.meshcore_node_helpers import resolve_or_create_mc_observed_node
+from common.protocol import Protocol
+
+from .models import ManagedNode, ObservedNode
+
+
+def _names_from_managed_node(managed_node: ManagedNode) -> tuple[str, str]:
+    name = (managed_node.name or "").strip()
+    if managed_node.protocol == Protocol.MESHTASTIC:
+        display_id = meshtastic_id_to_hex(managed_node.meshtastic_node_id)
+    else:
+        display_id = managed_node.node_id_str
+    long_name = (name or f"Unknown Node {display_id}")[:50]
+    if len(name) >= 4:
+        short_name = name[:5]
+    elif display_id and len(display_id) >= 4:
+        short_name = display_id[-4:]
+    else:
+        short_name = "????"
+    return long_name, short_name[:5]
+
+
+def _find_matching_observed_node(managed_node: ManagedNode) -> ObservedNode | None:
+    if managed_node.protocol == Protocol.MESHTASTIC:
+        if managed_node.meshtastic_node_id is None:
+            raise ValueError("Meshtastic managed node requires meshtastic_node_id")
+        return ObservedNode.objects.filter(
+            protocol=Protocol.MESHTASTIC,
+            meshtastic_node_id=managed_node.meshtastic_node_id,
+        ).first()
+    if managed_node.protocol == Protocol.MESHCORE:
+        if not managed_node.mc_pubkey:
+            raise ValueError("MeshCore managed node requires mc_pubkey")
+        return ObservedNode.objects.filter(
+            protocol=Protocol.MESHCORE,
+            mc_pubkey=managed_node.mc_pubkey,
+        ).first()
+    raise ValueError(f"Unsupported protocol: {managed_node.protocol}")
+
+
+@transaction.atomic
+def ensure_observed_node_for_managed_node(managed_node: ManagedNode) -> tuple[ObservedNode, bool]:
+    """
+    Ensure a matching ObservedNode exists for a ManagedNode.
+
+    Returns (observed_node, created) where created is True only when a new row was inserted.
+    When the observed node is unclaimed, sets claimed_by to the managed node owner.
+    """
+    long_name, short_name = _names_from_managed_node(managed_node)
+    observed = _find_matching_observed_node(managed_node)
+    created = False
+
+    if observed is None:
+        if managed_node.protocol == Protocol.MESHCORE:
+            observed = resolve_or_create_mc_observed_node(
+                mc_pubkey=managed_node.mc_pubkey,
+                long_name=long_name,
+                short_name=short_name,
+            )
+        else:
+            observed = ObservedNode.objects.create(
+                protocol=Protocol.MESHTASTIC,
+                meshtastic_node_id=managed_node.meshtastic_node_id,
+                long_name=long_name,
+                short_name=short_name,
+            )
+        created = True
+
+    if observed.claimed_by_id is None:
+        observed.claimed_by = managed_node.owner
+        observed.save(update_fields=["claimed_by"])
+
+    return observed, created

--- a/Meshflow/nodes/tests/test_managed_node_admin_form.py
+++ b/Meshflow/nodes/tests/test_managed_node_admin_form.py
@@ -5,6 +5,12 @@ from nodes.admin import MANAGED_NODE_CHANNEL_FIELDS, ManagedNodeAdmin, ManagedNo
 from nodes.models import ManagedNode
 
 
+class _PostRequest:
+    def __init__(self, protocol):
+        self.method = "POST"
+        self.POST = {"protocol": str(protocol)}
+
+
 @pytest.mark.django_db
 def test_managed_node_admin_form_meshcore_clears_meshtastic_node_id(create_user, create_constellation):
     owner = create_user()
@@ -59,3 +65,28 @@ def test_managed_node_admin_fieldsets_include_meshtastic_channels(create_managed
     fieldsets = admin.get_fieldsets(request=None, obj=node)
     channel_section = next(fs for fs in fieldsets if fs[0] == "Meshtastic channels")
     assert channel_section[1]["fields"] == MANAGED_NODE_CHANNEL_FIELDS
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_add_fieldsets_meshcore_show_pubkey():
+    admin = ManagedNodeAdmin(ManagedNode, None)
+    fieldsets = admin.get_fieldsets(request=_PostRequest(Protocol.MESHCORE), obj=None)
+    titles = [section[0] for section in fieldsets]
+    assert "MeshCore identity" in titles
+    assert "Meshtastic channels" not in titles
+    identity = next(section for section in fieldsets if section[0] == "MeshCore identity")
+    assert identity[1]["fields"] == ("mc_pubkey",)
+    feeder = next(section for section in fieldsets if section[0] == "Feeder")
+    assert "meshtastic_node_id" not in feeder[1]["fields"]
+    assert "mc_flood_advert_interval_hours" in feeder[1]["fields"]
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_add_fieldsets_meshtastic_show_node_id_and_channels():
+    admin = ManagedNodeAdmin(ManagedNode, None)
+    fieldsets = admin.get_fieldsets(request=_PostRequest(Protocol.MESHTASTIC), obj=None)
+    titles = [section[0] for section in fieldsets]
+    assert "Meshtastic channels" in titles
+    assert "MeshCore identity" not in titles
+    feeder = next(section for section in fieldsets if section[0] == "Feeder")
+    assert "meshtastic_node_id" in feeder[1]["fields"]

--- a/Meshflow/nodes/tests/test_managed_node_admin_form.py
+++ b/Meshflow/nodes/tests/test_managed_node_admin_form.py
@@ -82,6 +82,23 @@ def test_managed_node_admin_add_fieldsets_meshcore_show_pubkey():
 
 
 @pytest.mark.django_db
+def test_managed_node_admin_observed_node_link(create_managed_node, create_observed_node):
+    managed = create_managed_node()
+    observed = create_observed_node(meshtastic_node_id=managed.meshtastic_node_id)
+    admin = ManagedNodeAdmin(ManagedNode, None)
+    html = admin.observed_node_link(managed)
+    assert str(observed) in html
+    assert f"admin/nodes/observednode/{observed.pk}/change/" in html
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_observed_node_link_missing(create_managed_node):
+    managed = create_managed_node(meshtastic_node_id=0x99999999)
+    admin = ManagedNodeAdmin(ManagedNode, None)
+    assert admin.observed_node_link(managed) == "—"
+
+
+@pytest.mark.django_db
 def test_managed_node_admin_add_fieldsets_meshtastic_show_node_id_and_channels():
     admin = ManagedNodeAdmin(ManagedNode, None)
     fieldsets = admin.get_fieldsets(request=_PostRequest(Protocol.MESHTASTIC), obj=None)

--- a/Meshflow/nodes/tests/test_managed_node_bootstrap.py
+++ b/Meshflow/nodes/tests/test_managed_node_bootstrap.py
@@ -1,0 +1,165 @@
+from unittest.mock import Mock
+
+from django.contrib.admin.sites import AdminSite
+
+import pytest
+
+from common.protocol import Protocol
+from nodes.admin import ManagedNodeAdmin, ManagedNodeAdminForm
+from nodes.managed_node_bootstrap import ensure_observed_node_for_managed_node
+from nodes.models import ManagedNode, ObservedNode
+
+
+@pytest.mark.django_db
+def test_ensure_observed_node_creates_meshcore_row(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    constellation = create_constellation(protocol=Protocol.MESHCORE, created_by=owner)
+    pubkey = "a" * 64
+    managed = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=pubkey,
+        name="Bootstrap MC",
+    )
+
+    observed, created = ensure_observed_node_for_managed_node(managed)
+
+    assert created is True
+    assert observed.mc_pubkey == pubkey
+    assert observed.claimed_by_id == owner.id
+    assert ObservedNode.objects.filter(protocol=Protocol.MESHCORE, mc_pubkey=pubkey).count() == 1
+
+
+@pytest.mark.django_db
+def test_ensure_observed_node_creates_meshtastic_row(create_user, create_constellation, create_managed_node):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    node_id = 0x40440440
+    managed = create_managed_node(
+        owner=owner,
+        constellation=constellation,
+        protocol=Protocol.MESHTASTIC,
+        meshtastic_node_id=node_id,
+        name="Bootstrap MT",
+    )
+
+    observed, created = ensure_observed_node_for_managed_node(managed)
+
+    assert created is True
+    assert observed.meshtastic_node_id == node_id
+    assert observed.claimed_by_id == owner.id
+    assert observed.long_name == "Bootstrap MT"
+
+
+@pytest.mark.django_db
+def test_ensure_observed_node_claims_unclaimed_existing(create_user, create_observed_node, create_managed_node):
+    owner = create_user()
+    pubkey = "b" * 64
+    observed = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=pubkey,
+        claimed_by=None,
+    )
+    managed = create_managed_node(
+        owner=owner,
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=pubkey,
+    )
+
+    result, created = ensure_observed_node_for_managed_node(managed)
+
+    assert created is False
+    assert result.pk == observed.pk
+    result.refresh_from_db()
+    assert result.claimed_by_id == owner.id
+    assert ObservedNode.objects.filter(mc_pubkey=pubkey).count() == 1
+
+
+@pytest.mark.django_db
+def test_ensure_observed_node_does_not_steal_existing_claim(create_user, create_observed_node, create_managed_node):
+    owner = create_user()
+    other = create_user()
+    pubkey = "c" * 64
+    observed = create_observed_node(
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=pubkey,
+        claimed_by=other,
+    )
+    managed = create_managed_node(
+        owner=owner,
+        protocol=Protocol.MESHCORE,
+        meshtastic_node_id=None,
+        mc_pubkey=pubkey,
+    )
+
+    result, created = ensure_observed_node_for_managed_node(managed)
+
+    assert created is False
+    assert result.pk == observed.pk
+    result.refresh_from_db()
+    assert result.claimed_by_id == other.id
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_save_model_bootstraps_meshcore_observed_node(create_user, create_constellation):
+    owner = create_user()
+    constellation = create_constellation(protocol=Protocol.MESHCORE, created_by=owner)
+    pubkey = "d" * 64
+    form = ManagedNodeAdminForm(
+        data={
+            "protocol": str(Protocol.MESHCORE),
+            "meshtastic_node_id": "",
+            "mc_pubkey": pubkey,
+            "name": "Admin Bootstrap MC",
+            "owner": owner.pk,
+            "constellation": constellation.pk,
+            "allow_auto_traceroute": False,
+            "mc_flood_advert_interval_hours": 6,
+            "latlong_0": "",
+            "latlong_1": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+    admin = ManagedNodeAdmin(ManagedNode, AdminSite())
+    request = Mock()
+    obj = form.save(commit=False)
+    admin.save_model(request, obj, form, change=False)
+
+    observed = ObservedNode.objects.get(mc_pubkey=pubkey)
+    assert observed.claimed_by_id == owner.id
+    assert ManagedNode.objects.filter(mc_pubkey=pubkey).exists()
+
+
+@pytest.mark.django_db
+def test_managed_node_admin_save_model_bootstraps_meshtastic_observed_node(create_user, create_constellation):
+    owner = create_user()
+    constellation = create_constellation(created_by=owner)
+    node_id = 0x40440441
+    form = ManagedNodeAdminForm(
+        data={
+            "protocol": str(Protocol.MESHTASTIC),
+            "meshtastic_node_id": str(node_id),
+            "name": "Admin Bootstrap MT",
+            "owner": owner.pk,
+            "constellation": constellation.pk,
+            "allow_auto_traceroute": False,
+            "latlong_0": "",
+            "latlong_1": "",
+        }
+    )
+    assert form.is_valid(), form.errors
+
+    admin = ManagedNodeAdmin(ManagedNode, AdminSite())
+    request = Mock()
+    obj = form.save(commit=False)
+    admin.save_model(request, obj, form, change=False)
+
+    observed = ObservedNode.objects.get(meshtastic_node_id=node_id)
+    assert observed.claimed_by_id == owner.id
+    assert ManagedNode.objects.filter(meshtastic_node_id=node_id).exists()


### PR DESCRIPTION
## Summary

- Add `ensure_observed_node_for_managed_node` to create or claim a matching `ObservedNode` when bootstrapping a feeder without prior mesh observation.
- Fix Django Admin `ManagedNode` add fieldsets to be protocol-aware (MeshCore shows `mc_pubkey`; Meshtastic shows node id and channel slots).
- Auto-run the bootstrap helper on admin create so sparse constellations can seed their first feeder.

Closes #404

## Testing performed

- `python -m pytest Meshflow/nodes/tests/test_managed_node_admin_form.py Meshflow/nodes/tests/test_managed_node_bootstrap.py -v` (12 passed)
- `black`, `isort`, `flake8` on touched files